### PR TITLE
Remove draft PR gate and skip tests for docs-only changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,10 +4,13 @@ on:
   push:
     branches:
       - main
+    paths-ignore:
+      - 'docs/**'
   pull_request:
     branches:
       - main
-    types: [ opened, synchronize, reopened, ready_for_review ]
+    paths-ignore:
+      - 'docs/**'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -15,7 +18,6 @@ concurrency:
 
 jobs:
   test:
-    if: github.event.pull_request.draft == false
     runs-on: ubuntu-22.04
 
     steps:


### PR DESCRIPTION
## Summary
- Remove `draft == false` check so tests run on draft PRs too
- Add `paths-ignore: docs/**` so docs-only changes don't trigger test runs

Closes LPX-283

## Test plan
- [ ] Verify tests run on draft PRs
- [ ] Verify docs-only pushes skip the test workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)