### PR TITLE
Exit non-zero on failed deploys, add deploy --watch

### DIFF
--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -42,7 +42,7 @@ class BuildCommand extends SteppedCommand
         if (! str_starts_with($appVersion, $expectedAppVersionPrefix) && ! str_starts_with($appVersion, $expectedAppVersionPrefixAlt)) {
             error(sprintf('App version must start with %s or %s', $expectedAppVersionPrefix, $expectedAppVersionPrefixAlt));
 
-            return 1;
+            return self::FAILURE;
         }
 
         $this->input->setOption('app-version', $appVersion);

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -32,7 +32,7 @@ class BuildCommand extends SteppedCommand
             ->setDescription('Prepare a build of the application for deployment');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         $appVersion = $this->option('app-version') ?? Carbon::now(Manifest::timezone())->format('y.W.N.Hi');
         $now = Carbon::now(Manifest::timezone());
@@ -42,13 +42,13 @@ class BuildCommand extends SteppedCommand
         if (! str_starts_with($appVersion, $expectedAppVersionPrefix) && ! str_starts_with($appVersion, $expectedAppVersionPrefixAlt)) {
             error(sprintf('App version must start with %s or %s', $expectedAppVersionPrefix, $expectedAppVersionPrefixAlt));
 
-            return;
+            return 1;
         }
 
         $this->input->setOption('app-version', $appVersion);
 
         intro("Building app version: {$appVersion}");
 
-        parent::handle();
+        return parent::handle();
     }
 }

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -63,6 +63,6 @@ class DeployCommand extends SteppedCommand
             return (new DeployStatusCommand())->execute(Helpers::app('input'), Helpers::app('output'));
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -39,10 +39,11 @@ class DeployCommand extends SteppedCommand
             ->addOption('app-version', null, InputOption::VALUE_REQUIRED, 'The app version to tag the build with')
             ->addOption('no-progress', null, InputOption::VALUE_NONE, 'Hide the progress output')
             ->addOption('only', null, InputOption::VALUE_REQUIRED, 'Deploy only to the specified server groups')
+            ->addOption('watch', 'w', InputOption::VALUE_NONE, 'Watch deployments until they complete')
             ->setDescription('Deploy a build of the application to AWS');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         $reuseBuild = false;
 
@@ -57,5 +58,11 @@ class DeployCommand extends SteppedCommand
         }
 
         parent::handle();
+
+        if ($this->option('watch')) {
+            return (new DeployStatusCommand())->execute(Helpers::app('input'), Helpers::app('output'));
+        }
+
+        return 0;
     }
 }

--- a/src/Commands/DeployStatusCommand.php
+++ b/src/Commands/DeployStatusCommand.php
@@ -63,7 +63,7 @@ class DeployStatusCommand extends Command
                 || str_contains($row[2], 'Stopped')
         );
 
-        return $hasFailure ? 1 : 0;
+        return $hasFailure ? self::FAILURE : self::SUCCESS;
     }
 
     protected function getDeploymentRows(): array

--- a/src/Commands/DeployStatusCommand.php
+++ b/src/Commands/DeployStatusCommand.php
@@ -26,8 +26,10 @@ class DeployStatusCommand extends Command
             ->setDescription('Show the status of in-progress and recent deployments');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
+        $rows = [];
+
         do {
             $rows = $this->getDeploymentRows();
 
@@ -55,6 +57,13 @@ class DeployStatusCommand extends Command
             sleep(5);
             $this->output->write("\033[2J\033[H");
         } while (true);
+
+        $hasFailure = collect($rows)->contains(
+            fn ($row) => str_contains($row[2], 'Failed')
+                || str_contains($row[2], 'Stopped')
+        );
+
+        return $hasFailure ? 1 : 0;
     }
 
     protected function getDeploymentRows(): array

--- a/src/Commands/StageCommand.php
+++ b/src/Commands/StageCommand.php
@@ -43,7 +43,7 @@ class StageCommand extends SteppedCommand
             ->setDescription('Set the stage');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         $amis = collect(Aws::ec2()->describeImages(['Owners' => ['self']])['Images'])
             ->filter(fn (array $image) => $image['State'] === 'available')
@@ -69,6 +69,6 @@ class StageCommand extends SteppedCommand
             $this->input->setOption('update', ! confirm('The --update option was not provided. This will create new resources. Are you sure?'));
         }
 
-        parent::handle();
+        return parent::handle();
     }
 }

--- a/src/Commands/SteppedCommand.php
+++ b/src/Commands/SteppedCommand.php
@@ -25,6 +25,6 @@ abstract class SteppedCommand extends Command
             info(sprintf('Completed successfully in %ss.', $totalTime));
         }
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/SteppedCommand.php
+++ b/src/Commands/SteppedCommand.php
@@ -13,7 +13,7 @@ abstract class SteppedCommand extends Command
 
     protected array $steps;
 
-    public function handle(): void
+    public function handle(): int
     {
         $environment = $this->argument('environment');
 
@@ -24,5 +24,7 @@ abstract class SteppedCommand extends Command
         if (! $this->option('no-progress')) {
             info(sprintf('Completed successfully in %ss.', $totalTime));
         }
+
+        return 0;
     }
 }

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -44,6 +44,6 @@ class SyncCommand extends SteppedCommand
 
         info('Sync command executed successfully.');
 
-        return 0;
+        return self::SUCCESS;
     }
 }

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -21,7 +21,7 @@ class SyncCommand extends SteppedCommand
             ->setDescription('Sync all resources for the given environment');
     }
 
-    public function handle(): void
+    public function handle(): int
     {
         intro('Executing sync commands...');
 
@@ -43,5 +43,7 @@ class SyncCommand extends SteppedCommand
         ])->each(fn ($command) => (new $command())->execute(Helpers::app('input'), Helpers::app('output')));
 
         info('Sync command executed successfully.');
+
+        return 0;
     }
 }


### PR DESCRIPTION
## Summary
- `deploy:status` now exits 1 when any displayed deployment ended in `Failed` or `Stopped`, so CI scripts can fail loudly on a bad deploy.
- `deploy <env>` gains a `--watch` (`-w`) flag — once the deploy steps finish, it chains straight into `deploy:status --watch` and propagates its exit code.
- `SteppedCommand::handle()` switched to `int` return so subclasses can chain a non-zero exit code through.

## Test plan
- [ ] `yolo deploy:status <env>` against a healthy env exits 0
- [ ] `yolo deploy:status <env>` against an env whose latest CodeDeploy is `Failed` exits 1
- [ ] `yolo deploy <env> --watch` runs deploy as normal then drops into the polling status table, exits 0 when all green
- [ ] `yolo deploy <env> --watch` exits 1 if any group ends `Failed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)