### PR TITLE
Flatten aws.logging.ivs to aws.ivs, add IVS docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ YOLO supports Laravel Octane for turbocharged PHP applications.
 
 YOLO can configure your app environment to utilise video transcoding using AWS Elemental MediaConvert.
 
+### Interactive Video Service (IVS)
+
+AWS IVS is Amazon's managed low-latency live video streaming service. For apps that use IVS, YOLO captures all IVS state-change events to CloudWatch via EventBridge for audit and debugging.
+
 ### And Much More...
 
 - Least priviledge permissions with strong segregation across environments and apps
@@ -150,6 +154,7 @@ The full list of available sync commands are:
 - `yolo sync:compute <environment>` prepares the compute resources
 - `yolo sync:ci <environment>` prepares the continuous integration pipeline
 - `yolo sync:iam <environment>` prepares necessary permissions
+- `yolo sync:logging <environment>` prepares observability infrastructure (e.g. IVS state-change events)
 
 > [!TIP]
 > All sync commands support a `--dry-run` argument; this is a great starting point to see what resources will be created
@@ -238,6 +243,7 @@ environments:
       cloudfront:
       alb:
       mediaconvert: false
+      ivs: false
       autoscaling:
         web:
         queue:

--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -25,7 +25,7 @@ You can also provision resources individually:
 | `yolo sync:compute <env>` | EC2, autoscaling groups |
 | `yolo sync:ci <env>` | CI/CD pipeline |
 | `yolo sync:iam <env>` | IAM roles and policies |
-| `yolo sync:logging <env>` | IVS state-change logging (CloudWatch + EventBridge) |
+| `yolo sync:logging <env>` | Logging and observability infrastructure |
 
 ## Dry Run
 

--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -25,6 +25,7 @@ You can also provision resources individually:
 | `yolo sync:compute <env>` | EC2, autoscaling groups |
 | `yolo sync:ci <env>` | CI/CD pipeline |
 | `yolo sync:iam <env>` | IAM roles and policies |
+| `yolo sync:logging <env>` | IVS state-change logging (CloudWatch + EventBridge) |
 
 ## Dry Run
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -21,7 +21,7 @@
 | `sync:tenant <env>` | Per-tenant resources |
 | `sync:ci <env>` | CI/CD pipeline |
 | `sync:iam <env>` | IAM roles and policies |
-| `sync:logging <env>` | IVS state-change logging (CloudWatch + EventBridge) |
+| `sync:logging <env>` | Logging and observability infrastructure |
 | `sync:storage <env>` | S3 bucket configuration |
 
 ## Environment

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -21,7 +21,7 @@
 | `sync:tenant <env>` | Per-tenant resources |
 | `sync:ci <env>` | CI/CD pipeline |
 | `sync:iam <env>` | IAM roles and policies |
-| `sync:logging <env>` | Logging infrastructure |
+| `sync:logging <env>` | IVS state-change logging (CloudWatch + EventBridge) |
 | `sync:storage <env>` | S3 bucket configuration |
 
 ## Environment

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -22,6 +22,7 @@ environments:
       cloudfront:
       alb:
       mediaconvert: false
+      ivs: false
       autoscaling:
         web:
         queue:
@@ -100,6 +101,10 @@ When `true`, consolidates web, queue, and scheduler onto a single EC2 instance. 
 ### `aws.ec2.octane`
 
 Enable experimental Laravel Octane support.
+
+### `aws.ivs`
+
+Set to `true` to provision a CloudWatch log group, EventBridge rule, and target that captures all `aws.ivs` source events for audit and debugging. Override the log retention with `aws.ivs.log-retention-days` (defaults to 14).
 
 ### `mysqldump`
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -104,7 +104,18 @@ Enable experimental Laravel Octane support.
 
 ### `aws.ivs`
 
-Set to `true` to provision a CloudWatch log group, EventBridge rule, and target that captures all `aws.ivs` source events for audit and debugging. Override the log retention with `aws.ivs.log-retention-days` (defaults to 14).
+Set to `true` to provision a CloudWatch log group, EventBridge rule, and target that captures all `aws.ivs` source events for audit and debugging. Logs use a 14-day default retention.
+
+For finer control, expand into a map:
+
+```yaml
+aws:
+  ivs:
+    logging: true
+    log-retention-days: 30
+```
+
+`logging` toggles the EventBridge → CloudWatch pipeline; `log-retention-days` overrides the log retention.
 
 ### `mysqldump`
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -94,6 +94,12 @@ class Manifest
         return ! empty(static::get('tenants'));
     }
 
+    public static function ivsLoggingEnabled(): bool
+    {
+        return static::get('aws.ivs') === true
+            || static::get('aws.ivs.logging') === true;
+    }
+
     /**
      * @return array<int, array{
      *     domain: string,

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -94,7 +94,7 @@ class Manifest
         return ! empty(static::get('tenants'));
     }
 
-    public static function ivsLoggingEnabled(): bool
+    public static function ivsEnabled(): bool
     {
         return static::get('aws.ivs') === true
             || static::get('aws.ivs.logging') === true;

--- a/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
+++ b/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
@@ -15,13 +15,13 @@ class SyncIvsCloudWatchLogGroupStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.logging.ivs')) {
+        if (! Manifest::get('aws.ivs')) {
             return StepResult::SKIPPED;
         }
 
         $name = self::logGroupName();
 
-        $retentionDays = Manifest::get('aws.logging.ivs.log-retention-days', 14);
+        $retentionDays = Manifest::get('aws.ivs.log-retention-days', 14);
 
         $region = Manifest::get('aws.region');
         $accountId = Aws::accountId();

--- a/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
+++ b/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
@@ -15,7 +15,7 @@ class SyncIvsCloudWatchLogGroupStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.ivs')) {
+        if (! Manifest::ivsLoggingEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
+++ b/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
@@ -15,7 +15,7 @@ class SyncIvsCloudWatchLogGroupStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsLoggingEnabled()) {
+        if (! Manifest::ivsEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
@@ -15,7 +15,7 @@ class SyncIvsEventBridgeRuleStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.ivs')) {
+        if (! Manifest::ivsLoggingEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
@@ -15,7 +15,7 @@ class SyncIvsEventBridgeRuleStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsLoggingEnabled()) {
+        if (! Manifest::ivsEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
@@ -15,7 +15,7 @@ class SyncIvsEventBridgeRuleStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.logging.ivs')) {
+        if (! Manifest::get('aws.ivs')) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
@@ -14,7 +14,7 @@ class SyncIvsEventBridgeTargetStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.logging.ivs')) {
+        if (! Manifest::get('aws.ivs')) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
@@ -14,7 +14,7 @@ class SyncIvsEventBridgeTargetStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::get('aws.ivs')) {
+        if (! Manifest::ivsLoggingEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
@@ -14,7 +14,7 @@ class SyncIvsEventBridgeTargetStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsLoggingEnabled()) {
+        if (! Manifest::ivsEnabled()) {
             return StepResult::SKIPPED;
         }
 

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -95,6 +95,44 @@ describe('multitenancy', function () {
     });
 });
 
+describe('ivsLoggingEnabled', function () {
+    it('is false when aws.ivs is absent', function () {
+        writeManifest([]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+    });
+
+    it('is true for the boolean shorthand', function () {
+        writeManifest(['aws' => ['ivs' => true]]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeTrue();
+    });
+
+    it('is false when aws.ivs is explicitly false', function () {
+        writeManifest(['aws' => ['ivs' => false]]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+    });
+
+    it('is true for the expanded form with logging on', function () {
+        writeManifest(['aws' => ['ivs' => ['logging' => true, 'log-retention-days' => 30]]]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeTrue();
+    });
+
+    it('is false for the expanded form with logging off', function () {
+        writeManifest(['aws' => ['ivs' => ['logging' => false, 'log-retention-days' => 30]]]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+    });
+
+    it('is false for the expanded form without a logging key', function () {
+        writeManifest(['aws' => ['ivs' => ['log-retention-days' => 30]]]);
+
+        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+    });
+});
+
 describe('apex', function () {
     it('returns the apex domain', function () {
         writeManifest(['domain' => 'example.com']);

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -25,10 +25,10 @@ describe('has and get', function () {
     });
 
     it('has returns true even for falsy values', function () {
-        writeManifest(['aws' => ['logging' => ['ivs' => false]]]);
+        writeManifest(['aws' => ['ivs' => false]]);
 
-        expect(Manifest::has('aws.logging.ivs'))->toBeTrue();
-        expect(Manifest::get('aws.logging.ivs'))->toBeFalse();
+        expect(Manifest::has('aws.ivs'))->toBeTrue();
+        expect(Manifest::get('aws.ivs'))->toBeFalse();
     });
 });
 

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -95,41 +95,41 @@ describe('multitenancy', function () {
     });
 });
 
-describe('ivsLoggingEnabled', function () {
+describe('ivsEnabled', function () {
     it('is false when aws.ivs is absent', function () {
         writeManifest([]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+        expect(Manifest::ivsEnabled())->toBeFalse();
     });
 
     it('is true for the boolean shorthand', function () {
         writeManifest(['aws' => ['ivs' => true]]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeTrue();
+        expect(Manifest::ivsEnabled())->toBeTrue();
     });
 
     it('is false when aws.ivs is explicitly false', function () {
         writeManifest(['aws' => ['ivs' => false]]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+        expect(Manifest::ivsEnabled())->toBeFalse();
     });
 
     it('is true for the expanded form with logging on', function () {
         writeManifest(['aws' => ['ivs' => ['logging' => true, 'log-retention-days' => 30]]]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeTrue();
+        expect(Manifest::ivsEnabled())->toBeTrue();
     });
 
     it('is false for the expanded form with logging off', function () {
         writeManifest(['aws' => ['ivs' => ['logging' => false, 'log-retention-days' => 30]]]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+        expect(Manifest::ivsEnabled())->toBeFalse();
     });
 
     it('is false for the expanded form without a logging key', function () {
         writeManifest(['aws' => ['ivs' => ['log-retention-days' => 30]]]);
 
-        expect(Manifest::ivsLoggingEnabled())->toBeFalse();
+        expect(Manifest::ivsEnabled())->toBeFalse();
     });
 });
 


### PR DESCRIPTION
## Summary

- Flatten the IVS manifest key from `aws.logging.ivs` to `aws.ivs` (and `aws.ivs.log-retention-days` for the optional retention override). No back-compat — `aws.logging.*` was the wrong shape since YOLO's manifest is organised by AWS service, not cross-cutting category.
- The `sync:logging` CLI command and `Codinglabs\Yolo\Steps\Logging` PHP namespace stay as deliberately broad umbrella names — sync buckets are intentionally broader than the manifest service taxonomy, so they don't 1:1 mirror manifest keys.
- README and VitePress docs gain IVS coverage: a new Features section, schema entries, a `aws.ivs` Key Options entry in the manifest reference, and `sync:logging` in the provisioning guide + commands reference.

## Test plan

- [x] `./vendor/bin/pint` — clean
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `./vendor/bin/pest` — 48/48 passed
- [x] `grep -rn 'aws.logging.ivs' src/ tests/ docs/ README.md` — zero matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)