### PR TITLE
LPX-600: rename `standalone` namespace to `solo`

### DIFF
--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -17,7 +17,7 @@ class DeployCommand extends SteppedCommand
         Steps\Deploy\ExecuteDeployStepsStep::class,
         Steps\Deploy\UpdateEcsServiceStep::class,
         Steps\Deploy\WaitForServiceStableStep::class,
-        Steps\Deploy\SyncStandaloneRecordSetStep::class,
+        Steps\Deploy\SyncSoloRecordSetStep::class,
         Steps\Deploy\SyncMultitenancyRecordSetStep::class,
     ];
 

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -34,7 +34,7 @@ class SyncCommand extends SteppedCommand
                     SyncMultitenancyTenantsCommand::class,
                 ]
                 : [
-                    SyncStandaloneCommand::class,
+                    SyncSoloCommand::class,
                 ],
             ...Manifest::has('tasks.web')
                 ? [SyncComputeCommand::class]

--- a/src/Commands/SyncSoloCommand.php
+++ b/src/Commands/SyncSoloCommand.php
@@ -5,22 +5,22 @@ namespace Codinglabs\Yolo\Commands;
 use Codinglabs\Yolo\Steps;
 use Symfony\Component\Console\Input\InputArgument;
 
-class SyncStandaloneCommand extends SteppedCommand
+class SyncSoloCommand extends SteppedCommand
 {
     protected array $steps = [
-        Steps\Standalone\SyncHostedZoneStep::class,
-        Steps\Standalone\SyncSslCertificateStep::class,
-        Steps\Standalone\SyncQueueStep::class,
-        Steps\Standalone\SyncQueueAlarmStep::class,
+        Steps\Solo\SyncHostedZoneStep::class,
+        Steps\Solo\SyncSslCertificateStep::class,
+        Steps\Solo\SyncQueueStep::class,
+        Steps\Solo\SyncQueueAlarmStep::class,
     ];
 
     protected function configure(): void
     {
         $this
-            ->setName('sync:standalone')
+            ->setName('sync:solo')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('dry-run', null, null, 'Run the command without making changes')
             ->addOption('no-progress', null, null, 'Hide the progress output')
-            ->setDescription('Sync AWS resources for standalone app');
+            ->setDescription('Sync AWS resources for solo (single-tenant) app');
     }
 }

--- a/src/Concerns/ChecksIfCommandsShouldBeRunning.php
+++ b/src/Concerns/ChecksIfCommandsShouldBeRunning.php
@@ -9,8 +9,8 @@ use Codinglabs\Yolo\Commands\Command;
 use Codinglabs\Yolo\Contracts\RunsOnAws;
 use Codinglabs\Yolo\Contracts\RunsOnAwsWeb;
 use Codinglabs\Yolo\Contracts\RunsOnAwsQueue;
+use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
 use Codinglabs\Yolo\Contracts\RunsOnAwsScheduler;
-use Codinglabs\Yolo\Contracts\ExecutesStandaloneStep;
 use Codinglabs\Yolo\Contracts\ExecutesMultitenancyStep;
 
 trait ChecksIfCommandsShouldBeRunning
@@ -18,7 +18,7 @@ trait ChecksIfCommandsShouldBeRunning
     public function shouldBeRunning(Command|Step $instance): bool
     {
         if (
-            $instance instanceof ExecutesStandaloneStep && Manifest::isMultitenanted()
+            $instance instanceof ExecutesSoloStep && Manifest::isMultitenanted()
             || $instance instanceof ExecutesMultitenancyStep && ! Manifest::isMultitenanted()) {
             return false;
         }

--- a/src/Contracts/ExecutesSoloStep.php
+++ b/src/Contracts/ExecutesSoloStep.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Codinglabs\Yolo\Contracts;
+
+interface ExecutesSoloStep extends Step {}

--- a/src/Contracts/ExecutesStandaloneStep.php
+++ b/src/Contracts/ExecutesStandaloneStep.php
@@ -1,5 +1,0 @@
-<?php
-
-namespace Codinglabs\Yolo\Contracts;
-
-interface ExecutesStandaloneStep extends Step {}

--- a/src/Steps/Deploy/SyncSoloRecordSetStep.php
+++ b/src/Steps/Deploy/SyncSoloRecordSetStep.php
@@ -6,9 +6,9 @@ use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Concerns\SyncsRecordSets;
-use Codinglabs\Yolo\Contracts\ExecutesStandaloneStep;
+use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
 
-class SyncStandaloneRecordSetStep implements ExecutesStandaloneStep
+class SyncSoloRecordSetStep implements ExecutesSoloStep
 {
     use SyncsRecordSets;
 

--- a/src/Steps/Ensures/EnsureHostedZonesExistStep.php
+++ b/src/Steps/Ensures/EnsureHostedZonesExistStep.php
@@ -5,10 +5,10 @@ namespace Codinglabs\Yolo\Steps\Ensures;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
 use Codinglabs\Yolo\Concerns\EnsuresResourcesExist;
-use Codinglabs\Yolo\Contracts\ExecutesStandaloneStep;
 
-class EnsureHostedZonesExistStep implements ExecutesStandaloneStep
+class EnsureHostedZonesExistStep implements ExecutesSoloStep
 {
     use EnsuresResourcesExist;
 

--- a/src/Steps/Solo/SyncHostedZoneStep.php
+++ b/src/Steps/Solo/SyncHostedZoneStep.php
@@ -1,33 +1,29 @@
 <?php
 
-namespace Codinglabs\Yolo\Steps\Standalone;
+namespace Codinglabs\Yolo\Steps\Solo;
 
 use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Helpers;
+use Illuminate\Support\Str;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Contracts\ExecutesStandaloneStep;
+use Codinglabs\Yolo\Contracts\ExecutesDomainStep;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class SyncQueueStep implements ExecutesStandaloneStep, Step
+class SyncHostedZoneStep implements ExecutesDomainStep
 {
     public function __invoke(array $options): StepResult
     {
-        $name = Helpers::keyedResourceName();
-
         try {
-            AwsResources::queue($name);
+            AwsResources::hostedZone(Manifest::apex());
 
             return StepResult::SYNCED;
         } catch (ResourceDoesNotExistException) {
             if (! Arr::get($options, 'dry-run')) {
-                Aws::sqs()->createQueue([
-                    'QueueName' => $name,
-                    'Attributes' => [
-                        'MessageRetentionPeriod' => '1209600', // 14 days
-                    ],
+                Aws::route53()->createHostedZone([
+                    'CallerReference' => Str::uuid(),
+                    'Name' => Manifest::apex(),
                 ]);
 
                 return StepResult::CREATED;

--- a/src/Steps/Solo/SyncQueueAlarmStep.php
+++ b/src/Steps/Solo/SyncQueueAlarmStep.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Codinglabs\Yolo\Steps\Standalone;
+namespace Codinglabs\Yolo\Steps\Solo;
 
 use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;

--- a/src/Steps/Solo/SyncQueueStep.php
+++ b/src/Steps/Solo/SyncQueueStep.php
@@ -1,29 +1,33 @@
 <?php
 
-namespace Codinglabs\Yolo\Steps\Standalone;
+namespace Codinglabs\Yolo\Steps\Solo;
 
 use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
-use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\AwsResources;
+use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Contracts\ExecutesDomainStep;
+use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class SyncHostedZoneStep implements ExecutesDomainStep
+class SyncQueueStep implements ExecutesSoloStep, Step
 {
     public function __invoke(array $options): StepResult
     {
+        $name = Helpers::keyedResourceName();
+
         try {
-            AwsResources::hostedZone(Manifest::apex());
+            AwsResources::queue($name);
 
             return StepResult::SYNCED;
         } catch (ResourceDoesNotExistException) {
             if (! Arr::get($options, 'dry-run')) {
-                Aws::route53()->createHostedZone([
-                    'CallerReference' => Str::uuid(),
-                    'Name' => Manifest::apex(),
+                Aws::sqs()->createQueue([
+                    'QueueName' => $name,
+                    'Attributes' => [
+                        'MessageRetentionPeriod' => '1209600', // 14 days
+                    ],
                 ]);
 
                 return StepResult::CREATED;

--- a/src/Steps/Solo/SyncSslCertificateStep.php
+++ b/src/Steps/Solo/SyncSslCertificateStep.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Codinglabs\Yolo\Steps\Standalone;
+namespace Codinglabs\Yolo\Steps\Solo;
 
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -26,7 +26,7 @@ class Yolo
         Commands\SyncCommand::class,
         Commands\SyncNetworkCommand::class,
         Commands\SyncStorageCommand::class,
-        Commands\SyncStandaloneCommand::class,
+        Commands\SyncSoloCommand::class,
         Commands\SyncMultitenancyTenantsCommand::class,
         Commands\SyncMultitenancyLandlordCommand::class,
         Commands\SyncComputeCommand::class,


### PR DESCRIPTION
## Hey, I made a thing! 🥳

[LPX-600](https://linear.app/codinglabsau/issue/LPX-600/rename-standalone-namespace-to-solo)

**What problems are you solving?**

`Standalone` was alpha-era language that never validated on a shipped consumer (LP — the only consumer — is multitenant). The name implies an architectural choice (standalone vs embedded) when it actually means "single tenant DNS + queue path." `Solo` reads naturally as the sibling of `Multitenancy` and conveys what the namespace actually represents.

Mechanical rename:

- `Steps/Standalone/` → `Steps/Solo/` (HostedZone, SslCertificate, Queue, QueueAlarm rehomed verbatim)
- `SyncStandaloneCommand` → `SyncSoloCommand`, CLI name `sync:standalone` → `sync:solo`
- `ExecutesStandaloneStep` → `ExecutesSoloStep` (marker interface)
- `SyncStandaloneRecordSetStep` → `SyncSoloRecordSetStep`
- All consumers (`SyncCommand`, `DeployCommand`, `ChecksIfCommandsShouldBeRunning`, `EnsureHostedZonesExistStep`, `Yolo.php`) updated

Queue model unchanged: solo app = 1 queue, multitenant app = 1 queue per tenant. Manifest-driven queue shape (multiple queues per app) is deferred until a real consumer needs it.

**Is there anything the reviewer needs to know to deploy this?**

- Zero behaviour changes — AWS resource names unchanged (still `yolo-{env}-{app}` via `keyedResourceName()`).
- CLI surface: `yolo sync:standalone` → `yolo sync:solo`. No documented consumer invokes the subcommand directly; `sync` is the orchestrator that fans out.
- LP runs on `yolo-alpha` and is unaffected by changes in `codinglabsau/yolo`.
- 93 pest, 0 phpstan, pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)