### PR TITLE
LPX-602: route listener rule on `domain`, not `apex`

### DIFF
--- a/src/Steps/Fargate/SyncListenerRuleStep.php
+++ b/src/Steps/Fargate/SyncListenerRuleStep.php
@@ -20,8 +20,7 @@ class SyncListenerRuleStep implements Step
             return StepResult::SKIPPED;
         }
 
-        $apex = Manifest::apex();
-        $hosts = collect([$apex, "www.$apex"])->unique()->values()->all();
+        $hosts = static::routedHosts();
 
         try {
             $listener = AwsResources::loadBalancerListenerOnPort(443);
@@ -94,6 +93,18 @@ class SyncListenerRuleStep implements Step
             ->all();
 
         return static::nextAvailablePriority(Helpers::keyedResourceName(exclusive: true), $usedPriorities);
+    }
+
+    public static function routedHosts(): array
+    {
+        $apex = Manifest::apex();
+        $domain = Manifest::get('domain', $apex);
+
+        // Apex deploy: route apex + www.apex (both are reasonable inbound hostnames).
+        // Subdomain deploy (apex != domain): route only the literal domain.
+        return $domain === $apex
+            ? [$apex, "www.$apex"]
+            : [$domain];
     }
 
     public static function nextAvailablePriority(string $name, array $usedPriorities): int

--- a/tests/Unit/Steps/Fargate/SyncListenerRuleStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncListenerRuleStepTest.php
@@ -3,6 +3,50 @@
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Steps\Fargate\SyncListenerRuleStep;
 
+describe('routedHosts', function () {
+    it('routes apex + www.apex when domain matches apex', function () {
+        writeManifest([
+            'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+            'domain' => 'codinglabs.com.au',
+        ]);
+
+        expect(SyncListenerRuleStep::routedHosts())
+            ->toBe(['codinglabs.com.au', 'www.codinglabs.com.au']);
+    });
+
+    it('routes apex + www.apex when only apex is set', function () {
+        writeManifest([
+            'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+            'apex' => 'codinglabs.com.au',
+        ]);
+
+        expect(SyncListenerRuleStep::routedHosts())
+            ->toBe(['codinglabs.com.au', 'www.codinglabs.com.au']);
+    });
+
+    it('routes only the literal domain when apex and domain differ', function () {
+        writeManifest([
+            'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+            'apex' => 'codinglabs.com.au',
+            'domain' => 'fargate.codinglabs.com.au',
+        ]);
+
+        expect(SyncListenerRuleStep::routedHosts())
+            ->toBe(['fargate.codinglabs.com.au']);
+    });
+
+    it('routes only the literal domain for tenant-style subdomains (apex ≠ domain)', function () {
+        writeManifest([
+            'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+            'apex' => 'liveplatforms.net',
+            'domain' => 'brushly.liveplatforms.net',
+        ]);
+
+        expect(SyncListenerRuleStep::routedHosts())
+            ->toBe(['brushly.liveplatforms.net']);
+    });
+});
+
 it('returns a priority within the 1000-49999 range', function () {
     $priority = SyncListenerRuleStep::nextAvailablePriority('my-app', []);
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

[LPX-602](https://linear.app/codinglabsau/issue/LPX-602/synclistenerrulestep-routes-on-apex-breaks-subdomain)

**What problems are you solving?**

`SyncListenerRuleStep` built its host-routing list from `Manifest::apex()` regardless of whether `domain` differed. When `apex` and `domain` are explicitly different (subdomain canary, vanity zone case) the listener rule matched the wrong host and the canary's own traffic got 503'd by the listener's default action.

Repro:

```yaml
apex: codinglabs.com.au
domain: fargate.codinglabs.com.au
```

- DNS: `fargate.codinglabs.com.au` → Fargate ALB
- ALB receives request, `Host: fargate.codinglabs.com.au`
- Listener rule matched `[codinglabs.com.au, www.codinglabs.com.au]` — neither equals the actual Host header
- Default listener action returns 503 "No application matched the host header"

Greenfield bug — alpha never implemented listener rules (EC2 + CodeDeploy did host routing inside Laravel). The only tested path in [PR #25](https://github.com/codinglabsau/yolo/pull/25) was `domain == apex` (where `apex` defaults to `domain`).

**Fix:**

`SyncListenerRuleStep::routedHosts()` (new public static):

- Routes `apex + www.apex` when `domain` matches `apex` (today's single-tenant behaviour)
- Routes the literal `domain` only when `apex` and `domain` differ (subdomain canary / vanity zone)

The pure helper is extracted so 4 unit tests pin the four shapes (apex-only, domain==apex, subdomain canary, tenant-style subdomain).

**Is there anything the reviewer needs to know to deploy this?**

- Existing single-tenant deploys see no change — `Manifest::apex()` still defaults to `Manifest::get('domain')` when no explicit `apex:` is set, and `domain === apex` selects the same `apex + www.apex` host list as before.
- Unblocks the codinglabs.com.au → fargate.codinglabs.com.au Fargate canary and the [LPX-599](https://linear.app/codinglabsau/issue/LPX-599) vanity DNS zone work (both rely on `apex` ≠ `domain`).
- 97 pest, 0 phpstan, pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)