### PR TITLE
LPX-606: yolo deploy always builds; --app-version names the build

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ Consumers migrating from `yolo-alpha` to `yolo` 1.0 install both packages side-b
 ## YOLO 1.0 in one line
 
 ```bash
-yolo init && yolo build && yolo sync production && yolo deploy production
+yolo init && yolo sync production && yolo deploy production
 ```
 
-That's the goal. Today the `Yolo` class registers zero commands — it's a placeholder while 1.0 is being built.
+`yolo deploy` builds and pushes the image, then ships it. Pass `--app-version=<tag>` (e.g. a GitHub release name) to stamp the build with a specific tag instead of an auto-generated timestamp.
 
 ## Pre-1.0 alpha documentation
 

--- a/src/Commands/DeployCommand.php
+++ b/src/Commands/DeployCommand.php
@@ -2,12 +2,9 @@
 
 namespace Codinglabs\Yolo\Commands;
 
-use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Steps;
-use Codinglabs\Yolo\Manifest;
 use Symfony\Component\Console\Input\InputArgument;
 
-use function Laravel\Prompts\error;
 use function Laravel\Prompts\intro;
 
 class DeployCommand extends SteppedCommand
@@ -26,41 +23,22 @@ class DeployCommand extends SteppedCommand
         $this
             ->setName('deploy')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('app-version', null, InputArgument::OPTIONAL, 'The app version to deploy (defaults to the last build)')
+            ->addOption('app-version', null, InputArgument::OPTIONAL, 'Tag to stamp on the build (defaults to a timestamp)')
             ->addOption('watch', null, null, 'Wait for the ECS service to reach a steady state')
             ->addOption('no-progress', null, null, 'Hide the progress output')
-            ->setDescription('Deploy the latest build to the given environment');
+            ->setDescription('Build, push, and deploy the application');
     }
 
     public function handle(): int
     {
-        if (! Manifest::has('tasks.web')) {
-            error('`yolo deploy` requires a `tasks.web` block in yolo.yml — this is the Fargate deploy path.');
+        $build = (new BuildCommand())->execute($this->input, $this->output);
 
-            return self::FAILURE;
+        if ($build !== self::SUCCESS) {
+            return $build;
         }
 
-        $appVersion = $this->option('app-version') ?? $this->lastBuiltVersion();
-
-        if (! $appVersion) {
-            error('No app version specified and no build artefact found. Run `yolo build` first.');
-
-            return self::FAILURE;
-        }
-
-        $this->input->setOption('app-version', $appVersion);
-
-        intro("Deploying app version: {$appVersion}");
+        intro("Deploying app version: {$this->option('app-version')}");
 
         return parent::handle();
-    }
-
-    protected function lastBuiltVersion(): ?string
-    {
-        if (! file_exists(Paths::version())) {
-            return null;
-        }
-
-        return trim(file_get_contents(Paths::version()));
     }
 }

--- a/src/Steps/Deploy/SyncMultitenancyRecordSetStep.php
+++ b/src/Steps/Deploy/SyncMultitenancyRecordSetStep.php
@@ -6,8 +6,9 @@ use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Steps\TenantStep;
 use Codinglabs\Yolo\Concerns\SyncsRecordSets;
+use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 
-class SyncMultitenancyRecordSetStep extends TenantStep
+class SyncMultitenancyRecordSetStep extends TenantStep implements ExecutesWebStep
 {
     use SyncsRecordSets;
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

[LPX-606](https://linear.app/codinglabsau/issue/LPX-606/restore-build-in-deploy-behaviour-fix-readme-one-liner)

**What problems are you solving?**

`yolo deploy <env>` now always builds, pushes, and deploys as one motion. The v1 rewrite in [PR #26](https://github.com/codinglabsau/yolo/pull/26) had inadvertently dropped build-in-deploy, leaving the README's one-liner broken and forcing users to remember a separate `yolo build` step.

`--app-version` is now reframed as **an input to the build** — the tag to stamp on the fresh image:

- `yolo deploy production` — auto-generates a timestamp tag (`26.21.2.1500`), builds, pushes, deploys.
- `yolo deploy production --app-version=v1.2.3` — uses `v1.2.3` (e.g. a GitHub release name) as the build's tag, builds, pushes, deploys.

The alpha-era "skip build when `--app-version` is supplied" branch is gone. Deploying a pre-existing ECR tag is rollback's job, tracked separately as [LPX-608](https://linear.app/codinglabsau/issue/LPX-608). Folding rollback into `deploy --app-version=<old-tag>` muddied the mental model.

BuildCommand writes `--app-version` back onto the shared `InputInterface` before returning, so deploy's downstream steps pick up the tag via `$this->option('app-version')`.

**Also drops the `Manifest::has('tasks.web')` guard.** The `ExecutesWebStep` interface + `Manifest::isHeadless()` already gates DNS steps for headless apps (the right axis). The dropped guard was catching a different scenario — "yolo.yml has no Fargate spec at all" — which is best left to surface as `ServiceNotFoundException` via the natural AWS error path. Consistent with the "let AWS errors bubble" stance.

**Plus: closes a coverage gap in `ExecutesWebStep`.** LPX-604 (#29) added headless-mode gating for solo DNS (`SyncSoloRecordSetStep`) but missed the multitenancy mirror. `SyncMultitenancyRecordSetStep` dereferences `$this->config['apex']` and `['domain']` unconditionally, so a headless multitenant deploy would undefined-key-crash before reaching ECS. Adding `implements ExecutesWebStep` to the tenant step lets `shouldBeRunning()` skip it via the existing trait.

README's `yolo init && yolo build && yolo sync production && yolo deploy production` was nonsensical (`yolo build` errored on the missing env arg; explicit build was redundant). Updated to:

```
yolo init && yolo sync production && yolo deploy production
```

**Is there anything the reviewer needs to know to deploy this?**

- Every `yolo deploy` now triggers the full build pipeline (rsync → composer/npm → docker build → ECR push) before the deploy steps. ~2-5 min added depending on cache hits.
- CI workflows that previously ran `yolo build` and `yolo deploy --app-version=<tag>` as separate stages can now collapse to a single `yolo deploy production --app-version=<release-tag>` call. If the split is still wanted for any reason (e.g. preview before promotion), `yolo build` alone still works.
- Unit tests not added for the build-invocation path — goes through `Command::execute()` which runs `registerAwsServices()` and shouldBeRunning checks, hard to mock cleanly. Smoke-tested locally via the CL Fargate canary path.
- 119 pest, 0 phpstan, pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)