### PR TITLE
yolo sync: collate into one plan → confirm → execute flow

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -74,9 +74,6 @@ abstract class Command extends SymfonyCommand
             return 1;
         }
 
-        // todo: remove once mvp is finished
-        $this->output->setVerbosity(OutputInterface::VERBOSITY_DEBUG);
-
         $exitCode = (int) (Helpers::app()->call([$this, 'handle']) ?: 0);
 
         foreach ($this->after as $closure) {

--- a/src/Commands/SteppedCommand.php
+++ b/src/Commands/SteppedCommand.php
@@ -13,6 +13,14 @@ abstract class SteppedCommand extends Command
 
     protected array $steps;
 
+    /**
+     * @return array<int, class-string>
+     */
+    public function steps(): array
+    {
+        return $this->steps;
+    }
+
     public function handle(): int
     {
         $environment = $this->argument('environment');

--- a/src/Commands/SyncCommand.php
+++ b/src/Commands/SyncCommand.php
@@ -2,49 +2,45 @@
 
 namespace Codinglabs\Yolo\Commands;
 
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
-use Symfony\Component\Console\Input\InputArgument;
 
-use function Laravel\Prompts\info;
-use function Laravel\Prompts\intro;
-
-class SyncCommand extends SteppedCommand
+class SyncCommand extends SyncSteppedCommand
 {
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync all resources for the given environment');
     }
 
     public function handle(): int
     {
-        intro('Executing sync commands...');
+        return $this->runDomains($this->argument('environment'), $this->domains());
+    }
 
-        collect([
-            SyncNetworkCommand::class,
-            SyncStorageCommand::class,
-            SyncIamCommand::class,
+    /**
+     * The ordered, domain-labelled steps this environment will sync.
+     *
+     * @return array<string, array<int, class-string>>
+     */
+    protected function domains(): array
+    {
+        return [
+            'Network' => (new SyncNetworkCommand())->steps(),
+            'Storage' => (new SyncStorageCommand())->steps(),
+            'IAM' => (new SyncIamCommand())->steps(),
             ...Manifest::isMultitenanted()
                 ? [
-                    SyncMultitenancyLandlordCommand::class,
-                    SyncMultitenancyTenantsCommand::class,
+                    'Landlord' => (new SyncMultitenancyLandlordCommand())->steps(),
+                    'Tenants' => (new SyncMultitenancyTenantsCommand())->steps(),
                 ]
                 : [
-                    SyncSoloCommand::class,
+                    'Solo' => (new SyncSoloCommand())->steps(),
                 ],
             ...Manifest::has('tasks.web')
-                ? [SyncComputeCommand::class]
+                ? ['Compute' => (new SyncComputeCommand())->steps()]
                 : [],
-            SyncLoggingCommand::class,
-        ])->each(fn ($command) => (new $command())->execute(Helpers::app('input'), Helpers::app('output')));
-
-        info('Sync command executed successfully.');
-
-        return self::SUCCESS;
+            'Logging' => (new SyncLoggingCommand())->steps(),
+        ];
     }
 }

--- a/src/Commands/SyncComputeCommand.php
+++ b/src/Commands/SyncComputeCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncComputeCommand extends SteppedCommand
+class SyncComputeCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         Steps\Fargate\SyncEcrRepositoryStep::class,
@@ -24,11 +23,8 @@ class SyncComputeCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:compute')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync the compute resources for the given environment');
     }
 }

--- a/src/Commands/SyncIamCommand.php
+++ b/src/Commands/SyncIamCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncIamCommand extends SteppedCommand
+class SyncIamCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         Steps\Iam\SyncMediaConvertRoleStep::class,
@@ -19,11 +18,8 @@ class SyncIamCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:iam')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync the IAM permissions for the given environment');
     }
 }

--- a/src/Commands/SyncLoggingCommand.php
+++ b/src/Commands/SyncLoggingCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncLoggingCommand extends SteppedCommand
+class SyncLoggingCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         // ivs
@@ -16,11 +15,8 @@ class SyncLoggingCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:logging')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync the logging resources for the given environment');
     }
 }

--- a/src/Commands/SyncMultitenancyLandlordCommand.php
+++ b/src/Commands/SyncMultitenancyLandlordCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncMultitenancyLandlordCommand extends SteppedCommand
+class SyncMultitenancyLandlordCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         Steps\Landlord\SyncQueueStep::class,
@@ -14,11 +13,8 @@ class SyncMultitenancyLandlordCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:multitenancy-landlord')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync configured landlord AWS resources');
     }
 }

--- a/src/Commands/SyncMultitenancyTenantsCommand.php
+++ b/src/Commands/SyncMultitenancyTenantsCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncMultitenancyTenantsCommand extends SteppedCommand
+class SyncMultitenancyTenantsCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         //        Steps\Tenant\SyncHostedZoneStep::class,
@@ -18,11 +17,8 @@ class SyncMultitenancyTenantsCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:multitenancy-tenants')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync configured tenant AWS resources');
     }
 }

--- a/src/Commands/SyncNetworkCommand.php
+++ b/src/Commands/SyncNetworkCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncNetworkCommand extends SteppedCommand
+class SyncNetworkCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         // vpc
@@ -37,11 +36,8 @@ class SyncNetworkCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:network')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync the network resources for the given environment');
     }
 }

--- a/src/Commands/SyncSoloCommand.php
+++ b/src/Commands/SyncSoloCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncSoloCommand extends SteppedCommand
+class SyncSoloCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         Steps\Solo\SyncHostedZoneStep::class,
@@ -16,11 +15,8 @@ class SyncSoloCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:solo')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync AWS resources for a solo app');
     }
 }

--- a/src/Commands/SyncSteppedCommand.php
+++ b/src/Commands/SyncSteppedCommand.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Illuminate\Support\Str;
+use Symfony\Component\Console\Input\InputArgument;
+
+abstract class SyncSteppedCommand extends SteppedCommand
+{
+    public function handle(): int
+    {
+        return $this->runDomains(
+            $this->argument('environment'),
+            [$this->domainLabel() => $this->steps()],
+        );
+    }
+
+    protected function domainLabel(): string
+    {
+        return (string) Str::of($this->getName())
+            ->after('sync')
+            ->trim(':')
+            ->headline();
+    }
+
+    protected function addSyncOptions(): static
+    {
+        $this->addArgument('environment', InputArgument::REQUIRED, 'The environment name');
+        $this->addOption('dry-run', null, null, 'Show what would change without applying it');
+        $this->addOption('no-progress', null, null, 'Hide the progress output');
+        $this->addOption('force', 'f', null, 'Skip the confirmation prompt');
+
+        return $this;
+    }
+}

--- a/src/Commands/SyncStorageCommand.php
+++ b/src/Commands/SyncStorageCommand.php
@@ -3,9 +3,8 @@
 namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
-use Symfony\Component\Console\Input\InputArgument;
 
-class SyncStorageCommand extends SteppedCommand
+class SyncStorageCommand extends SyncSteppedCommand
 {
     protected array $steps = [
         Steps\Storage\SyncS3ArtefactBucketStep::class,
@@ -15,11 +14,8 @@ class SyncStorageCommand extends SteppedCommand
 
     protected function configure(): void
     {
-        $this
+        $this->addSyncOptions()
             ->setName('sync:storage')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('dry-run', null, null, 'Run the command without making changes')
-            ->addOption('no-progress', null, null, 'Hide the progress output')
             ->setDescription('Sync the storage resources for the given environment');
     }
 }

--- a/src/Concerns/ChecksIfCommandsShouldBeRunning.php
+++ b/src/Concerns/ChecksIfCommandsShouldBeRunning.php
@@ -9,6 +9,7 @@ use Codinglabs\Yolo\Commands\Command;
 use Codinglabs\Yolo\Contracts\RunsOnAws;
 use Codinglabs\Yolo\Contracts\RunsOnAwsWeb;
 use Codinglabs\Yolo\Contracts\RunsOnAwsQueue;
+use Codinglabs\Yolo\Contracts\ExecutesIvsStep;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
 use Codinglabs\Yolo\Contracts\RunsOnAwsScheduler;
@@ -18,33 +19,46 @@ trait ChecksIfCommandsShouldBeRunning
 {
     public function shouldBeRunning(Command|Step $instance): bool
     {
-        if (
-            ($instance instanceof ExecutesSoloStep && Manifest::isMultitenanted())
-            || ($instance instanceof ExecutesMultitenancyStep && ! Manifest::isMultitenanted())
-        ) {
-            return false;
+        return $this->skipReason($instance) === null;
+    }
+
+    /**
+     * The human-readable reason this command/step is skipped, or null if it should run.
+     */
+    public function skipReason(Command|Step $instance): ?string
+    {
+        if ($instance instanceof ExecutesSoloStep && Manifest::isMultitenanted()) {
+            return 'solo-only step in a multi-tenant app';
+        }
+
+        if ($instance instanceof ExecutesMultitenancyStep && ! Manifest::isMultitenanted()) {
+            return 'multi-tenancy step in a solo app';
         }
 
         if ($instance instanceof ExecutesWebStep && Manifest::isHeadless()) {
-            return false;
+            return 'headless app (no ALB / Route 53 / domain)';
+        }
+
+        if ($instance instanceof ExecutesIvsStep && ! Manifest::ivsEnabled()) {
+            return 'aws.ivs not enabled in manifest';
         }
 
         if (Aws::runningInAws()) {
             if ($instance instanceof RunsOnAwsWeb) {
-                return Aws::runningInAwsWebEnvironment();
+                return Aws::runningInAwsWebEnvironment() ? null : 'not the web environment';
             }
 
             if ($instance instanceof RunsOnAwsQueue) {
-                return Aws::runningInAwsQueueEnvironment();
+                return Aws::runningInAwsQueueEnvironment() ? null : 'not the queue environment';
             }
 
             if ($instance instanceof RunsOnAwsScheduler) {
-                return Aws::runningInAwsSchedulerEnvironment();
+                return Aws::runningInAwsSchedulerEnvironment() ? null : 'not the scheduler environment';
             }
 
-            return $instance instanceof RunsOnAws;
+            return $instance instanceof RunsOnAws ? null : 'does not run on AWS instances';
         }
 
-        return ! $instance instanceof RunsOnAws;
+        return $instance instanceof RunsOnAws ? 'only runs on AWS instances' : null;
     }
 }

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -3,7 +3,9 @@
 namespace Codinglabs\Yolo\Concerns;
 
 use Illuminate\Support\Str;
+use Laravel\Prompts\Prompt;
 use Codinglabs\Yolo\Manifest;
+use Laravel\Prompts\Progress;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use Codinglabs\Yolo\Contracts\Step;
@@ -13,14 +15,233 @@ use Codinglabs\Yolo\Contracts\RunsOnBuild;
 use Codinglabs\Yolo\Contracts\ExecutesTenantStep;
 use Codinglabs\Yolo\Contracts\ExecutesCommandStep;
 use Codinglabs\Yolo\Steps\ExecuteBuildCommandStep;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
 use function Laravel\Prompts\table;
+use function Laravel\Prompts\confirm;
 use function Laravel\Prompts\warning;
 use function Laravel\Prompts\progress;
 
 trait RunsSteppedCommands
 {
     use ChecksIfCommandsShouldBeRunning;
+
+    /**
+     * Collate, plan, confirm and execute a set of domain-grouped steps as a single flow.
+     *
+     * @param  array<string, array<int, class-string>>  $domains  ordered label => step class names
+     */
+    protected function runDomains(string $environment, array $domains): int
+    {
+        Prompt::interactive($this->input->isInteractive());
+
+        [$plan, $skipped] = $this->collateSteps($domains, $environment);
+
+        if ($plan->isEmpty() && $skipped->isEmpty()) {
+            warning('No steps detected.');
+
+            return SymfonyCommand::SUCCESS;
+        }
+
+        $this->printDeterminations($environment, $plan, $skipped);
+
+        if (! $this->confirmGate($environment)) {
+            warning('Aborted — no changes made.');
+
+            return SymfonyCommand::SUCCESS;
+        }
+
+        $now = time();
+
+        $ran = $this->executePlan($plan, $now);
+
+        $this->renderResults($environment, $ran, $skipped, time() - $now);
+
+        return SymfonyCommand::SUCCESS;
+    }
+
+    /**
+     * Expand and partition every domain's steps into a runnable plan and a skipped ledger.
+     *
+     * @param  array<string, array<int, class-string>>  $domains
+     * @return array{0: Collection<int, array{domain: string, step: Step}>, 1: Collection<int, array{domain: string, step: Step, reason: string}>}
+     */
+    protected function collateSteps(array $domains, string $environment): array
+    {
+        $plan = collect();
+        $skipped = collect();
+
+        foreach ($domains as $label => $stepNames) {
+            foreach ($stepNames as $stepName) {
+                foreach ($this->expandStep(new $stepName($environment), $environment) as $step) {
+                    $reason = $this->skipReason($step);
+
+                    if ($reason === null) {
+                        $plan->push(['domain' => $label, 'step' => $step]);
+                    } else {
+                        $skipped->push(['domain' => $label, 'step' => $step, 'reason' => $reason]);
+                    }
+                }
+            }
+        }
+
+        return [$plan, $skipped];
+    }
+
+    protected function printDeterminations(string $environment, Collection $plan, Collection $skipped): void
+    {
+        intro(sprintf('Planning %s for %s', $this->getName(), $environment));
+
+        $this->output->writeln('  <options=bold>Will sync</>');
+
+        $plan->groupBy('domain')->each(function (Collection $entries, string $domain) {
+            $this->output->writeln(sprintf('  <fg=green>✔</> %s <fg=gray>(%d)</>', $domain, $entries->count()));
+        });
+
+        if ($skipped->isNotEmpty()) {
+            $this->output->writeln('');
+            $this->output->writeln('  <options=bold>Skipping</>');
+
+            $skipped
+                ->groupBy(fn (array $entry) => $entry['domain'] . '|' . $entry['reason'])
+                ->each(function (Collection $group) {
+                    $first = $group->first();
+
+                    $this->output->writeln(sprintf(
+                        '  <fg=yellow>•</> %s <fg=gray>(%d)</> — %s',
+                        $first['domain'],
+                        $group->count(),
+                        $first['reason'],
+                    ));
+                });
+        }
+
+        $this->output->writeln('');
+    }
+
+    protected function confirmGate(string $environment): bool
+    {
+        if ($this->option('force') || $this->option('dry-run') || ! $this->input->isInteractive()) {
+            return true;
+        }
+
+        return confirm(
+            label: sprintf('Apply these changes to %s?', $environment),
+            default: false,
+        );
+    }
+
+    /**
+     * @param  Collection<int, array{domain: string, step: Step}>  $plan
+     * @return Collection<int, array{index: int, domain: string, step: Step, status: StepResult|string, elapsed: int}>
+     */
+    protected function executePlan(Collection $plan, int $now): Collection
+    {
+        $multiDomain = $plan->pluck('domain')->unique()->count() > 1;
+
+        $progress = $this->option('no-progress')
+            ? null
+            : progress(label: 'Starting first step...', steps: $plan->count());
+
+        $progress?->start();
+
+        $ran = $plan->values()->map(function (array $entry, int $i) use ($progress, $now, $multiDomain) {
+            $step = $entry['step'];
+
+            $label = $multiDomain
+                ? sprintf('%s · %s', $entry['domain'], static::normaliseStep($step))
+                : static::normaliseStep($step);
+
+            return [
+                'index' => $i + 1,
+                'domain' => $entry['domain'],
+                'step' => $step,
+                ...$this->invokeStep($step, $progress, $label, $now),
+            ];
+        });
+
+        $progress?->finish();
+
+        return $ran;
+    }
+
+    /**
+     * Render the progress frame for a step, invoke it, and time it.
+     *
+     * @return array{status: StepResult|string, elapsed: int}
+     */
+    protected function invokeStep(Step $step, ?Progress $progress, string $label, int $now): array
+    {
+        $progress?->label($label)
+            ->hint(sprintf('%d seconds elapsed', time() - $now))
+            ->render();
+
+        $started = time();
+
+        $status = $step->__invoke($this->input->getOptions(), $this);
+
+        $progress?->advance();
+
+        return ['status' => $status, 'elapsed' => time() - $started];
+    }
+
+    /**
+     * @param  Collection<int, array{index: int, domain: string, step: Step, status: StepResult|string, elapsed: int}>  $ran
+     * @param  Collection<int, array{domain: string, step: Step, reason: string}>  $skipped
+     */
+    protected function renderResults(string $environment, Collection $ran, Collection $skipped, int $elapsed): void
+    {
+        $multiDomain = $ran->pluck('domain')->unique()->count() > 1;
+
+        $lastDomain = null;
+
+        $rows = $ran->map(function (array $result) use (&$lastDomain, $multiDomain) {
+            $row = [$result['index']];
+
+            if ($multiDomain) {
+                $row[] = $result['domain'] === $lastDomain ? '' : $result['domain'];
+                $lastDomain = $result['domain'];
+            }
+
+            $row[] = static::normaliseStep($result['step'], pad: true, bold: true, arrow: true);
+            $row[] = static::renderStatus($result['status']);
+            $row[] = sprintf('%ds', $result['elapsed']);
+
+            return $row;
+        });
+
+        if ($rows->isNotEmpty()) {
+            table(
+                $multiDomain
+                    ? ['#', 'Domain', 'Step', 'Status', 'Elapsed']
+                    : ['#', 'Step', 'Status', 'Elapsed'],
+                $rows->all()
+            );
+        }
+
+        if ($skipped->isNotEmpty()) {
+            if ($this->output->isVerbose()) {
+                table(
+                    ['Domain', 'Step', 'Reason'],
+                    $skipped->map(fn (array $entry) => [
+                        $entry['domain'],
+                        static::normaliseStep($entry['step']),
+                        $entry['reason'],
+                    ])->all()
+                );
+            } else {
+                info(sprintf(
+                    '%d step%s skipped (run with -v to show).',
+                    $skipped->count(),
+                    $skipped->count() === 1 ? '' : 's',
+                ));
+            }
+        }
+
+        info(sprintf('Synced %s in %ds.', $environment, $elapsed));
+    }
 
     protected function handleSteps(string $environment): int
     {
@@ -44,40 +265,13 @@ trait RunsSteppedCommands
         $progress?->start();
 
         $output = $steps->map(function (Step $step, int $i) use ($progress, $now) {
-            $progress?->label(static::normaliseStep($step))
-                ->hint(sprintf('%d seconds elapsed', time() - $now))
-                ->render();
-
-            $started = time();
-
-            $status = $step->__invoke($this->input->getOptions(), $this);
-
-            $progress?->advance();
+            ['status' => $status, 'elapsed' => $elapsed] = $this->invokeStep($step, $progress, static::normaliseStep($step), $now);
 
             return [
                 $i + 1,
                 static::normaliseStep($step, pad: true, bold: true, arrow: true),
-                match ($status) {
-                    // green
-                    StepResult::CREATED => '<fg=green>CREATED</>',
-                    StepResult::SUCCESS => '<fg=green>SUCCESS</>',
-                    StepResult::SYNCED => '<fg=green>SYNCED</>',
-
-                    // yellow
-                    StepResult::SKIPPED => '<fg=yellow>SKIPPED</>',
-                    StepResult::CUSTOM_MANAGED => '<fg=yellow>CUSTOM MANAGED</>',
-                    StepResult::WOULD_CREATE => '<fg=yellow>WOULD CREATE</>',
-                    StepResult::WOULD_SYNC => '<fg=yellow>WOULD SYNC</>',
-
-                    // red
-                    StepResult::MANIFEST_INVALID => '<fg=red>MANIFEST INVALID</>',
-                    StepResult::OUT_OF_SYNC => '<fg=red>OUT OF SYNC</>',
-                    StepResult::TIMEOUT => '<fg=red>TIMEOUT</>',
-                    default => is_string($status)
-                        ? $status
-                        : '',
-                },
-                time() - $started,
+                static::renderStatus($status),
+                $elapsed,
             ];
         });
 
@@ -99,32 +293,61 @@ trait RunsSteppedCommands
     protected function extractSteps(string $environment): Collection
     {
         return collect($this->steps)
-            ->flatMap(function (string $stepName) use ($environment) {
-                $step = new $stepName($environment);
-
-                if ($step instanceof HasSubSteps) {
-                    return collect($step->__invoke())
-                        ->map(fn (string $subStepName) => match (true) {
-                            $step instanceof RunsOnBuild => new ExecuteBuildCommandStep($environment, $subStepName),
-                        })
-                        ->prepend($step);
-                }
-
-                if ($step instanceof ExecutesTenantStep) {
-                    return collect(Manifest::tenants())
-                        ->map(function (array $config, string $tenantId) use ($step) {
-                            $step = clone $step;
-
-                            $step->setTenantId($tenantId)
-                                ->setConfig($config);
-
-                            return $step;
-                        })->values();
-                }
-
-                return [$step];
-            })
+            ->flatMap(fn (string $stepName) => $this->expandStep(new $stepName($environment), $environment))
             ->filter(fn (Step $step) => $this->shouldBeRunning($step));
+    }
+
+    /**
+     * Expand a step into its concrete runnable instances (sub-steps and per-tenant clones).
+     *
+     * @return array<int, Step>
+     */
+    protected function expandStep(Step $step, string $environment): array
+    {
+        if ($step instanceof HasSubSteps) {
+            return collect($step->__invoke())
+                ->map(fn (string $subStepName) => match (true) {
+                    $step instanceof RunsOnBuild => new ExecuteBuildCommandStep($environment, $subStepName),
+                })
+                ->prepend($step)
+                ->all();
+        }
+
+        if ($step instanceof ExecutesTenantStep) {
+            return collect(Manifest::tenants())
+                ->map(function (array $config, string $tenantId) use ($step) {
+                    $clone = clone $step;
+
+                    $clone->setTenantId($tenantId)
+                        ->setConfig($config);
+
+                    return $clone;
+                })->values()->all();
+        }
+
+        return [$step];
+    }
+
+    protected static function renderStatus(StepResult|string $status): string
+    {
+        return match ($status) {
+            // green
+            StepResult::CREATED => '<fg=green>CREATED</>',
+            StepResult::SUCCESS => '<fg=green>SUCCESS</>',
+            StepResult::SYNCED => '<fg=green>SYNCED</>',
+
+            // yellow
+            StepResult::SKIPPED => '<fg=yellow>SKIPPED</>',
+            StepResult::CUSTOM_MANAGED => '<fg=yellow>CUSTOM MANAGED</>',
+            StepResult::WOULD_CREATE => '<fg=yellow>WOULD CREATE</>',
+            StepResult::WOULD_SYNC => '<fg=yellow>WOULD SYNC</>',
+
+            // red
+            StepResult::MANIFEST_INVALID => '<fg=red>MANIFEST INVALID</>',
+            StepResult::OUT_OF_SYNC => '<fg=red>OUT OF SYNC</>',
+            StepResult::TIMEOUT => '<fg=red>TIMEOUT</>',
+            default => is_string($status) ? $status : '',
+        };
     }
 
     protected static function normaliseStep(Step $step, $pad = false, $bold = false, $arrow = false): string

--- a/src/Contracts/ExecutesIvsStep.php
+++ b/src/Contracts/ExecutesIvsStep.php
@@ -1,0 +1,5 @@
+<?php
+
+namespace Codinglabs\Yolo\Contracts;
+
+interface ExecutesIvsStep extends Step {}

--- a/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
+++ b/src/Steps/Logging/SyncIvsCloudWatchLogGroupStep.php
@@ -7,18 +7,14 @@ use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\ExecutesIvsStep;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class SyncIvsCloudWatchLogGroupStep implements Step
+class SyncIvsCloudWatchLogGroupStep implements ExecutesIvsStep
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsEnabled()) {
-            return StepResult::SKIPPED;
-        }
-
         $name = self::logGroupName();
 
         $retentionDays = Manifest::get('aws.ivs.log-retention-days', 14);

--- a/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeRuleStep.php
@@ -5,20 +5,15 @@ namespace Codinglabs\Yolo\Steps\Logging;
 use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
-use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\ExecutesIvsStep;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class SyncIvsEventBridgeRuleStep implements Step
+class SyncIvsEventBridgeRuleStep implements ExecutesIvsStep
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsEnabled()) {
-            return StepResult::SKIPPED;
-        }
-
         $name = self::ruleName();
 
         try {

--- a/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
+++ b/src/Steps/Logging/SyncIvsEventBridgeTargetStep.php
@@ -6,18 +6,14 @@ use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\ExecutesIvsStep;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class SyncIvsEventBridgeTargetStep implements Step
+class SyncIvsEventBridgeTargetStep implements ExecutesIvsStep
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::ivsEnabled()) {
-            return StepResult::SKIPPED;
-        }
-
         $ruleName = SyncIvsEventBridgeRuleStep::ruleName();
         $logGroupName = SyncIvsCloudWatchLogGroupStep::logGroupName();
 

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Codinglabs\Yolo\Helpers;
+use Illuminate\Support\Collection;
+use Codinglabs\Yolo\Commands\SyncCommand;
+use Codinglabs\Yolo\Commands\SyncLoggingCommand;
+
+beforeEach(function () {
+    Helpers::app()->instance('runningInAws', false);
+});
+
+/**
+ * @return array<string, array<int, class-string>>
+ */
+function umbrellaDomains(): array
+{
+    $command = new SyncCommand();
+    $method = new ReflectionMethod($command, 'domains');
+
+    return $method->invoke($command);
+}
+
+/**
+ * @param  array<string, array<int, class-string>>  $domains
+ * @return array{0: Collection, 1: Collection} [$plan, $skipped]
+ */
+function collate(array $domains): array
+{
+    $command = new SyncCommand();
+    $method = new ReflectionMethod($command, 'collateSteps');
+
+    return $method->invoke($command, $domains, 'testing');
+}
+
+it('collates solo domains without compute when there is no web task', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    expect(array_keys(umbrellaDomains()))
+        ->toBe(['Network', 'Storage', 'IAM', 'Solo', 'Logging']);
+});
+
+it('includes compute when the manifest declares a web task', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'domain' => 'codinglabs.com.au',
+        'tasks' => ['web' => ['cpu' => 512, 'memory' => 1024]],
+    ]);
+
+    expect(array_keys(umbrellaDomains()))
+        ->toBe(['Network', 'Storage', 'IAM', 'Solo', 'Compute', 'Logging']);
+});
+
+it('collates landlord and tenant domains for a multi-tenant app', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'tenants' => ['alpha' => []],
+    ]);
+
+    expect(array_keys(umbrellaDomains()))
+        ->toBe(['Network', 'Storage', 'IAM', 'Landlord', 'Tenants', 'Logging']);
+});
+
+it('groups the three skipped IVS steps under a single determination', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    [$plan, $skipped] = collate(['Logging' => (new SyncLoggingCommand())->steps()]);
+
+    expect($plan)->toHaveCount(0);
+    expect($skipped)->toHaveCount(3);
+
+    // All three collapse to one (domain, reason) determination line.
+    expect($skipped->groupBy(fn (array $entry) => $entry['domain'] . '|' . $entry['reason']))
+        ->toHaveCount(1);
+    expect($skipped->first()['reason'])->toBe('aws.ivs not enabled in manifest');
+});
+
+it('plans the IVS steps when aws.ivs is enabled', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'ivs' => true],
+    ]);
+
+    [$plan, $skipped] = collate(['Logging' => (new SyncLoggingCommand())->steps()]);
+
+    expect($plan)->toHaveCount(3);
+    expect($skipped)->toHaveCount(0);
+});

--- a/tests/Unit/Concerns/RunDomainsRenderTest.php
+++ b/tests/Unit/Concerns/RunDomainsRenderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+use Laravel\Prompts\Prompt;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Commands\SyncCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Codinglabs\Yolo\Commands\SyncLoggingCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+class RunDomainsFakeStep implements Step
+{
+    public function __invoke(array $options): StepResult
+    {
+        return StepResult::CREATED;
+    }
+}
+
+/**
+ * Drive the full collate → determinations → confirm → execute → results pipeline
+ * against a non-interactive command and return everything written to the terminal.
+ *
+ * @param  array<string, array<int, class-string>>  $domains
+ * @param  array<string, mixed>  $options
+ */
+function runDomainsCapture(array $domains, array $options = []): string
+{
+    $command = new SyncCommand();
+
+    $input = new ArrayInput(['environment' => 'testing'] + $options, $command->getDefinition());
+    $input->setInteractive(false);
+
+    $output = new BufferedOutput();
+
+    $command->input = $input;
+    $command->output = $output;
+
+    Prompt::setOutput($output);
+
+    (new ReflectionMethod($command, 'runDomains'))->invoke($command, 'testing', $domains);
+
+    return $output->fetch();
+}
+
+beforeEach(function () {
+    Helpers::app()->instance('runningInAws', false);
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+});
+
+it('prints determinations, runs the plan, and reports skips in one flow', function () {
+    $output = runDomainsCapture([
+        'Network' => [RunDomainsFakeStep::class, RunDomainsFakeStep::class],
+        'Storage' => [RunDomainsFakeStep::class],
+        'Logging' => (new SyncLoggingCommand())->steps(),
+    ], ['--no-progress' => true]);
+
+    // up-front determinations summary
+    expect($output)
+        ->toContain('Will sync')
+        ->toContain('Network')
+        ->toContain('Storage')
+        ->toContain('Skipping')
+        ->toContain('aws.ivs not enabled in manifest');
+
+    // executed results, skip summary, and completion line
+    expect($output)
+        ->toContain('CREATED')
+        ->toContain('3 steps skipped')
+        ->toContain('Synced testing');
+});
+
+it('auto-proceeds without a prompt when non-interactive', function () {
+    // No exception / no hang means confirmGate short-circuited on !isInteractive.
+    $output = runDomainsCapture(
+        ['Network' => [RunDomainsFakeStep::class]],
+        ['--no-progress' => true],
+    );
+
+    expect($output)->toContain('Synced testing');
+});

--- a/tests/Unit/Concerns/SkipReasonTest.php
+++ b/tests/Unit/Concerns/SkipReasonTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Commands\SyncCommand;
+use Codinglabs\Yolo\Contracts\ExecutesIvsStep;
+use Codinglabs\Yolo\Contracts\ExecutesWebStep;
+use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
+use Codinglabs\Yolo\Contracts\ExecutesMultitenancyStep;
+
+beforeEach(function () {
+    // skipReason() consults Aws::runningInAws() for steps that pass every
+    // structural gate; bind it so the "should run" path resolves locally.
+    Helpers::app()->instance('runningInAws', false);
+});
+
+function skipReasonFor(object $step): ?string
+{
+    return (new SyncCommand())->skipReason($step);
+}
+
+it('skips solo-only steps in a multi-tenant app', function () {
+    writeManifest(['tenants' => ['alpha' => []]]);
+
+    expect(skipReasonFor(new class() implements ExecutesSoloStep {}))
+        ->toBe('solo-only step in a multi-tenant app');
+});
+
+it('skips multi-tenancy steps in a solo app', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    expect(skipReasonFor(new class() implements ExecutesMultitenancyStep {}))
+        ->toBe('multi-tenancy step in a solo app');
+});
+
+it('skips web steps for a headless app', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    expect(skipReasonFor(new class() implements ExecutesWebStep {}))
+        ->toBe('headless app (no ALB / Route 53 / domain)');
+});
+
+it('runs web steps when the app has a domain', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'domain' => 'codinglabs.com.au',
+    ]);
+
+    expect(skipReasonFor(new class() implements ExecutesWebStep {}))->toBeNull();
+});
+
+it('skips IVS steps when aws.ivs is not enabled', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    expect(skipReasonFor(new class() implements ExecutesIvsStep {}))
+        ->toBe('aws.ivs not enabled in manifest');
+});
+
+it('runs IVS steps when aws.ivs is enabled', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'ivs' => true],
+    ]);
+
+    expect(skipReasonFor(new class() implements ExecutesIvsStep {}))->toBeNull();
+});
+
+it('runs a plain step with no structural gate', function () {
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    expect(skipReasonFor(new class() implements Step {}))->toBeNull();
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

`yolo sync` ran ~7 sub-commands, each printing its own intro, progress bar, and results table — a wall of tables with no upfront sense of the plan, and skips (e.g. IVS) only surfaced mid-run. This makes `sync` read like a plan.

What changed:
- **Collate up front** — every step gathered first, partitioned into *will run* vs *skipped-with-reason* using manifest reads only (no AWS calls), so the plan is honest before touching AWS.
- **Determinations summary** — grouped "Will sync" counts per domain + a "Skipping" section, one line per (domain, reason), e.g. `Logging (3) — aws.ivs not enabled in manifest`.
- **Confirm gate** — `confirm('Apply these changes to <env>?')` before any mutation; skip with `--force` (`-f`), auto-skipped on `--dry-run` and when non-interactive (CI). Decline = clean exit 0.
- **One** progress bar + **one** grouped results table (ran-only, domain shown once per group). Terse by default with an `N steps skipped` line; `-v` shows the full skipped ledger.
- Same flow for `--dry-run` and every standalone `sync:*` command.

How it's built:
- `skipReason()` — reason-returning sibling of `shouldBeRunning()`.
- New `ExecutesIvsStep` marker hoists the IVS manifest skip to collation time, replacing the inline per-step `if (! ivsEnabled) return SKIPPED` guard.
- Shared `runDomains()` pipeline in `RunsSteppedCommands`; sync commands extend a new `SyncSteppedCommand` base. `build` / `deploy` keep the existing `handleSteps()` flat-table path untouched.

**Is there anything the reviewer needs to know to deploy this?**

- **Behaviour change worth a look:** removed the `// todo: remove once mvp is finished` line in `Command.php` that force-set `VERBOSITY_DEBUG`. It made `-v` meaningless (everything was always verbose), which blocked the new `-v` ledger. Nothing else in `src/` reads verbosity, so the effect is: default output is quieter and real `-v`/`-vv`/`-vvv` now works. Easy to revert if you'd rather keep DEBUG-always.
- IVS steps now skip *structurally* at collation time instead of returning `SKIPPED` mid-run — so when `aws.ivs` is off they no longer appear in the ran table (they show in the determinations "Skipping" line, and in the `-v` ledger).
- No manifest/schema changes. Rebased onto current main (includes #32 CloudFront assets); the new `SyncS3AssetBucketStep` / `SyncAssetDistributionStep` flow through the new pipeline automatically.
- Verified: 169 Pest tests pass, Pint + PHPStan clean. Not run against a live AWS account.

Minor pre-existing inconsistency noticed (not touched): `Steps\Solo\SyncQueueAlarmStep` implements plain `Step` while its sibling `SyncQueueStep` implements `ExecutesSoloStep` — only matters if someone runs `sync:solo` standalone against a multi-tenant manifest.

🤖 Generated with [Claude Code](https://claude.ai/code)