### PR TITLE
Inject SQS connection block on build + grant task role SQS access

### DIFF
--- a/src/Resources/Iam/EcsTaskPolicy.php
+++ b/src/Resources/Iam/EcsTaskPolicy.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Resources\Iam;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Iam;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
@@ -64,7 +65,7 @@ class EcsTaskPolicy implements Resource
      */
     public function description(): string
     {
-        return 'YOLO managed policy granting ECS Exec session channel permissions to the shared task role';
+        return 'YOLO managed baseline policy granting ECS Exec session channels and SQS queue access to the shared task role';
     }
 
     public function synchroniseTags(): void
@@ -112,7 +113,35 @@ class EcsTaskPolicy implements Resource
                         'ssmmessages:OpenDataChannel',
                     ],
                 ],
+                [
+                    // Lets the container dispatch to and work the YOLO-provisioned
+                    // SQS queues via the task role (no static AWS keys in the app).
+                    // Shared policy → scoped to every YOLO queue in this environment
+                    // (solo `yolo-{env}-{app}` + per-tenant variants).
+                    'Effect' => 'Allow',
+                    'Resource' => $this->queueArnPattern(),
+                    'Action' => [
+                        'sqs:SendMessage',
+                        'sqs:SendMessageBatch',
+                        'sqs:ReceiveMessage',
+                        'sqs:DeleteMessage',
+                        'sqs:DeleteMessageBatch',
+                        'sqs:ChangeMessageVisibility',
+                        'sqs:GetQueueAttributes',
+                        'sqs:GetQueueUrl',
+                    ],
+                ],
             ],
         ];
+    }
+
+    protected function queueArnPattern(): string
+    {
+        return sprintf(
+            'arn:aws:sqs:%s:%s:%s-*',
+            Manifest::get('aws.region'),
+            Aws::accountId(),
+            Helpers::keyedResourceName(exclusive: false),
+        );
     }
 }

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -44,10 +44,31 @@ class ConfigureEnvAndVersionStep implements Step
         // own prefix and old builds keep resolving.
         $values['ASSET_URL'] = sprintf('https://%s/builds/%s', (new AssetDistribution())->domain(), $appVersion);
 
-        // Inject the app's S3 bucket from the manifest when the consumer hasn't set
-        // it explicitly — single source of truth, respects an explicit .env override.
-        if (Manifest::has('aws.bucket') && ! $this->envDefines($envPath, 'AWS_BUCKET')) {
-            $values['AWS_BUCKET'] = Manifest::get('aws.bucket');
+        // Fargate-sane defaults injected only when the consumer's .env doesn't
+        // already set them — so the app "just works" with zero queue config but
+        // can still override. YOLO owns the SQS queue it provisions, so it knows
+        // the exact name + URL; the app never has to (and can't accidentally point
+        // at the wrong queue). No static AWS keys — the task role carries SQS access.
+        $defaults = [
+            'QUEUE_CONNECTION' => 'sqs',
+            'AWS_DEFAULT_REGION' => Manifest::get('aws.region'),
+            'SQS_PREFIX' => sprintf('https://sqs.%s.amazonaws.com/%s', Manifest::get('aws.region'), Aws::accountId()),
+        ];
+
+        // Solo apps have one queue; in multitenancy the worker resolves the
+        // per-tenant queue at runtime, so a single SQS_QUEUE would be wrong.
+        if (! Manifest::isMultitenanted()) {
+            $defaults['SQS_QUEUE'] = Helpers::keyedResourceName();
+        }
+
+        if (Manifest::has('aws.bucket')) {
+            $defaults['AWS_BUCKET'] = Manifest::get('aws.bucket');
+        }
+
+        foreach ($defaults as $key => $value) {
+            if (! $this->envDefines($envPath, $key)) {
+                $values[$key] = $value;
+            }
         }
 
         $this->filesystem->append($envPath, $this->generateValues($values));

--- a/tests/Unit/Resources/Iam/EcsTaskPolicyAndRoleTest.php
+++ b/tests/Unit/Resources/Iam/EcsTaskPolicyAndRoleTest.php
@@ -3,11 +3,17 @@
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskPolicy;
 
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+});
+
 it('describes the ECS task policy with the four ssmmessages exec permissions', function () {
     $document = (new EcsTaskPolicy())->document();
 
     expect($document['Version'])->toBe('2012-10-17');
-    expect($document['Statement'])->toHaveCount(1);
+    expect($document['Statement'])->toHaveCount(2);
     expect($document['Statement'][0])->toMatchArray([
         'Effect' => 'Allow',
         'Resource' => '*',
@@ -19,6 +25,14 @@ it('describes the ECS task policy with the four ssmmessages exec permissions', f
         'ssmmessages:OpenControlChannel',
         'ssmmessages:OpenDataChannel',
     ]);
+});
+
+it('grants SQS access scoped to this environment\'s YOLO queues', function () {
+    $statement = (new EcsTaskPolicy())->document()['Statement'][1];
+
+    expect($statement['Effect'])->toBe('Allow');
+    expect($statement['Resource'])->toBe('arn:aws:sqs:ap-southeast-2:111111111111:yolo-testing-*');
+    expect($statement['Action'])->toContain('sqs:ReceiveMessage', 'sqs:DeleteMessage', 'sqs:SendMessage', 'sqs:ChangeMessageVisibility');
 });
 
 it('trusts the ecs-tasks service in the ECS task assume role policy', function () {

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -49,6 +49,45 @@ it('does not inject AWS_BUCKET when the manifest does not define one', function 
     expect(file_get_contents(Paths::build('.env.testing')))->not->toContain('AWS_BUCKET=');
 });
 
+it('injects the SQS connection block for a solo app', function () {
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=sqs');
+    expect($env)->toContain('AWS_DEFAULT_REGION=ap-southeast-2');
+    expect($env)->toContain('SQS_PREFIX=https://sqs.ap-southeast-2.amazonaws.com/111111111111');
+    expect($env)->toContain('SQS_QUEUE=yolo-testing-my-app');
+});
+
+it('respects a QUEUE_CONNECTION already set in the .env', function () {
+    file_put_contents(Paths::build('.env.testing'), "QUEUE_CONNECTION=redis\n");
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=redis');
+    expect($env)->not->toContain('QUEUE_CONNECTION=sqs');
+});
+
+it('does not pin SQS_QUEUE for a multitenant app (worker resolves it per tenant)', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'tenants' => ['acme' => ['domain' => 'acme.test']],
+    ]);
+
+    is_dir(Paths::build()) || mkdir(Paths::build(), 0755, true);
+    file_exists(Paths::build('.env.testing')) && unlink(Paths::build('.env.testing'));
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=sqs');
+    expect($env)->not->toContain('SQS_QUEUE=');
+});
+
 it('respects an AWS_BUCKET already set in the .env', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket'],


### PR DESCRIPTION
## What

Wires Fargate apps to the SQS queue YOLO already provisions, so the queue works with **zero app config**. Today YOLO creates `yolo-{env}-{app}` but never tells the app about it — prod falls through to Laravel's framework queue default (wrong queue, or `sync`).

- **`ConfigureEnvAndVersionStep`** injects, only when the consumer's `.env` doesn't already define them (mirrors the existing `AWS_BUCKET` inject-if-absent pattern):
  - `QUEUE_CONNECTION=sqs`
  - `SQS_PREFIX=https://sqs.{region}.amazonaws.com/{account-id}`
  - `AWS_DEFAULT_REGION={region}`
  - `SQS_QUEUE={keyedResourceName}` — **solo apps only**; multitenant apps resolve the per-tenant queue at runtime, so pinning one would be wrong.

  All derived from the manifest. The app can't accidentally point at the wrong queue (e.g. an orphaned Vapor-era one), and an explicit `.env` value still wins. No static AWS keys — the task role carries access.
- **`EcsTaskPolicy`** (the shared task role's baseline policy) gains an SQS statement — `SendMessage(Batch)`, `ReceiveMessage`, `DeleteMessage(Batch)`, `ChangeMessageVisibility`, `GetQueueAttributes`, `GetQueueUrl` — scoped to `arn:aws:sqs:{region}:{account}:yolo-{env}-*` (every YOLO queue in the env, solo + per-tenant). Reconciled onto existing deployments via `synchroniseDocument()` on the next `sync:iam`.

## Not in this PR

Actually **running** `queue:work` + `schedule:work` is the container's process manager (supervisor in the consumer's Dockerfile), not YOLO. And cache/session drivers still fall to framework defaults — the real answer there is ElastiCache/Redis (LPX-263), a separate decision.

## Test plan
- [x] `./vendor/bin/pest` — 159 passed
- [x] `./vendor/bin/phpstan analyse` — clean
- [x] `./vendor/bin/pint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)