### PR TITLE
LPX-619: reconcile target-group health-check config on sync

### DIFF
--- a/src/Resources/Fargate/TargetGroup.php
+++ b/src/Resources/Fargate/TargetGroup.php
@@ -8,9 +8,10 @@ use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class TargetGroup implements Resource
+class TargetGroup implements Resource, SynchronisesConfiguration
 {
     public function name(): string
     {
@@ -48,12 +49,7 @@ class TargetGroup implements Resource
             // VPC lookup is still on the legacy AwsResources facade — covered by LPX-612.
             'VpcId' => AwsResources::vpc()['VpcId'],
             'HealthCheckProtocol' => 'HTTP',
-            'HealthCheckPath' => Manifest::get('tasks.web.health-check.path', '/health'),
-            'HealthCheckIntervalSeconds' => (int) Manifest::get('tasks.web.health-check.interval', 30),
-            'HealthCheckTimeoutSeconds' => (int) Manifest::get('tasks.web.health-check.timeout', 5),
-            'HealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.healthy-threshold', 2),
-            'UnhealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.unhealthy-threshold', 3),
-            'Matcher' => ['HttpCode' => '200'],
+            ...static::reconcilableHealthCheck(),
             ...Aws::tags($this->tags()),
         ]);
     }
@@ -61,5 +57,56 @@ class TargetGroup implements Resource
     public function synchroniseTags(): void
     {
         Aws::synchroniseElbV2Tags($this->arn(), $this->tags());
+    }
+
+    /**
+     * Push managed health-check config onto an existing target group. Create
+     * sets these once; without this, a changed default or manifest override
+     * (`tasks.web.health-check.*`) would never reach an already-deployed app —
+     * tag sync alone doesn't cover them. Diffs first so a clean sync makes no
+     * needless ModifyTargetGroup call. (The service grace period is a separate,
+     * service-level setting reconciled by EcsService.)
+     */
+    public function synchroniseConfiguration(): void
+    {
+        $live = ElbV2::targetGroup($this->name());
+        $desired = static::reconcilableHealthCheck();
+
+        $current = [
+            'HealthCheckPath' => $live['HealthCheckPath'] ?? null,
+            'HealthCheckIntervalSeconds' => $live['HealthCheckIntervalSeconds'] ?? null,
+            'HealthCheckTimeoutSeconds' => $live['HealthCheckTimeoutSeconds'] ?? null,
+            'HealthyThresholdCount' => $live['HealthyThresholdCount'] ?? null,
+            'UnhealthyThresholdCount' => $live['UnhealthyThresholdCount'] ?? null,
+            'Matcher' => ['HttpCode' => $live['Matcher']['HttpCode'] ?? null],
+        ];
+
+        if ($current == $desired) {
+            return;
+        }
+
+        Aws::elasticLoadBalancingV2()->modifyTargetGroup([
+            'TargetGroupArn' => $live['TargetGroupArn'],
+            ...$desired,
+        ]);
+    }
+
+    /**
+     * The health-check fields create sets and sync keeps current — one source
+     * of truth so the two paths can't drift apart. Timeout must stay below the
+     * interval (an AWS constraint on ModifyTargetGroup).
+     *
+     * @return array<string, mixed>
+     */
+    public static function reconcilableHealthCheck(): array
+    {
+        return [
+            'HealthCheckPath' => Manifest::get('tasks.web.health-check.path', '/health'),
+            'HealthCheckIntervalSeconds' => (int) Manifest::get('tasks.web.health-check.interval', 10),
+            'HealthCheckTimeoutSeconds' => (int) Manifest::get('tasks.web.health-check.timeout', 5),
+            'HealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.healthy-threshold', 2),
+            'UnhealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.unhealthy-threshold', 3),
+            'Matcher' => ['HttpCode' => '200'],
+        ];
     }
 }

--- a/tests/Unit/Resources/Fargate/TargetGroupTest.php
+++ b/tests/Unit/Resources/Fargate/TargetGroupTest.php
@@ -1,0 +1,99 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Resources\Fargate\TargetGroup;
+use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+});
+
+/**
+ * Bind an ELBv2 client whose DescribeTargetGroups returns the supplied target
+ * group, recording every command name so tests can assert whether (and which)
+ * write calls fired. Returns the recorder so the test can read `$recorder->calls`.
+ */
+function bindRecordingElbV2Client(array $targetGroup): object
+{
+    $recorder = new class($targetGroup) extends MockHandler
+    {
+        /** @var array<int, string> */
+        public array $calls = [];
+
+        public function __construct(public array $targetGroup) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = $cmd->getName();
+
+            return Create::promiseFor(
+                $cmd->getName() === 'DescribeTargetGroups'
+                    ? new Result(['TargetGroups' => [$this->targetGroup]])
+                    : new Result([])
+            );
+        }
+    };
+
+    Helpers::app()->instance('elasticLoadBalancingV2', new ElasticLoadBalancingV2Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+function liveTargetGroup(array $overrides = []): array
+{
+    return array_merge([
+        'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:targetgroup/yolo-testing-my-app/abc',
+        'HealthCheckPath' => '/health',
+        'HealthCheckIntervalSeconds' => 10,
+        'HealthCheckTimeoutSeconds' => 5,
+        'HealthyThresholdCount' => 2,
+        'UnhealthyThresholdCount' => 3,
+        'Matcher' => ['HttpCode' => '200'],
+    ], $overrides);
+}
+
+it('shares one health-check config between create and sync', function () {
+    expect(TargetGroup::reconcilableHealthCheck())->toBe([
+        'HealthCheckPath' => '/health',
+        'HealthCheckIntervalSeconds' => 10,
+        'HealthCheckTimeoutSeconds' => 5,
+        'HealthyThresholdCount' => 2,
+        'UnhealthyThresholdCount' => 3,
+        'Matcher' => ['HttpCode' => '200'],
+    ]);
+});
+
+it('modifies the target group when a health-check field has drifted', function () {
+    $recorder = bindRecordingElbV2Client(liveTargetGroup(['HealthCheckIntervalSeconds' => 30]));
+
+    (new TargetGroup())->synchroniseConfiguration();
+
+    expect($recorder->calls)->toContain('ModifyTargetGroup');
+});
+
+it('does not modify the target group when the live config already matches', function () {
+    $recorder = bindRecordingElbV2Client(liveTargetGroup());
+
+    (new TargetGroup())->synchroniseConfiguration();
+
+    expect($recorder->calls)->not->toContain('ModifyTargetGroup');
+});
+
+it('reads the live target group only once (reuses the lookup, no second describe)', function () {
+    $recorder = bindRecordingElbV2Client(liveTargetGroup(['HealthCheckIntervalSeconds' => 30]));
+
+    (new TargetGroup())->synchroniseConfiguration();
+
+    expect(collect($recorder->calls)->filter(fn ($c) => $c === 'DescribeTargetGroups'))->toHaveCount(1);
+});


### PR DESCRIPTION
## What

[LPX-619](https://linear.app/codinglabsau/issue/LPX-619). The target-group parallel to LPX-616's CloudFront config reconciliation.

`TargetGroup` set its health-check attributes (interval, path, timeout, healthy/unhealthy thresholds, matcher) only in the **create** path. On an existing target group `sync:compute` reconciled tags only — so a changed default or `tasks.web.health-check.*` override silently never reached already-deployed apps.

- `TargetGroup` now implements **`SynchronisesConfiguration`**, so the `SynchronisesResource` trait's SYNCED branch calls `synchroniseConfiguration()`.
- Extracted **`reconcilableHealthCheck()`** as the single source of truth shared by create + sync — they can't drift apart.
- `synchroniseConfiguration()` reuses the existing `ElbV2::targetGroup()` lookup (no second describe), diffs the managed fields, and only calls `ModifyTargetGroup` on real drift (no no-op API calls on a clean sync).
- Default health-check interval lowered **30 → 10s** — the change that surfaced the gap on the codinglabs canary (LPX-583).

## Scope

Target-group health-check tunables only. The ECS **service** grace period is a service-level setting already reconciled by `EcsService`; protocol/port are out of scope. AWS constraint respected: timeout (5s) < interval (10s).

## Test plan
- [x] `vendor/bin/pest --compact` — 173 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/pint --dirty` — pass
- New `TargetGroupTest`: shared helper, modify-on-drift, no-modify-when-matched, single-lookup (recording ELBv2 mock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)