### PR TITLE
Default web queue/scheduler off in code, on in the init stub

### DIFF
--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -15,10 +15,12 @@ use Illuminate\Filesystem\Filesystem;
  * so the running processes can't drift from the manifest and the octane port
  * always matches tasks.web.port (the same value the target group health-checks).
  *
- * The web task does everything: octane (the web server) always runs; the
- * scheduler and queue worker run unless tasks.web.scheduler / tasks.web.queue
- * are turned off. Splitting these into independent queue/scheduler services is
- * a later concern — this step only models the single-container web task.
+ * Octane (the web server) always runs; the scheduler and queue worker run only
+ * when tasks.web.scheduler / tasks.web.queue are explicitly true. The code
+ * default is false (octane only) — `yolo init` ships a manifest that turns both
+ * on, so a fresh app gets the full web task while the absence of config stays
+ * conservative. Splitting these into independent queue/scheduler services is a
+ * later concern; this step only models the single-container web task.
  */
 class GenerateSupervisorConfigStep implements Step
 {
@@ -47,11 +49,11 @@ class GenerateSupervisorConfigStep implements Step
             )),
         ];
 
-        if (Helpers::validateStrictBool(Manifest::get('tasks.web.scheduler', true), 'tasks.web.scheduler')) {
+        if (Helpers::validateStrictBool(Manifest::get('tasks.web.scheduler', false), 'tasks.web.scheduler')) {
             $blocks[] = $this->program('scheduler', 'php artisan schedule:work');
         }
 
-        if (Helpers::validateStrictBool(Manifest::get('tasks.web.queue', true), 'tasks.web.queue')) {
+        if (Helpers::validateStrictBool(Manifest::get('tasks.web.queue', false), 'tasks.web.queue')) {
             // Longer stop wait so an in-flight job can finish on SIGTERM before
             // supervisor force-kills the worker.
             $blocks[] = $this->program('queue', 'php artisan queue:work --tries=3 --max-time=3600', stopwaitsecs: 70);

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -2,24 +2,44 @@ name: {NAME}
 
 environments:
   production:
+    # Public domain. Omit both for a headless app (no ALB / DNS).
+    # apex: example.com
+    # domain: app.example.com   # defaults to apex; set for a subdomain
+
     aws:
       account-id: {AWS_ACCOUNT_ID}
       region: {AWS_REGION}
-      bucket:
-      cloudfront: // todo use magic [account level]
-      autoscaling:
-        web:
-        queue:
-        scheduler:
-      ec2:
-        instance-type: t3.small
-        octane: true
+      # bucket: my-app-bucket   # optional app S3 bucket, injected as AWS_BUCKET
+
+    tasks:
+      web:
+        cpu: '512'
+        memory: '1024'
+        port: 8000
+        desired-count: 1
+        enable-execute-command: true
+        queue: true        # run queue:work in the web container
+        scheduler: true    # run schedule:work in the web container
+
+      # Independent task groups — not yet implemented. Today the web task runs
+      # octane + queue:work + schedule:work together (toggle the flags above).
+      # When you need to scale the web tier without duplicating the scheduler,
+      # these become their own ECS services:
+      # queue:
+      #   cpu: '256'
+      #   memory: '512'
+      # scheduler:
+      #   cpu: '256'
+      #   memory: '512'
 
     build:
       - composer install --no-cache --no-interaction --optimize-autoloader --no-progress --classmap-authoritative --no-dev
       - npm ci
       - npm run build
-      - rm -rf package-lock.json resources/js resources/css node_modules database/seeders database/factories resources/seeding
+      - rm -rf package-lock.json node_modules database/seeders database/factories
+
+    deploy:
+      - php artisan migrate --force
 
     deploy-all:
       - php artisan optimize

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -35,7 +35,20 @@ it('defaults the octane port to 8000', function () {
     expect(generatedSupervisorConfig())->toContain('--port=8000');
 });
 
-it('runs the scheduler and queue worker by default (the web task does everything)', function () {
+it('runs octane only by default — scheduler and queue are opt-in', function () {
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('[program:octane]');
+    expect($config)->not->toContain('[program:scheduler]');
+    expect($config)->not->toContain('[program:queue]');
+});
+
+it('runs the scheduler and queue worker when explicitly enabled', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'tasks' => ['web' => ['queue' => true, 'scheduler' => true]],
+    ]);
+
     $config = generatedSupervisorConfig();
 
     expect($config)->toContain('[program:scheduler]');
@@ -44,28 +57,15 @@ it('runs the scheduler and queue worker by default (the web task does everything
     expect($config)->toContain('command=php artisan queue:work --tries=3 --max-time=3600');
 });
 
-it('omits the queue worker when tasks.web.queue is false', function () {
+it('runs the queue worker without the scheduler when only queue is enabled', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'tasks' => ['web' => ['queue' => false]],
+        'tasks' => ['web' => ['queue' => true]],
     ]);
 
     $config = generatedSupervisorConfig();
 
-    expect($config)->not->toContain('[program:queue]');
-    expect($config)->toContain('[program:octane]');
-    expect($config)->toContain('[program:scheduler]');
-});
-
-it('omits the scheduler when tasks.web.scheduler is false', function () {
-    writeManifest([
-        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'tasks' => ['web' => ['scheduler' => false]],
-    ]);
-
-    $config = generatedSupervisorConfig();
-
+    expect($config)->toContain('[program:queue]');
     expect($config)->not->toContain('[program:scheduler]');
     expect($config)->toContain('[program:octane]');
-    expect($config)->toContain('[program:queue]');
 });


### PR DESCRIPTION
## What

Makes the process set **explicit in the manifest** rather than a hidden code default.

- **`GenerateSupervisorConfigStep`**: `tasks.web.queue` / `tasks.web.scheduler` now default to **false** (octane only). They run only when explicitly `true`.
- **`stubs/yolo.yml.stub`**: `yolo init` now ships a v1 manifest that sets both to **true**, so a fresh app still gets the full web task — but the toggle is visible and the absence of config stays conservative.

Net: a brand-new `init` app runs octane + `queue:work` + `schedule:work`; an app that omits the keys runs octane only. The manifest is the single source of truth for what runs in the container.

## Also

The stub was still alpha-shaped (autoscaling/ec2/octane, no `tasks` block). Brought it to the v1 schema: `tasks.web` with the flags, commented `apex`/`domain`/`bucket` hints, and commented-out `tasks.queue` / `tasks.scheduler` groups as a forward pointer to independent (scaled) services — not yet implemented.

## Test plan
- [x] `vendor/bin/pest --compact` — 182 passed
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `vendor/bin/pint --dirty` — pass
- Stub parses as valid YAML with `queue: true` / `scheduler: true`.
- `GenerateSupervisorConfigStepTest`: octane-only by default, both-on when enabled, queue-only when only queue enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)