### PR TITLE
Resolve local AWS credentials via the full provider chain

### DIFF
--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -97,11 +97,19 @@ trait RegistersAws
         }
 
         // otherwise we are using a local env value to point to the correct AWS profile.
-        if (in_array(Helpers::keyedEnv('AWS_PROFILE'), ['', null, 'default'])) {
+        $profile = Helpers::keyedEnv('AWS_PROFILE');
+
+        if (in_array($profile, ['', null, 'default'])) {
             throw new IntegrityCheckException(sprintf('Using the default AWS profile in your credentials file is risky. Name your profile to something specific and update %s in your .env file before proceeding.', Helpers::keyedEnvName('AWS_PROFILE')));
         }
 
-        return CredentialProvider::ini(Helpers::keyedEnv('AWS_PROFILE'));
+        // Resolve through the full credential chain rather than ini() alone, so a
+        // `credential_process` profile (e.g. 1Password-backed short-lived creds)
+        // resolves alongside plain static keys. defaultProvider() selects the
+        // profile from the AWS_PROFILE env var.
+        putenv("AWS_PROFILE={$profile}");
+
+        return CredentialProvider::defaultProvider();
     }
 
     /**

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -103,13 +103,22 @@ trait RegistersAws
             throw new IntegrityCheckException(sprintf('Using the default AWS profile in your credentials file is risky. Name your profile to something specific and update %s in your .env file before proceeding.', Helpers::keyedEnvName('AWS_PROFILE')));
         }
 
-        // Resolve through the full credential chain rather than ini() alone, so a
-        // `credential_process` profile (e.g. 1Password-backed short-lived creds)
-        // resolves alongside plain static keys. defaultProvider() selects the
-        // profile from the AWS_PROFILE env var.
-        putenv("AWS_PROFILE={$profile}");
+        // Resolve the named profile through credential_process and static keys in
+        // both the credentials and config files, so a `credential_process` profile
+        // (e.g. 1Password-backed short-lived creds) resolves alongside plain static
+        // keys. Built explicitly rather than via defaultProvider() — which only
+        // reads the profile from $AWS_PROFILE — so the profile stays scoped without
+        // mutating the environment. Memoised so credentials resolve once per run.
+        $configFile = CredentialProvider::getConfigFileName();
 
-        return CredentialProvider::defaultProvider();
+        return CredentialProvider::memoize(
+            CredentialProvider::chain(
+                CredentialProvider::process($profile),
+                CredentialProvider::ini($profile),
+                CredentialProvider::process('profile ' . $profile, $configFile),
+                CredentialProvider::ini('profile ' . $profile, $configFile),
+            )
+        );
     }
 
     /**


### PR DESCRIPTION
## Summary

Prerequisite for `credential_process`-based auth (1Password / SSO / Keychain). Replaces the **local** branch's `CredentialProvider::ini()` in `RegistersAws::awsCredentials()` with an explicit, memoised credential chain scoped to the keyed profile:

```
process(credentials) → ini(credentials) → process(config) → ini(config)
```

This lets a profile defined purely via `credential_process` in `~/.aws/config` resolve — the seam 1Password's `op` plugs into — so long-lived keys can be kept out of `~/.aws/credentials` entirely, while plain static-key profiles keep working unchanged.

Built explicitly rather than via `defaultProvider()` because `defaultProvider()` only selects the profile from the `$AWS_PROFILE` env var (it ignores a passed-in profile). The explicit chain keeps the profile scoped **without mutating the environment**, and avoids `defaultProvider()`'s fall-through to the IMDS/instance provider on a misconfigured local profile.

## Backwards compatibility

- Only the **local** branch changes — CI (env keys) and on-AWS (IMDS role) branches return earlier and are untouched.
- A plain static key+secret profile still resolves via the chain's `ini` link.
- Verified locally against temp credentials/config files: a static-key profile and a `credential_process` profile both resolve correctly.

## Test plan

- [x] `./vendor/bin/pest` — 213 passed
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `./vendor/bin/pint` — pass
- [x] Manual: static-key profile + credential_process profile both resolve via the chain

🤖 Generated with [Claude Code](https://claude.com/claude-code)