### PR TITLE
feat: provision GitHub OIDC deployer role + policy in sync:iam (LPX-625)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,15 +45,26 @@ yolo init && yolo sync production && yolo deploy production
 
 Deploy from CI with short-lived, keyless credentials — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo secrets.
 
-Add a `deployer` block to the environment in `yolo.yml`. Both keys are optional — `repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI) and `branch` defaults to `main`, so `deployer: true` on its own is enough:
+Add a `deployer` block per environment in `yolo.yml`. `repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI), and you set **exactly one trigger** to scope which GitHub context may assume the role (defaults to `branch: main`):
+
+| Trigger | OIDC `sub` scope | Typical use |
+|---|---|---|
+| `branch: main` (default) | `…:ref:refs/heads/main` | push to a branch — e.g. staging |
+| `tag: 'v*'` (`true` = any tag) | `…:ref:refs/tags/v*` | tag push — e.g. production |
+| `environment: production` | `…:environment:production` | gate on a GitHub environment's reviewer / tag rules |
+
+Staging-on-`main`, production-on-tag, out of the box:
 
 ```yaml
 environments:
+  staging:
+    deployer: true            # repository inferred, branch main
   production:
     deployer:
-      repository: my-org/my-repo   # optional — inferred from the git origin
-      branch: main                 # optional — defaults to main
+      tag: 'v*'               # only a v* tag can assume the prod role
 ```
+
+For the strongest production gate, combine `environment: production` here with that GitHub environment's required-reviewers + protected `v*` tag rules — the AWS trust and the GitHub environment rules then both have to pass.
 
 `yolo sync:iam production` then provisions (and keeps in sync with the deploy steps):
 

--- a/README.md
+++ b/README.md
@@ -45,32 +45,30 @@ yolo init && yolo sync production && yolo deploy production
 
 Deploy from CI with short-lived, keyless credentials — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo secrets.
 
-Add a `deployer` block per environment in `yolo.yml`. `repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI), and you set **exactly one trigger** to scope which GitHub context may assume the role (defaults to `branch: main`):
+Each environment declares the **ref it deploys from**. That one setting drives the CI deployer role's OIDC trust (and, later, the local deploy guard). It defaults to the `main` branch, so the common case needs no config at all:
 
-| Trigger | OIDC `sub` scope | Typical use |
+| Ref | OIDC `sub` scope | Typical use |
 |---|---|---|
 | `branch: main` (default) | `…:ref:refs/heads/main` | push to a branch — e.g. staging |
 | `tag: 'v*'` (`true` = any tag) | `…:ref:refs/tags/v*` | tag push — e.g. production |
-| `environment: production` | `…:environment:production` | gate on a GitHub environment's reviewer / tag rules |
 
-Staging-on-`main`, production-on-tag, out of the box:
+Staging-on-`develop`, production-on-tag:
 
 ```yaml
 environments:
   staging:
-    deployer: true            # repository inferred, branch main
+    branch: develop           # deploys on push to develop
   production:
-    deployer:
-      tag: 'v*'               # only a v* tag can assume the prod role
+    tag: 'v*'                 # only a v* tag can assume the prod role
 ```
 
-For the strongest production gate, combine `environment: production` here with that GitHub environment's required-reviewers + protected `v*` tag rules — the AWS trust and the GitHub environment rules then both have to pass.
+`repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI) — set `repository: org/repo` per environment only to override (monorepo / fork).
 
-`yolo sync:iam production` then provisions (and keeps in sync with the deploy steps):
+When a GitHub repository is detected, `yolo sync:iam` provisions (and keeps in sync with the deploy steps):
 
 - the account's GitHub Actions OIDC identity provider (`token.actions.githubusercontent.com`), an account-level singleton;
-- a deployer role `yolo-{env}-deployer` whose trust policy only lets `repo:{repository}:ref:refs/heads/{branch}` assume it; and
-- a tightly-scoped permission policy covering exactly what `yolo deploy` does (ECR push, ECS register/update, `iam:PassRole` on the task + execution roles, S3 env/asset access, Route 53 record changes on the app's hosted zone).
+- a deployer role `yolo-{env}-{app}-deployer` whose trust only lets the environment's repo + ref assume it; and
+- a tightly-scoped permission policy covering exactly what `yolo deploy` does (ECR push, ECS register/update, `iam:PassRole` on the task + execution roles, S3 env/asset access, Route 53 record changes).
 
 In the consumer workflow, request the OIDC token and assume the role — no stored secrets:
 
@@ -82,10 +80,12 @@ permissions:
 steps:
   - uses: aws-actions/configure-aws-credentials@v4
     with:
-      role-to-assume: arn:aws:iam::<account-id>:role/yolo-production-deployer
+      role-to-assume: arn:aws:iam::<account-id>:role/yolo-production-myapp-deployer
       aws-region: <region>
   - run: vendor/bin/yolo deploy production
 ```
+
+For the strongest production gate, pair `tag: 'v*'` with a GitHub protected-tag ruleset (only maintainers may cut `v*` tags) — the AWS trust then just confirms "a tag push from this repo", and GitHub enforces who can trigger it.
 
 In CI, YOLO defers to the AWS SDK's default credential chain, so all three auth methods work out of the box with no extra config — OIDC (above), AWS IAM Identity Center (SSO), and legacy long-lived static access keys. Static keys still work but emit a warning nudging you towards OIDC.
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,41 @@ yolo init && yolo sync production && yolo deploy production
 
 `yolo deploy` builds and pushes the image, then ships it. Pass `--app-version=<tag>` (e.g. a GitHub release name) to stamp the build with a specific tag instead of an auto-generated timestamp.
 
+## Deploying from GitHub Actions (OIDC)
+
+Deploy from CI with short-lived, keyless credentials — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo secrets.
+
+Add a `deployer` block to the environment in `yolo.yml`:
+
+```yaml
+environments:
+  production:
+    deployer:
+      repository: my-org/my-repo   # scopes the OIDC sub claim
+      branch: main                 # defaults to main
+```
+
+`yolo sync:iam production` then provisions (and keeps in sync with the deploy steps):
+
+- the account's GitHub Actions OIDC identity provider (`token.actions.githubusercontent.com`), an account-level singleton;
+- a deployer role `yolo-{env}-deployer` whose trust policy only lets `repo:{repository}:ref:refs/heads/{branch}` assume it; and
+- a tightly-scoped permission policy covering exactly what `yolo deploy` does (ECR push, ECS register/update, `iam:PassRole` on the task + execution roles, S3 env/asset access, Route 53 record changes on the app's hosted zone).
+
+In the consumer workflow, request the OIDC token and assume the role — no stored secrets:
+
+```yaml
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::<account-id>:role/yolo-production-deployer
+      aws-region: <region>
+  - run: vendor/bin/yolo deploy production
+```
+
 ## Pre-1.0 alpha documentation
 
 The EC2/ASG `yolo-alpha` documentation lives in its own repo: [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha). Existing consumers should reference that repo.

--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ steps:
   - run: vendor/bin/yolo deploy production
 ```
 
+In CI, YOLO defers to the AWS SDK's default credential chain, so all three auth methods work out of the box with no extra config — OIDC (above), AWS IAM Identity Center (SSO), and legacy long-lived static access keys. Static keys still work but emit a warning nudging you towards OIDC.
+
 ## Pre-1.0 alpha documentation
 
 The EC2/ASG `yolo-alpha` documentation lives in its own repo: [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha). Existing consumers should reference that repo.

--- a/README.md
+++ b/README.md
@@ -45,14 +45,14 @@ yolo init && yolo sync production && yolo deploy production
 
 Deploy from CI with short-lived, keyless credentials — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo secrets.
 
-Add a `deployer` block to the environment in `yolo.yml`:
+Add a `deployer` block to the environment in `yolo.yml`. Both keys are optional — `repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI) and `branch` defaults to `main`, so `deployer: true` on its own is enough:
 
 ```yaml
 environments:
   production:
     deployer:
-      repository: my-org/my-repo   # scopes the OIDC sub claim
-      branch: main                 # defaults to main
+      repository: my-org/my-repo   # optional — inferred from the git origin
+      branch: main                 # optional — defaults to main
 ```
 
 `yolo sync:iam production` then provisions (and keeps in sync with the deploy steps):

--- a/src/Aws/Iam.php
+++ b/src/Aws/Iam.php
@@ -42,4 +42,21 @@ class Iam
             'VersionId' => $versionId,
         ])['PolicyVersion'];
     }
+
+    /**
+     * OIDC providers are account-level singletons keyed by their full ARN
+     * (no name field) — match the list entry by ARN.
+     */
+    public static function openIdConnectProvider(string $arn): array
+    {
+        $providers = Aws::iam()->listOpenIDConnectProviders();
+
+        foreach ($providers['OpenIDConnectProviderList'] as $provider) {
+            if ($provider['Arn'] === $arn) {
+                return $provider;
+            }
+        }
+
+        throw new ResourceDoesNotExistException("Could not find OIDC provider $arn");
+    }
 }

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -58,7 +58,7 @@ abstract class Command extends SymfonyCommand
 
         Helpers::app()->instance('environment', $this->argument('environment'));
 
-        if (! Aws::runningInAws() && ! Helpers::keyedEnv('AWS_PROFILE')) {
+        if (static::requiresAwsProfile() && ! Helpers::keyedEnv('AWS_PROFILE')) {
             error(sprintf('You need to specify YOLO_%s_AWS_PROFILE in your .env file before proceeding', strtoupper(Helpers::environment())));
 
             return 1;

--- a/src/Commands/SyncIamCommand.php
+++ b/src/Commands/SyncIamCommand.php
@@ -14,6 +14,10 @@ class SyncIamCommand extends SyncSteppedCommand
         Steps\Iam\AttachEcsTaskRolePoliciesStep::class,
         Steps\Iam\SyncEcsExecutionRoleStep::class,
         Steps\Iam\AttachEcsExecutionRolePoliciesStep::class,
+        Steps\Iam\SyncGithubOidcProviderStep::class,
+        Steps\Iam\SyncDeployerPolicyStep::class,
+        Steps\Iam\SyncDeployerRoleStep::class,
+        Steps\Iam\AttachDeployerRolePoliciesStep::class,
     ];
 
     protected function configure(): void

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -76,11 +76,15 @@ trait RegistersAws
             return null;
         }
 
-        // in CI (GitHub Actions) we use environment variables
+        // in CI (GitHub Actions) we use environment variables. The session token
+        // is required for OIDC assumed-role credentials (the modern, keyless
+        // path) and is null-safe for legacy static access keys — a null token is
+        // ignored by the SDK — so this stays backwards compatible.
         if (static::detectCiEnvironment()) {
             return [
                 'key' => env('AWS_ACCESS_KEY_ID'),
                 'secret' => env('AWS_SECRET_ACCESS_KEY'),
+                'token' => env('AWS_SESSION_TOKEN'),
             ];
         }
 

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -112,6 +112,18 @@ trait RegistersAws
         return (bool) env('AWS_ACCESS_KEY_ID') && ! env('AWS_SESSION_TOKEN');
     }
 
+    /**
+     * A named AWS profile is required only for genuinely local runs (off AWS and
+     * outside CI). On AWS we use the instance role; in CI awsCredentials() defers
+     * to the SDK default chain (OIDC / static keys), so the profile is never
+     * consulted. The account guard still STS-verifies whatever creds resolve, so
+     * not requiring a profile here doesn't weaken the which-account safety net.
+     */
+    protected static function requiresAwsProfile(): bool
+    {
+        return ! Aws::runningInAws() && ! static::detectCiEnvironment();
+    }
+
     protected static function detectLocalEnvironment(): bool
     {
         return env('APP_ENV', false) === 'local';

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -30,6 +30,8 @@ use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
 
+use function Laravel\Prompts\warning;
+
 trait RegistersAws
 {
     protected function registerAwsServices(): void
@@ -72,20 +74,24 @@ trait RegistersAws
     protected static function awsCredentials(): callable|array|null
     {
         if (Aws::runningInAws()) {
-            // On AWS we are using IAM roles, so we don't need to provide credentials
+            // On AWS we use the instance/task IAM role — defer to the SDK default
+            // credential chain (IMDS / container credentials).
             return null;
         }
 
-        // in CI (GitHub Actions) we use environment variables. The session token
-        // is required for OIDC assumed-role credentials (the modern, keyless
-        // path) and is null-safe for legacy static access keys — a null token is
-        // ignored by the SDK — so this stays backwards compatible.
+        // In CI we defer to the SDK default credential chain too, so every auth
+        // method works out of the box with no manifest changes — the chain
+        // resolves whatever the runner provides:
+        //   - GitHub OIDC via aws-actions/configure-aws-credentials (key + secret
+        //     + session token in the env) or the raw web-identity-token file;
+        //   - AWS IAM Identity Center (SSO);
+        //   - long-lived static access keys (legacy — warned against below).
         if (static::detectCiEnvironment()) {
-            return [
-                'key' => env('AWS_ACCESS_KEY_ID'),
-                'secret' => env('AWS_SECRET_ACCESS_KEY'),
-                'token' => env('AWS_SESSION_TOKEN'),
-            ];
+            if (static::usingLongLivedAccessKeys()) {
+                warning('Using long-lived AWS access keys in CI. Prefer keyless GitHub OIDC: add a `deployer` block to yolo.yml, run `yolo sync:iam`, then assume the yolo-<env>-deployer role via aws-actions/configure-aws-credentials. See the YOLO README.');
+            }
+
+            return null;
         }
 
         // otherwise we are using a local env value to point to the correct AWS profile.
@@ -94,6 +100,16 @@ trait RegistersAws
         }
 
         return CredentialProvider::ini(Helpers::keyedEnv('AWS_PROFILE'));
+    }
+
+    /**
+     * A static IAM user access key with no session token — OIDC, assumed-role and
+     * SSO credentials always carry a session token, so a key without one is the
+     * tell that long-lived keys are in play.
+     */
+    protected static function usingLongLivedAccessKeys(): bool
+    {
+        return (bool) env('AWS_ACCESS_KEY_ID') && ! env('AWS_SESSION_TOKEN');
     }
 
     protected static function detectLocalEnvironment(): bool

--- a/src/Enums/Iam.php
+++ b/src/Enums/Iam.php
@@ -9,4 +9,6 @@ enum Iam: string
     case ECS_TASK_ROLE = 'ecs-task-role';
     case ECS_TASK_POLICY = 'ecs-task-policy';
     case ECS_EXECUTION_ROLE = 'ecs-execution-role';
+    case DEPLOYER_ROLE = 'deployer';
+    case DEPLOYER_POLICY = 'deployer-policy';
 }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo;
 
 use BackedEnum;
 use Illuminate\Container\Container;
+use Symfony\Component\Process\Process;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
 class Helpers
@@ -70,6 +71,46 @@ class Helpers
         }
 
         return static::app('environment');
+    }
+
+    /**
+     * The GitHub `owner/repo` for the deployer OIDC trust, inferred without
+     * manifest config: GITHUB_REPOSITORY when running inside Actions, otherwise
+     * the GitHub origin remote of the local checkout. Returns null when it can't
+     * be determined (no GitHub origin) — the caller decides whether that's fatal.
+     */
+    public static function githubRepository(): ?string
+    {
+        if ($repository = env('GITHUB_REPOSITORY')) {
+            return $repository;
+        }
+
+        return static::parseGithubRepository(static::gitOriginUrl());
+    }
+
+    public static function gitOriginUrl(): ?string
+    {
+        $process = new Process(['git', '-C', Paths::base(), 'remote', 'get-url', 'origin']);
+        $process->run();
+
+        return $process->isSuccessful()
+            ? (trim($process->getOutput()) ?: null)
+            : null;
+    }
+
+    /**
+     * Extract the GitHub `owner/repo` from a remote URL (https or ssh form,
+     * with or without the trailing .git), or null if it isn't a github.com remote.
+     */
+    public static function parseGithubRepository(?string $url): ?string
+    {
+        if ($url === null) {
+            return null;
+        }
+
+        return preg_match('#github\.com[:/]([^/]+/[^/]+?)(?:\.git)?/?$#', $url, $matches)
+            ? $matches[1]
+            : null;
     }
 
     public static function validatePositiveInt(mixed $value, string $key): int

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -81,6 +81,12 @@ class Helpers
      */
     public static function githubRepository(): ?string
     {
+        // An explicit manifest `repository` wins (monorepos, forks); otherwise
+        // infer from CI's GITHUB_REPOSITORY or the GitHub origin remote.
+        if ($repository = Manifest::get('repository')) {
+            return $repository;
+        }
+
         if ($repository = env('GITHUB_REPOSITORY')) {
             return $repository;
         }

--- a/src/Resources/Iam/DeployerPolicy.php
+++ b/src/Resources/Iam/DeployerPolicy.php
@@ -7,7 +7,6 @@ use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Iam;
-use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\Fargate\EcsCluster;
@@ -23,10 +22,9 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * same place and CI never drifts into AccessDenied. Attached to the deployer
  * role by AttachDeployerRolePoliciesStep.
  *
- * Resource ARNs are constructed deterministically from the manifest (region,
- * account id, app name) so the document is pure — the one exception is the
- * Route 53 hosted-zone ARN, which has no derivable form and is resolved live
- * when a public domain is configured.
+ * All resource ARNs are constructed deterministically from the manifest
+ * (region, account id, app name), so the document is pure — no live AWS calls,
+ * and no coupling to resources later sync phases provision.
  *
  * Document drift is reconciled via createPolicyVersion (see EcsTaskPolicy).
  */
@@ -257,9 +255,6 @@ class DeployerPolicy implements Resource
      */
     protected function route53Statements(): array
     {
-        $hostedZone = AwsResources::hostedZone(Manifest::apex());
-        $hostedZoneArn = sprintf('arn:aws:route53:::hostedzone/%s', basename($hostedZone['Id']));
-
         return [
             [
                 // ListHostedZones is a collection operation — no resource-level scoping.
@@ -268,8 +263,15 @@ class DeployerPolicy implements Resource
                 'Action' => ['route53:ListHostedZones'],
             ],
             [
+                // Scoped to the hosted-zone resource type rather than one resolved
+                // zone id. The id isn't derivable from the domain, and resolving it
+                // live here would couple the IAM sync phase to the hosted zone that
+                // the later Solo phase creates — wedging the first `yolo sync` on a
+                // green-field account. The OIDC repo/branch trust boundary is the
+                // real fence; a single deploy role changing records in its own
+                // account is an acceptable scope.
                 'Effect' => 'Allow',
-                'Resource' => $hostedZoneArn,
+                'Resource' => 'arn:aws:route53:::hostedzone/*',
                 'Action' => ['route53:ChangeResourceRecordSets'],
             ],
             [

--- a/src/Resources/Iam/DeployerPolicy.php
+++ b/src/Resources/Iam/DeployerPolicy.php
@@ -32,7 +32,7 @@ class DeployerPolicy implements Resource
 {
     public function name(): string
     {
-        return Helpers::keyedResourceName(Iam::DEPLOYER_POLICY, exclusive: false);
+        return Helpers::keyedResourceName(Iam::DEPLOYER_POLICY, exclusive: true);
     }
 
     public function tags(): array

--- a/src/Resources/Iam/DeployerPolicy.php
+++ b/src/Resources/Iam/DeployerPolicy.php
@@ -1,0 +1,282 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\Iam;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Iam;
+use Codinglabs\Yolo\AwsResources;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Resources\Fargate\EcsCluster;
+use Codinglabs\Yolo\Resources\Fargate\EcsService;
+use Codinglabs\Yolo\Resources\Storage\AssetBucket;
+use Codinglabs\Yolo\Resources\Fargate\EcrRepository;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * YOLO-managed customer-managed IAM policy granting exactly the AWS permissions
+ * `yolo deploy` exercises — co-located with the deploy steps so that when a new
+ * deploy step calls a new AWS API, the deployer's permission is bumped in the
+ * same place and CI never drifts into AccessDenied. Attached to the deployer
+ * role by AttachDeployerRolePoliciesStep.
+ *
+ * Resource ARNs are constructed deterministically from the manifest (region,
+ * account id, app name) so the document is pure — the one exception is the
+ * Route 53 hosted-zone ARN, which has no derivable form and is resolved live
+ * when a public domain is configured.
+ *
+ * Document drift is reconciled via createPolicyVersion (see EcsTaskPolicy).
+ */
+class DeployerPolicy implements Resource
+{
+    public function name(): string
+    {
+        return Helpers::keyedResourceName(Iam::DEPLOYER_POLICY, exclusive: false);
+    }
+
+    public function tags(): array
+    {
+        return ['Name' => $this->name()];
+    }
+
+    public function exists(): bool
+    {
+        try {
+            IamClient::policy($this->name());
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    public function arn(): string
+    {
+        return IamClient::policy($this->name())['Arn'];
+    }
+
+    public function create(): void
+    {
+        Aws::iam()->createPolicy([
+            'PolicyName' => $this->name(),
+            'Description' => $this->description(),
+            'PolicyDocument' => json_encode($this->document()),
+            ...Aws::tags($this->tags()),
+        ]);
+    }
+
+    /**
+     * IAM Description fields enforce a restricted character set
+     * (tab/LF/CR + printable ASCII + Latin-1 Supplement) — no em dashes,
+     * smart quotes, or U+007F - U+00A0 control range. Validated by
+     * IamDescriptionsAreSafeTest.
+     */
+    public function description(): string
+    {
+        return 'YOLO managed deploy-time permissions for the GitHub Actions deployer role';
+    }
+
+    public function synchroniseTags(): void
+    {
+        Aws::iam()->tagPolicy([
+            'PolicyArn' => $this->arn(),
+            ...Aws::tags($this->tags()),
+        ]);
+    }
+
+    /**
+     * Policy-document drift is reconciled by creating a new version and setting
+     * it as default — the mechanism that lets a YOLO upgrade that adds a deploy
+     * step also widen the deployer's permissions. AWS keeps up to 5 versions.
+     */
+    public function synchroniseDocument(): void
+    {
+        $policy = IamClient::policy($this->name());
+        $document = json_encode($this->document());
+
+        $currentVersion = IamClient::policyVersion($policy['Arn'], $policy['DefaultVersionId']);
+
+        if (urldecode($currentVersion['Document']) === $document) {
+            return;
+        }
+
+        Aws::iam()->createPolicyVersion([
+            'PolicyArn' => $policy['Arn'],
+            'PolicyDocument' => $document,
+            'SetAsDefault' => true,
+        ]);
+    }
+
+    public function document(): array
+    {
+        $region = Manifest::get('aws.region');
+        $accountId = Aws::accountId();
+
+        $ecrRepositoryArn = sprintf('arn:aws:ecr:%s:%s:repository/%s', $region, $accountId, (new EcrRepository())->name());
+
+        $cluster = (new EcsCluster())->name();
+        $service = (new EcsService())->name(); // also the task-definition family
+
+        $assetBucketArn = sprintf('arn:aws:s3:::%s', (new AssetBucket())->name());
+        $artefactsBucketArn = sprintf('arn:aws:s3:::%s', Paths::s3ArtefactsBucket());
+
+        $statements = [
+            [
+                // Operations AWS does not support resource-level permissions for,
+                // so they must be granted on "*". Read-only, except
+                // RegisterTaskDefinition which only mints an immutable revision
+                // that the scoped UpdateService below then adopts.
+                'Effect' => 'Allow',
+                'Resource' => '*',
+                'Action' => [
+                    'ecr:GetAuthorizationToken',
+                    'ecs:RegisterTaskDefinition',
+                    'ecs:DescribeTaskDefinition',
+                    'ecs:ListTasks',
+                    'elasticloadbalancing:DescribeLoadBalancers',
+                    'elasticloadbalancing:DescribeTargetGroups',
+                    'elasticloadbalancing:DescribeTargetHealth',
+                    'ec2:DescribeVpcs',
+                    'ec2:DescribeSubnets',
+                    'ec2:DescribeSecurityGroups',
+                    'sts:GetCallerIdentity',
+                ],
+            ],
+            [
+                // Push the application image to this app's ECR repository.
+                'Effect' => 'Allow',
+                'Resource' => $ecrRepositoryArn,
+                'Action' => [
+                    'ecr:BatchCheckLayerAvailability',
+                    'ecr:GetDownloadUrlForLayer',
+                    'ecr:BatchGetImage',
+                    'ecr:InitiateLayerUpload',
+                    'ecr:UploadLayerPart',
+                    'ecr:CompleteLayerUpload',
+                    'ecr:PutImage',
+                    'ecr:DescribeImages',
+                    'ecr:DescribeRepositories',
+                ],
+            ],
+            [
+                // Roll the new revision onto this app's service and run the one-off
+                // deploy task (migrations) on its cluster.
+                'Effect' => 'Allow',
+                'Resource' => [
+                    sprintf('arn:aws:ecs:%s:%s:cluster/%s', $region, $accountId, $cluster),
+                    sprintf('arn:aws:ecs:%s:%s:service/%s/%s', $region, $accountId, $cluster, $service),
+                    sprintf('arn:aws:ecs:%s:%s:task-definition/%s:*', $region, $accountId, $service),
+                    sprintf('arn:aws:ecs:%s:%s:task/%s/*', $region, $accountId, $cluster),
+                ],
+                'Action' => [
+                    'ecs:DescribeClusters',
+                    'ecs:DescribeServices',
+                    'ecs:UpdateService',
+                    'ecs:RunTask',
+                    'ecs:DescribeTasks',
+                ],
+            ],
+            [
+                // Hand the task + execution roles to ECS when registering the task
+                // definition — scoped to exactly the two roles YOLO manages, and
+                // only to the ECS tasks service.
+                'Effect' => 'Allow',
+                'Resource' => [
+                    $this->taskRoleArn(),
+                    $this->executionRoleArn(),
+                ],
+                'Action' => ['iam:PassRole'],
+                'Condition' => [
+                    'StringEquals' => [
+                        'iam:PassedToService' => 'ecs-tasks.amazonaws.com',
+                    ],
+                ],
+            ],
+            [
+                // Pull the environment file (build) and push the public asset tree
+                // (deploy) — object operations on the artefacts + asset buckets.
+                'Effect' => 'Allow',
+                'Resource' => [
+                    sprintf('%s/*', $assetBucketArn),
+                    sprintf('%s/*', $artefactsBucketArn),
+                ],
+                'Action' => [
+                    's3:GetObject',
+                    's3:PutObject',
+                    's3:AbortMultipartUpload',
+                    's3:ListMultipartUploadParts',
+                ],
+            ],
+            [
+                // Bucket-level operations the asset transfer + env pull need.
+                'Effect' => 'Allow',
+                'Resource' => [
+                    $assetBucketArn,
+                    $artefactsBucketArn,
+                ],
+                'Action' => [
+                    's3:ListBucket',
+                    's3:ListBucketMultipartUploads',
+                    's3:GetBucketLocation',
+                ],
+            ],
+        ];
+
+        // The apex/www DNS cutover only runs for apps with a public domain. Scope
+        // the record change to the app's hosted zone; the change-status poll
+        // can't be scoped (change ids aren't known ahead of time).
+        if (Manifest::has('apex') || Manifest::has('domain')) {
+            $statements = [...$statements, ...$this->route53Statements()];
+        }
+
+        return [
+            'Version' => '2012-10-17',
+            'Statement' => $statements,
+        ];
+    }
+
+    protected function taskRoleArn(): string
+    {
+        return Manifest::has('tasks.web.task-role')
+            ? Manifest::get('tasks.web.task-role')
+            : sprintf('arn:aws:iam::%s:role/%s', Aws::accountId(), (new EcsTaskRole())->name());
+    }
+
+    protected function executionRoleArn(): string
+    {
+        return Manifest::has('tasks.web.execution-role')
+            ? Manifest::get('tasks.web.execution-role')
+            : sprintf('arn:aws:iam::%s:role/%s', Aws::accountId(), (new EcsExecutionRole())->name());
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function route53Statements(): array
+    {
+        $hostedZone = AwsResources::hostedZone(Manifest::apex());
+        $hostedZoneArn = sprintf('arn:aws:route53:::hostedzone/%s', basename($hostedZone['Id']));
+
+        return [
+            [
+                // ListHostedZones is a collection operation — no resource-level scoping.
+                'Effect' => 'Allow',
+                'Resource' => '*',
+                'Action' => ['route53:ListHostedZones'],
+            ],
+            [
+                'Effect' => 'Allow',
+                'Resource' => $hostedZoneArn,
+                'Action' => ['route53:ChangeResourceRecordSets'],
+            ],
+            [
+                'Effect' => 'Allow',
+                'Resource' => 'arn:aws:route53:::change/*',
+                'Action' => ['route53:GetChange'],
+            ],
+        ];
+    }
+}

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -92,9 +92,6 @@ class DeployerRole implements Resource
 
     public function assumeRolePolicyDocument(): array
     {
-        $repository = $this->repository();
-        $branch = Manifest::get('deployer.branch', 'main');
-
         return [
             'Version' => '2012-10-17',
             'Statement' => [
@@ -107,12 +104,47 @@ class DeployerRole implements Resource
                             sprintf('%s:aud', GithubOidcProvider::URL) => GithubOidcProvider::AUDIENCE,
                         ],
                         'StringLike' => [
-                            sprintf('%s:sub', GithubOidcProvider::URL) => sprintf('repo:%s:ref:refs/heads/%s', $repository, $branch),
+                            sprintf('%s:sub', GithubOidcProvider::URL) => $this->subjectClaim(),
                         ],
                     ],
                 ],
             ],
         ];
+    }
+
+    /**
+     * The `sub` claim the OIDC token must match — which GitHub context may assume
+     * the role. Exactly one trigger may be set (a security boundary, so ambiguity
+     * fails loudly); defaults to the main branch:
+     *   - branch: main (default)   → ref:refs/heads/main      (push to branch, e.g. staging)
+     *   - tag: 'v*' (or true = *)  → ref:refs/tags/v*         (tag push, e.g. production)
+     *   - environment: production  → environment:production   (GitHub environment rules)
+     */
+    protected function subjectClaim(): string
+    {
+        $repository = $this->repository();
+
+        $triggers = array_keys(array_filter([
+            'branch' => Manifest::has('deployer.branch'),
+            'tag' => Manifest::has('deployer.tag'),
+            'environment' => Manifest::has('deployer.environment'),
+        ]));
+
+        if (count($triggers) > 1) {
+            throw new IntegrityCheckException(sprintf('Ambiguous deployer trust scope — set only one of branch, tag, or environment (got %s).', implode(', ', $triggers)));
+        }
+
+        if (Manifest::has('deployer.tag')) {
+            $tag = Manifest::get('deployer.tag');
+
+            return sprintf('repo:%s:ref:refs/tags/%s', $repository, $tag === true ? '*' : $tag);
+        }
+
+        if (Manifest::has('deployer.environment')) {
+            return sprintf('repo:%s:environment:%s', $repository, Manifest::get('deployer.environment'));
+        }
+
+        return sprintf('repo:%s:ref:refs/heads/%s', $repository, Manifest::get('deployer.branch', 'main'));
     }
 
     /**

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -1,0 +1,116 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\Iam;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Iam;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * YOLO-managed IAM role a GitHub Actions workflow assumes (via OIDC) to deploy.
+ * The trust policy federates to the account's GitHub OIDC provider and is scoped
+ * to a single repository + branch, so only that workflow can assume it — no
+ * stored AWS access keys. The deploy-time permission policy is provided by
+ * DeployerPolicy and attached by AttachDeployerRolePoliciesStep.
+ *
+ * Shared per environment (yolo-{env}-deployer) like the task and execution
+ * roles — the realistic YOLO topology is one deploying app per account+env.
+ */
+class DeployerRole implements Resource
+{
+    public function name(): string
+    {
+        return Helpers::keyedResourceName(Iam::DEPLOYER_ROLE, exclusive: false);
+    }
+
+    public function tags(): array
+    {
+        return ['Name' => $this->name()];
+    }
+
+    public function exists(): bool
+    {
+        try {
+            IamClient::role($this->name());
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    public function arn(): string
+    {
+        return IamClient::role($this->name())['Arn'];
+    }
+
+    public function create(): void
+    {
+        Aws::iam()->createRole([
+            'RoleName' => $this->name(),
+            'Description' => $this->description(),
+            'AssumeRolePolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
+            ...Aws::tags($this->tags()),
+        ]);
+    }
+
+    /**
+     * IAM Description fields enforce a restricted character set
+     * (tab/LF/CR + printable ASCII + Latin-1 Supplement) — no em dashes,
+     * smart quotes, or U+007F - U+00A0 control range. Validated by
+     * IamDescriptionsAreSafeTest.
+     */
+    public function description(): string
+    {
+        return 'YOLO managed GitHub Actions OIDC deployer role for this environment';
+    }
+
+    public function synchroniseTags(): void
+    {
+        Aws::iam()->tagRole([
+            'RoleName' => $this->name(),
+            ...Aws::tags($this->tags()),
+        ]);
+    }
+
+    /**
+     * Trust-policy drift (e.g. the manifest repository/branch changed) is
+     * reconciled by replacing the assume-role policy document.
+     */
+    public function synchroniseAssumeRolePolicy(): void
+    {
+        Aws::iam()->updateAssumeRolePolicy([
+            'RoleName' => $this->name(),
+            'PolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
+        ]);
+    }
+
+    public function assumeRolePolicyDocument(): array
+    {
+        $repository = Manifest::get('deployer.repository');
+        $branch = Manifest::get('deployer.branch', 'main');
+
+        return [
+            'Version' => '2012-10-17',
+            'Statement' => [
+                [
+                    'Effect' => 'Allow',
+                    'Principal' => ['Federated' => (new GithubOidcProvider())->arn()],
+                    'Action' => 'sts:AssumeRoleWithWebIdentity',
+                    'Condition' => [
+                        'StringEquals' => [
+                            sprintf('%s:aud', GithubOidcProvider::URL) => GithubOidcProvider::AUDIENCE,
+                        ],
+                        'StringLike' => [
+                            sprintf('%s:sub', GithubOidcProvider::URL) => sprintf('repo:%s:ref:refs/heads/%s', $repository, $branch),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -14,18 +14,19 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 /**
  * YOLO-managed IAM role a GitHub Actions workflow assumes (via OIDC) to deploy.
  * The trust policy federates to the account's GitHub OIDC provider and is scoped
- * to a single repository + branch, so only that workflow can assume it — no
- * stored AWS access keys. The deploy-time permission policy is provided by
- * DeployerPolicy and attached by AttachDeployerRolePoliciesStep.
+ * to a single repository + ref (the environment's branch or tag), so only that
+ * workflow can assume it — no stored AWS access keys. The deploy-time permission
+ * policy is provided by DeployerPolicy and attached by AttachDeployerRolePoliciesStep.
  *
- * Shared per environment (yolo-{env}-deployer) like the task and execution
- * roles — the realistic YOLO topology is one deploying app per account+env.
+ * App + environment specific (yolo-{env}-{app}-deployer): both its trust (one
+ * repo + ref) and its permissions (the app's ECR repo, buckets, cluster, service)
+ * are app-specific, so unlike the shared task/execution roles it can't be shared.
  */
 class DeployerRole implements Resource
 {
     public function name(): string
     {
-        return Helpers::keyedResourceName(Iam::DEPLOYER_ROLE, exclusive: false);
+        return Helpers::keyedResourceName(Iam::DEPLOYER_ROLE, exclusive: true);
     }
 
     public function tags(): array
@@ -113,50 +114,40 @@ class DeployerRole implements Resource
     }
 
     /**
-     * The `sub` claim the OIDC token must match — which GitHub context may assume
-     * the role. Exactly one trigger may be set (a security boundary, so ambiguity
-     * fails loudly); defaults to the main branch:
-     *   - branch: main (default)   → ref:refs/heads/main      (push to branch, e.g. staging)
-     *   - tag: 'v*' (or true = *)  → ref:refs/tags/v*         (tag push, e.g. production)
-     *   - environment: production  → environment:production   (GitHub environment rules)
+     * The `sub` claim the OIDC token must match — which GitHub ref may assume the
+     * role. Derived from the environment's source ref (a security boundary, so
+     * setting both branch and tag fails loudly); defaults to the main branch:
+     *   - branch: develop (default main)  → ref:refs/heads/develop  (push to branch, e.g. staging)
+     *   - tag: 'v*' (or true = *)         → ref:refs/tags/v*        (tag push, e.g. production)
      */
     protected function subjectClaim(): string
     {
         $repository = $this->repository();
 
-        $triggers = array_keys(array_filter([
-            'branch' => Manifest::has('deployer.branch'),
-            'tag' => Manifest::has('deployer.tag'),
-            'environment' => Manifest::has('deployer.environment'),
-        ]));
-
-        if (count($triggers) > 1) {
-            throw new IntegrityCheckException(sprintf('Ambiguous deployer trust scope — set only one of branch, tag, or environment (got %s).', implode(', ', $triggers)));
+        if (Manifest::has('branch') && Manifest::has('tag')) {
+            throw new IntegrityCheckException('An environment deploys from a branch or a tag, not both — set only one.');
         }
 
-        if (Manifest::has('deployer.tag')) {
-            $tag = Manifest::get('deployer.tag');
+        if (Manifest::has('tag')) {
+            $tag = Manifest::get('tag');
 
             return sprintf('repo:%s:ref:refs/tags/%s', $repository, $tag === true ? '*' : $tag);
         }
 
-        if (Manifest::has('deployer.environment')) {
-            return sprintf('repo:%s:environment:%s', $repository, Manifest::get('deployer.environment'));
-        }
-
-        return sprintf('repo:%s:ref:refs/heads/%s', $repository, Manifest::get('deployer.branch', 'main'));
+        return sprintf('repo:%s:ref:refs/heads/%s', $repository, Manifest::get('branch', 'main'));
     }
 
     /**
-     * The org/repo scoping the trust. Explicit `deployer.repository` wins;
-     * otherwise it's inferred from GITHUB_REPOSITORY or the git origin remote so
-     * the manifest needs no repo config. Fails loudly when it can't be resolved —
-     * a trust policy with a missing repo would be a silent security hole.
+     * The org/repo scoping the trust — inferred from the git origin (or an
+     * explicit manifest `repository`) via Helpers::githubRepository(). Fails
+     * loudly when it can't be resolved: a trust policy with a missing repo would
+     * be a silent security hole. (The Sync*Step gates skip provisioning entirely
+     * when no GitHub repo is resolvable, so in practice this only fires if called
+     * directly without a GitHub context.)
      */
     protected function repository(): string
     {
-        return Manifest::get('deployer.repository')
-            ?? Helpers::githubRepository()
-            ?? throw new IntegrityCheckException('Could not determine the deployer repository. Set `deployer.repository` in yolo.yml, or run from a GitHub clone (or GitHub Actions).');
+        return Helpers::githubRepository()
+            ?? throw new IntegrityCheckException('Could not determine the GitHub repository for the deployer trust. Set `repository` in yolo.yml, or run from a GitHub clone (or GitHub Actions).');
     }
 }

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -8,6 +8,7 @@ use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Iam;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -91,7 +92,7 @@ class DeployerRole implements Resource
 
     public function assumeRolePolicyDocument(): array
     {
-        $repository = Manifest::get('deployer.repository');
+        $repository = $this->repository();
         $branch = Manifest::get('deployer.branch', 'main');
 
         return [
@@ -112,5 +113,18 @@ class DeployerRole implements Resource
                 ],
             ],
         ];
+    }
+
+    /**
+     * The org/repo scoping the trust. Explicit `deployer.repository` wins;
+     * otherwise it's inferred from GITHUB_REPOSITORY or the git origin remote so
+     * the manifest needs no repo config. Fails loudly when it can't be resolved —
+     * a trust policy with a missing repo would be a silent security hole.
+     */
+    protected function repository(): string
+    {
+        return Manifest::get('deployer.repository')
+            ?? Helpers::githubRepository()
+            ?? throw new IntegrityCheckException('Could not determine the deployer repository. Set `deployer.repository` in yolo.yml, or run from a GitHub clone (or GitHub Actions).');
     }
 }

--- a/src/Resources/Iam/GithubOidcProvider.php
+++ b/src/Resources/Iam/GithubOidcProvider.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\Iam;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * The account-level IAM OIDC identity provider for GitHub Actions. There can be
+ * exactly one provider per URL per account — it is shared across every YOLO
+ * environment and app, so it is deliberately NOT keyed by environment and never
+ * carries the yolo:environment tag.
+ *
+ * The deployer role's trust policy federates to this provider's ARN, letting a
+ * GitHub Actions workflow exchange its OIDC token for short-lived AWS credentials
+ * via sts:AssumeRoleWithWebIdentity (no stored access keys).
+ */
+class GithubOidcProvider implements Resource
+{
+    public const URL = 'token.actions.githubusercontent.com';
+
+    public const AUDIENCE = 'sts.amazonaws.com';
+
+    /**
+     * GitHub's OIDC certificate thumbprints. AWS now validates the GitHub IdP
+     * against its own trusted-CA library, so these are largely vestigial — but
+     * CreateOpenIDConnectProvider still accepts the list, so we pin the known
+     * values rather than rely on undocumented optional behaviour.
+     */
+    public const THUMBPRINTS = [
+        '6938fd4d98bab03faadb97b34396831e3780aea1',
+        '1c58a3a8518e8759bf075b76b750d4f2df264fcd',
+    ];
+
+    public function name(): string
+    {
+        return self::URL;
+    }
+
+    public function tags(): array
+    {
+        return ['Name' => self::URL];
+    }
+
+    public function exists(): bool
+    {
+        try {
+            IamClient::openIdConnectProvider($this->arn());
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    public function arn(): string
+    {
+        // IAM ARNs carry no region; the OIDC provider ARN is fully derivable from
+        // the account id and the well-known GitHub URL — no lookup required.
+        return sprintf('arn:aws:iam::%s:oidc-provider/%s', Aws::accountId(), self::URL);
+    }
+
+    public function create(): void
+    {
+        Aws::iam()->createOpenIDConnectProvider([
+            'Url' => sprintf('https://%s', self::URL),
+            'ClientIDList' => [self::AUDIENCE],
+            'ThumbprintList' => self::THUMBPRINTS,
+            // Shared account singleton — tag with Name only, never yolo:environment.
+            'Tags' => [
+                ['Key' => 'Name', 'Value' => self::URL],
+            ],
+        ]);
+    }
+
+    public function synchroniseTags(): void
+    {
+        Aws::iam()->tagOpenIDConnectProvider([
+            'OpenIDConnectProviderArn' => $this->arn(),
+            'Tags' => [
+                ['Key' => 'Name', 'Value' => self::URL],
+            ],
+        ]);
+    }
+}

--- a/src/Steps/Iam/AttachDeployerRolePoliciesStep.php
+++ b/src/Steps/Iam/AttachDeployerRolePoliciesStep.php
@@ -4,7 +4,7 @@ namespace Codinglabs\Yolo\Steps\Iam;
 
 use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
@@ -14,7 +14,7 @@ class AttachDeployerRolePoliciesStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::has('deployer')) {
+        if (Helpers::githubRepository() === null) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Iam/AttachDeployerRolePoliciesStep.php
+++ b/src/Steps/Iam/AttachDeployerRolePoliciesStep.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Iam;
+
+use Codinglabs\Yolo\Aws;
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\DeployerRole;
+use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
+
+class AttachDeployerRolePoliciesStep implements Step
+{
+    public function __invoke(array $options): StepResult
+    {
+        if (! Manifest::has('deployer')) {
+            return StepResult::SKIPPED;
+        }
+
+        if (Arr::get($options, 'dry-run')) {
+            return StepResult::WOULD_SYNC;
+        }
+
+        Aws::iam()->attachRolePolicy([
+            'RoleName' => (new DeployerRole())->name(),
+            'PolicyArn' => (new DeployerPolicy())->arn(),
+        ]);
+
+        return StepResult::SYNCED;
+    }
+}

--- a/src/Steps/Iam/SyncDeployerPolicyStep.php
+++ b/src/Steps/Iam/SyncDeployerPolicyStep.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Iam;
+
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+
+class SyncDeployerPolicyStep implements Step
+{
+    use SynchronisesResource;
+
+    public function __invoke(array $options): StepResult
+    {
+        if (! Manifest::has('deployer')) {
+            return StepResult::SKIPPED;
+        }
+
+        $policy = new DeployerPolicy();
+
+        // Document drift (a YOLO upgrade that widened the deploy-time call set)
+        // reconciled by creating a new policy version.
+        if ($policy->exists() && ! Arr::get($options, 'dry-run')) {
+            $policy->synchroniseDocument();
+        }
+
+        return $this->syncResource($policy, $options);
+    }
+}

--- a/src/Steps/Iam/SyncDeployerPolicyStep.php
+++ b/src/Steps/Iam/SyncDeployerPolicyStep.php
@@ -3,7 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Iam;
 
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
@@ -15,7 +15,7 @@ class SyncDeployerPolicyStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::has('deployer')) {
+        if (Helpers::githubRepository() === null) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Iam/SyncDeployerRoleStep.php
+++ b/src/Steps/Iam/SyncDeployerRoleStep.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Iam;
+
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\DeployerRole;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+
+class SyncDeployerRoleStep implements Step
+{
+    use SynchronisesResource;
+
+    public function __invoke(array $options): StepResult
+    {
+        if (! Manifest::has('deployer')) {
+            return StepResult::SKIPPED;
+        }
+
+        $role = new DeployerRole();
+
+        // Trust-policy drift (the manifest repository/branch changed) reconciled
+        // by replacing the assume-role policy.
+        if ($role->exists() && ! Arr::get($options, 'dry-run')) {
+            $role->synchroniseAssumeRolePolicy();
+        }
+
+        return $this->syncResource($role, $options);
+    }
+}

--- a/src/Steps/Iam/SyncDeployerRoleStep.php
+++ b/src/Steps/Iam/SyncDeployerRoleStep.php
@@ -3,7 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Iam;
 
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
@@ -15,7 +15,7 @@ class SyncDeployerRoleStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::has('deployer')) {
+        if (Helpers::githubRepository() === null) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Iam/SyncGithubOidcProviderStep.php
+++ b/src/Steps/Iam/SyncGithubOidcProviderStep.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Iam;
+
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\GithubOidcProvider;
+
+class SyncGithubOidcProviderStep implements Step
+{
+    public function __invoke(array $options): StepResult
+    {
+        // Only apps that deploy from GitHub Actions need the OIDC provider.
+        if (! Manifest::has('deployer')) {
+            return StepResult::SKIPPED;
+        }
+
+        $provider = new GithubOidcProvider();
+
+        // Account-level singleton: shared across every environment and app, so it
+        // is never re-tagged or reconciled — if it already exists it is done.
+        if ($provider->exists()) {
+            return StepResult::SYNCED;
+        }
+
+        if (Arr::get($options, 'dry-run')) {
+            return StepResult::WOULD_CREATE;
+        }
+
+        $provider->create();
+
+        return StepResult::CREATED;
+    }
+}

--- a/src/Steps/Iam/SyncGithubOidcProviderStep.php
+++ b/src/Steps/Iam/SyncGithubOidcProviderStep.php
@@ -3,7 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Iam;
 
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\GithubOidcProvider;
@@ -12,8 +12,8 @@ class SyncGithubOidcProviderStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        // Only apps that deploy from GitHub Actions need the OIDC provider.
-        if (! Manifest::has('deployer')) {
+        // Only provision GitHub OIDC infra when this app is actually on GitHub.
+        if (Helpers::githubRepository() === null) {
             return StepResult::SKIPPED;
         }
 

--- a/stubs/Dockerfile.stub
+++ b/stubs/Dockerfile.stub
@@ -5,7 +5,7 @@
 FROM dunglas/frankenphp:1-php8.4-alpine
 
 RUN apk add --no-cache git supervisor \
-    && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache
+    && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache excimer
 
 WORKDIR /app
 

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -6,23 +6,19 @@ environments:
     # apex: example.com
     # domain: app.example.com   # defaults to apex; set for a subdomain
 
+    # Source ref this environment deploys from — drives the local deploy guard
+    # and, when this repo is on GitHub, the CI deployer role's OIDC trust. The
+    # role (yolo-{env}-{app}-deployer) is provisioned automatically by
+    # `yolo sync:iam` and assumed from GitHub Actions with no stored AWS keys.
+    # Defaults to the main branch, so omitting these just deploys on push to main.
+    # branch: main          # push to this branch (e.g. develop for staging)
+    # tag: 'v*'             # or a tag push (true = any tag) — e.g. production
+    # repository: org/repo  # optional — inferred from the git origin
+
     aws:
       account-id: {AWS_ACCOUNT_ID}
       region: {AWS_REGION}
       # bucket: my-app-bucket   # optional app S3 bucket, injected as AWS_BUCKET
-
-    # Deploy from GitHub Actions via OIDC (no stored AWS keys). When present,
-    # `yolo sync:iam` provisions the GitHub OIDC provider plus a deployer role
-    # (yolo-{env}-deployer) whose trust policy is scoped to this repo + branch.
-    # Assume it from the workflow with aws-actions/configure-aws-credentials.
-    # repository is inferred from your git origin, so `deployer: true` is enough.
-    # Set exactly one trigger to scope which GitHub context may deploy (defaults
-    # to branch: main). Omit the block if you don't deploy from CI.
-    # deployer:
-    #   repository: my-org/my-repo   # optional — inferred from the git origin
-    #   branch: main                 # push to branch (e.g. staging) — the default
-    #   # tag: 'v*'                  # tag push (e.g. production); true = any tag
-    #   # environment: production    # a GitHub environment (use its reviewer/tag rules)
 
     tasks:
       web:

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -15,10 +15,12 @@ environments:
     # `yolo sync:iam` provisions the GitHub OIDC provider plus a deployer role
     # (yolo-{env}-deployer) whose trust policy is scoped to this repo + branch.
     # Assume it from the workflow with aws-actions/configure-aws-credentials.
-    # Omit the block entirely for apps that don't deploy from CI.
+    # Both keys are optional — repository is inferred from your git origin and
+    # branch defaults to main, so `deployer: true` on its own is enough. Omit
+    # the block if you don't deploy from CI.
     # deployer:
-    #   repository: my-org/my-repo
-    #   branch: main   # defaults to main
+    #   repository: my-org/my-repo   # optional — inferred from the git origin
+    #   branch: main                 # optional — defaults to main
 
     tasks:
       web:

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -15,12 +15,14 @@ environments:
     # `yolo sync:iam` provisions the GitHub OIDC provider plus a deployer role
     # (yolo-{env}-deployer) whose trust policy is scoped to this repo + branch.
     # Assume it from the workflow with aws-actions/configure-aws-credentials.
-    # Both keys are optional — repository is inferred from your git origin and
-    # branch defaults to main, so `deployer: true` on its own is enough. Omit
-    # the block if you don't deploy from CI.
+    # repository is inferred from your git origin, so `deployer: true` is enough.
+    # Set exactly one trigger to scope which GitHub context may deploy (defaults
+    # to branch: main). Omit the block if you don't deploy from CI.
     # deployer:
     #   repository: my-org/my-repo   # optional — inferred from the git origin
-    #   branch: main                 # optional — defaults to main
+    #   branch: main                 # push to branch (e.g. staging) — the default
+    #   # tag: 'v*'                  # tag push (e.g. production); true = any tag
+    #   # environment: production    # a GitHub environment (use its reviewer/tag rules)
 
     tasks:
       web:

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -11,6 +11,15 @@ environments:
       region: {AWS_REGION}
       # bucket: my-app-bucket   # optional app S3 bucket, injected as AWS_BUCKET
 
+    # Deploy from GitHub Actions via OIDC (no stored AWS keys). When present,
+    # `yolo sync:iam` provisions the GitHub OIDC provider plus a deployer role
+    # (yolo-{env}-deployer) whose trust policy is scoped to this repo + branch.
+    # Assume it from the workflow with aws-actions/configure-aws-credentials.
+    # Omit the block entirely for apps that don't deploy from CI.
+    # deployer:
+    #   repository: my-org/my-repo
+    #   branch: main   # defaults to main
+
     tasks:
       web:
         cpu: '512'

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -109,6 +109,49 @@ function bindMockIamClient(array $roles): void
 }
 
 /**
+ * Bind a mock IAM client with command-routed responses, capturing every call.
+ * A command's value may be a single Result (repeated) or an array of Results
+ * used as a queue (the last entry repeats once exhausted). Mirrors the EC2 mock
+ * in SyncRdsSecurityGroupStepTest.
+ *
+ * @param  array<string, Result|array<int, Result>>  $byCommand
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
+ */
+function bindRoutedIamClient(array $byCommand, array &$captured): void
+{
+    $mock = new class($byCommand, $captured) extends MockHandler
+    {
+        /** @var array<string, int> */
+        private array $cursors = [];
+
+        public function __construct(protected array $byCommand, protected array &$captured) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $name = $cmd->getName();
+            $this->captured[] = ['name' => $name, 'args' => $cmd->toArray()];
+
+            $entry = $this->byCommand[$name] ?? new Result();
+
+            if (is_array($entry)) {
+                $index = min($this->cursors[$name] ?? 0, count($entry) - 1);
+                $this->cursors[$name] = $index + 1;
+                $entry = $entry[$index];
+            }
+
+            return Create::promiseFor($entry);
+        }
+    };
+
+    Helpers::app()->instance('iam', new IamClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
  * Bind a mock CloudFront client whose ListDistributions returns the supplied
  * distribution items. Repeating handler — every call resolves the same list.
  *

--- a/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
+++ b/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Concerns\RegistersAws;
+
+/**
+ * awsCredentials() is protected static; reach it through a tiny trait-using proxy.
+ */
+function resolveAwsCredentials(): callable|array|null
+{
+    $proxy = new class()
+    {
+        use RegistersAws;
+
+        public static function credentials(): callable|array|null
+        {
+            return self::awsCredentials();
+        }
+    };
+
+    return $proxy::credentials();
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+
+    // awsCredentials() short-circuits to the IAM-role path when on AWS — force
+    // the off-AWS path so the CI branch is reached.
+    Helpers::app()->instance('runningInAws', false);
+});
+
+afterEach(function () {
+    foreach (['CI', 'AWS_ACCESS_KEY_ID', 'AWS_SECRET_ACCESS_KEY', 'AWS_SESSION_TOKEN'] as $key) {
+        putenv($key);
+        unset($_ENV[$key], $_SERVER[$key]);
+    }
+});
+
+it('passes the session token in CI so OIDC assumed-role credentials are accepted', function () {
+    foreach ([
+        'CI' => 'true',
+        'AWS_ACCESS_KEY_ID' => 'ASIAEXAMPLE',
+        'AWS_SECRET_ACCESS_KEY' => 'secret-access-key',
+        'AWS_SESSION_TOKEN' => 'session-token-value',
+    ] as $key => $value) {
+        putenv("$key=$value");
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+
+    expect(resolveAwsCredentials())->toBe([
+        'key' => 'ASIAEXAMPLE',
+        'secret' => 'secret-access-key',
+        'token' => 'session-token-value',
+    ]);
+});
+
+it('leaves the token null for the legacy static-key path (backwards compatible)', function () {
+    foreach ([
+        'CI' => 'true',
+        'AWS_ACCESS_KEY_ID' => 'AKIAEXAMPLE',
+        'AWS_SECRET_ACCESS_KEY' => 'secret-access-key',
+    ] as $key => $value) {
+        putenv("$key=$value");
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+
+    expect(resolveAwsCredentials())->toBe([
+        'key' => 'AKIAEXAMPLE',
+        'secret' => 'secret-access-key',
+        'token' => null,
+    ]);
+});

--- a/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
+++ b/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
@@ -22,6 +22,11 @@ function credentialsProxy(): object
         {
             return self::usingLongLivedAccessKeys();
         }
+
+        public static function requiresProfile(): bool
+        {
+            return self::requiresAwsProfile();
+        }
     };
 }
 
@@ -89,4 +94,24 @@ it('does not flag the web-identity / SSO path where no static key is exported', 
     setEnv(['CI' => 'true']);
 
     expect(credentialsProxy()::longLivedKeys())->toBeFalse();
+});
+
+it('requires an AWS profile for a genuinely local run', function () {
+    // beforeEach binds runningInAws=false; ensure CI is unset so this is "local".
+    putenv('CI');
+    unset($_ENV['CI'], $_SERVER['CI']);
+
+    expect(credentialsProxy()::requiresProfile())->toBeTrue();
+});
+
+it('does not require an AWS profile in CI', function () {
+    setEnv(['CI' => 'true']);
+
+    expect(credentialsProxy()::requiresProfile())->toBeFalse();
+});
+
+it('does not require an AWS profile on AWS', function () {
+    Helpers::app()->instance('runningInAws', true);
+
+    expect(credentialsProxy()::requiresProfile())->toBeFalse();
 });

--- a/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
+++ b/tests/Unit/Concerns/RegistersAwsCredentialsTest.php
@@ -4,11 +4,12 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Concerns\RegistersAws;
 
 /**
- * awsCredentials() is protected static; reach it through a tiny trait-using proxy.
+ * awsCredentials() and usingLongLivedAccessKeys() are protected static; reach
+ * them through a tiny trait-using proxy.
  */
-function resolveAwsCredentials(): callable|array|null
+function credentialsProxy(): object
 {
-    $proxy = new class()
+    return new class()
     {
         use RegistersAws;
 
@@ -16,9 +17,12 @@ function resolveAwsCredentials(): callable|array|null
         {
             return self::awsCredentials();
         }
-    };
 
-    return $proxy::credentials();
+        public static function longLivedKeys(): bool
+        {
+            return self::usingLongLivedAccessKeys();
+        }
+    };
 }
 
 beforeEach(function () {
@@ -38,39 +42,51 @@ afterEach(function () {
     }
 });
 
-it('passes the session token in CI so OIDC assumed-role credentials are accepted', function () {
-    foreach ([
+function setEnv(array $values): void
+{
+    foreach ($values as $key => $value) {
+        putenv("$key=$value");
+        $_ENV[$key] = $value;
+        $_SERVER[$key] = $value;
+    }
+}
+
+it('defers to the SDK default credential chain in CI so every auth method works', function () {
+    // OIDC / assumed-role creds (session token present) — the SDK env provider
+    // reads key + secret + token itself, so YOLO returns null and stays out of it.
+    setEnv([
         'CI' => 'true',
         'AWS_ACCESS_KEY_ID' => 'ASIAEXAMPLE',
         'AWS_SECRET_ACCESS_KEY' => 'secret-access-key',
         'AWS_SESSION_TOKEN' => 'session-token-value',
-    ] as $key => $value) {
-        putenv("$key=$value");
-        $_ENV[$key] = $value;
-        $_SERVER[$key] = $value;
-    }
-
-    expect(resolveAwsCredentials())->toBe([
-        'key' => 'ASIAEXAMPLE',
-        'secret' => 'secret-access-key',
-        'token' => 'session-token-value',
     ]);
+
+    expect(credentialsProxy()::credentials())->toBeNull();
 });
 
-it('leaves the token null for the legacy static-key path (backwards compatible)', function () {
-    foreach ([
+it('flags long-lived static access keys (key present, no session token)', function () {
+    setEnv([
         'CI' => 'true',
         'AWS_ACCESS_KEY_ID' => 'AKIAEXAMPLE',
         'AWS_SECRET_ACCESS_KEY' => 'secret-access-key',
-    ] as $key => $value) {
-        putenv("$key=$value");
-        $_ENV[$key] = $value;
-        $_SERVER[$key] = $value;
-    }
-
-    expect(resolveAwsCredentials())->toBe([
-        'key' => 'AKIAEXAMPLE',
-        'secret' => 'secret-access-key',
-        'token' => null,
     ]);
+
+    expect(credentialsProxy()::longLivedKeys())->toBeTrue();
+});
+
+it('does not flag OIDC / assumed-role creds as long-lived', function () {
+    setEnv([
+        'CI' => 'true',
+        'AWS_ACCESS_KEY_ID' => 'ASIAEXAMPLE',
+        'AWS_SECRET_ACCESS_KEY' => 'secret-access-key',
+        'AWS_SESSION_TOKEN' => 'session-token-value',
+    ]);
+
+    expect(credentialsProxy()::longLivedKeys())->toBeFalse();
+});
+
+it('does not flag the web-identity / SSO path where no static key is exported', function () {
+    setEnv(['CI' => 'true']);
+
+    expect(credentialsProxy()::longLivedKeys())->toBeFalse();
 });

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -29,6 +29,37 @@ describe('keyedResourceName', function () {
     });
 });
 
+describe('parseGithubRepository', function () {
+    it('parses the ssh remote form', function () {
+        expect(Helpers::parseGithubRepository('git@github.com:codinglabsau/codinglabs.git'))
+            ->toBe('codinglabsau/codinglabs');
+    });
+
+    it('parses the https remote form', function () {
+        expect(Helpers::parseGithubRepository('https://github.com/codinglabsau/codinglabs.git'))
+            ->toBe('codinglabsau/codinglabs');
+    });
+
+    it('parses without the trailing .git', function () {
+        expect(Helpers::parseGithubRepository('https://github.com/codinglabsau/codinglabs'))
+            ->toBe('codinglabsau/codinglabs');
+    });
+
+    it('parses the ssh:// scheme form', function () {
+        expect(Helpers::parseGithubRepository('ssh://git@github.com/codinglabsau/codinglabs.git'))
+            ->toBe('codinglabsau/codinglabs');
+    });
+
+    it('returns null for a non-GitHub remote', function () {
+        expect(Helpers::parseGithubRepository('git@gitlab.com:codinglabsau/codinglabs.git'))
+            ->toBeNull();
+    });
+
+    it('returns null for a null url', function () {
+        expect(Helpers::parseGithubRepository(null))->toBeNull();
+    });
+});
+
 describe('keyedEnvName', function () {
     it('formats environment variable name', function () {
         expect(Helpers::keyedEnvName('DB_HOST'))

--- a/tests/Unit/Resources/Iam/DeployerPolicyTest.php
+++ b/tests/Unit/Resources/Iam/DeployerPolicyTest.php
@@ -1,11 +1,5 @@
 <?php
 
-use Aws\Result;
-use Aws\MockHandler;
-use Aws\CommandInterface;
-use Codinglabs\Yolo\Helpers;
-use Aws\Route53\Route53Client;
-use GuzzleHttp\Promise\Create;
 use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
 
 /**
@@ -15,28 +9,6 @@ function statementFor(array $document, string $action): array
 {
     return collect($document['Statement'])
         ->first(fn (array $statement) => in_array($action, (array) $statement['Action'], true));
-}
-
-function bindMockRoute53Client(array $hostedZones): void
-{
-    $result = new Result(['HostedZones' => $hostedZones]);
-
-    $mock = new class($result) extends MockHandler
-    {
-        public function __construct(protected Result $result) {}
-
-        public function __invoke(CommandInterface $cmd, $request)
-        {
-            return Create::promiseFor($this->result);
-        }
-    };
-
-    Helpers::app()->instance('route53', new Route53Client([
-        'region' => 'ap-southeast-2',
-        'version' => 'latest',
-        'credentials' => false,
-        'handler' => $mock,
-    ]));
 }
 
 beforeEach(function () {
@@ -132,22 +104,32 @@ it('omits Route 53 permissions for a headless app with no domain', function () {
     expect($actions)->not->toContain('route53:ChangeResourceRecordSets');
 });
 
-it('scopes Route 53 record changes to the resolved hosted zone when a domain is set', function () {
+it('grants Route 53 record changes scoped to the hosted-zone resource type when a domain is set', function () {
     writeManifest([
         'apex' => 'example.com',
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
         'deployer' => ['repository' => 'my-org/my-repo'],
     ]);
 
-    bindMockRoute53Client([
-        ['Name' => 'example.com.', 'Id' => '/hostedzone/Z123ABC'],
+    $document = (new DeployerPolicy())->document();
+
+    // No live zone lookup — the document is pure, so it never couples the IAM
+    // sync phase to the zone the Solo phase creates.
+    expect(statementFor($document, 'route53:ListHostedZones')['Resource'])->toBe('*');
+    expect(statementFor($document, 'route53:ChangeResourceRecordSets')['Resource'])
+        ->toBe('arn:aws:route53:::hostedzone/*');
+    expect(statementFor($document, 'route53:GetChange')['Resource'])
+        ->toBe('arn:aws:route53:::change/*');
+});
+
+it('includes Route 53 statements for a subdomain canary (domain only, no apex)', function () {
+    writeManifest([
+        'domain' => 'fargate.example.com',
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
     ]);
 
     $document = (new DeployerPolicy())->document();
 
-    expect(statementFor($document, 'route53:ListHostedZones')['Resource'])->toBe('*');
-    expect(statementFor($document, 'route53:ChangeResourceRecordSets')['Resource'])
-        ->toBe('arn:aws:route53:::hostedzone/Z123ABC');
-    expect(statementFor($document, 'route53:GetChange')['Resource'])
-        ->toBe('arn:aws:route53:::change/*');
+    expect(statementFor($document, 'route53:ChangeResourceRecordSets'))->not->toBeNull();
 });

--- a/tests/Unit/Resources/Iam/DeployerPolicyTest.php
+++ b/tests/Unit/Resources/Iam/DeployerPolicyTest.php
@@ -14,7 +14,6 @@ function statementFor(array $document, string $action): array
 beforeEach(function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
     ]);
 });
 
@@ -65,7 +64,6 @@ it('scopes PassRole to the task and execution roles, passed only to ECS tasks', 
 it('honours manifest task-role and execution-role overrides for PassRole', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
         'tasks' => ['web' => [
             'task-role' => 'arn:aws:iam::111111111111:role/custom-task',
             'execution-role' => 'arn:aws:iam::111111111111:role/custom-exec',
@@ -108,7 +106,6 @@ it('grants Route 53 record changes scoped to the hosted-zone resource type when 
     writeManifest([
         'apex' => 'example.com',
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
     ]);
 
     $document = (new DeployerPolicy())->document();
@@ -126,7 +123,6 @@ it('includes Route 53 statements for a subdomain canary (domain only, no apex)',
     writeManifest([
         'domain' => 'fargate.example.com',
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
     ]);
 
     $document = (new DeployerPolicy())->document();

--- a/tests/Unit/Resources/Iam/DeployerPolicyTest.php
+++ b/tests/Unit/Resources/Iam/DeployerPolicyTest.php
@@ -1,0 +1,153 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use Aws\Route53\Route53Client;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
+
+/**
+ * Returns the first statement in the document whose Action list contains $action.
+ */
+function statementFor(array $document, string $action): array
+{
+    return collect($document['Statement'])
+        ->first(fn (array $statement) => in_array($action, (array) $statement['Action'], true));
+}
+
+function bindMockRoute53Client(array $hostedZones): void
+{
+    $result = new Result(['HostedZones' => $hostedZones]);
+
+    $mock = new class($result) extends MockHandler
+    {
+        public function __construct(protected Result $result) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            return Create::promiseFor($this->result);
+        }
+    };
+
+    Helpers::app()->instance('route53', new Route53Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+    ]);
+});
+
+it('scopes the ECR push statement to this app\'s repository', function () {
+    $statement = statementFor((new DeployerPolicy())->document(), 'ecr:PutImage');
+
+    expect($statement['Resource'])->toBe('arn:aws:ecr:ap-southeast-2:111111111111:repository/my-app');
+    expect($statement['Action'])->toContain('ecr:InitiateLayerUpload', 'ecr:UploadLayerPart', 'ecr:CompleteLayerUpload');
+});
+
+it('grants RegisterTaskDefinition and the unscopeable describes on *', function () {
+    $statement = statementFor((new DeployerPolicy())->document(), 'ecs:RegisterTaskDefinition');
+
+    expect($statement['Resource'])->toBe('*');
+    expect($statement['Action'])->toContain(
+        'ecr:GetAuthorizationToken',
+        'ecs:DescribeTaskDefinition',
+        'elasticloadbalancing:DescribeTargetHealth',
+        'ec2:DescribeSubnets',
+        'sts:GetCallerIdentity',
+    );
+});
+
+it('scopes UpdateService and RunTask to this app\'s cluster resources', function () {
+    $statement = statementFor((new DeployerPolicy())->document(), 'ecs:UpdateService');
+
+    expect($statement['Resource'])->toEqualCanonicalizing([
+        'arn:aws:ecs:ap-southeast-2:111111111111:cluster/yolo-testing-my-app',
+        'arn:aws:ecs:ap-southeast-2:111111111111:service/yolo-testing-my-app/yolo-testing-my-app-web',
+        'arn:aws:ecs:ap-southeast-2:111111111111:task-definition/yolo-testing-my-app-web:*',
+        'arn:aws:ecs:ap-southeast-2:111111111111:task/yolo-testing-my-app/*',
+    ]);
+    expect($statement['Action'])->toContain('ecs:RunTask', 'ecs:DescribeServices');
+});
+
+it('scopes PassRole to the task and execution roles, passed only to ECS tasks', function () {
+    $statement = statementFor((new DeployerPolicy())->document(), 'iam:PassRole');
+
+    expect($statement['Resource'])->toBe([
+        'arn:aws:iam::111111111111:role/yolo-testing-ecs-task-role',
+        'arn:aws:iam::111111111111:role/yolo-testing-ecs-execution-role',
+    ]);
+    expect($statement['Condition'])->toBe([
+        'StringEquals' => ['iam:PassedToService' => 'ecs-tasks.amazonaws.com'],
+    ]);
+});
+
+it('honours manifest task-role and execution-role overrides for PassRole', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+        'tasks' => ['web' => [
+            'task-role' => 'arn:aws:iam::111111111111:role/custom-task',
+            'execution-role' => 'arn:aws:iam::111111111111:role/custom-exec',
+        ]],
+    ]);
+
+    $statement = statementFor((new DeployerPolicy())->document(), 'iam:PassRole');
+
+    expect($statement['Resource'])->toBe([
+        'arn:aws:iam::111111111111:role/custom-task',
+        'arn:aws:iam::111111111111:role/custom-exec',
+    ]);
+});
+
+it('grants S3 object and bucket access on the asset and artefacts buckets', function () {
+    $document = (new DeployerPolicy())->document();
+
+    $objects = statementFor($document, 's3:PutObject');
+    expect($objects['Resource'])->toBe([
+        'arn:aws:s3:::yolo-testing-my-app-assets/*',
+        'arn:aws:s3:::yolo-testing-my-app-artefacts/*',
+    ]);
+
+    $buckets = statementFor($document, 's3:ListBucket');
+    expect($buckets['Resource'])->toBe([
+        'arn:aws:s3:::yolo-testing-my-app-assets',
+        'arn:aws:s3:::yolo-testing-my-app-artefacts',
+    ]);
+});
+
+it('omits Route 53 permissions for a headless app with no domain', function () {
+    $document = (new DeployerPolicy())->document();
+
+    $actions = collect($document['Statement'])->flatMap(fn (array $statement) => (array) $statement['Action']);
+
+    expect($actions)->not->toContain('route53:ChangeResourceRecordSets');
+});
+
+it('scopes Route 53 record changes to the resolved hosted zone when a domain is set', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+    ]);
+
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/Z123ABC'],
+    ]);
+
+    $document = (new DeployerPolicy())->document();
+
+    expect(statementFor($document, 'route53:ListHostedZones')['Resource'])->toBe('*');
+    expect(statementFor($document, 'route53:ChangeResourceRecordSets')['Resource'])
+        ->toBe('arn:aws:route53:::hostedzone/Z123ABC');
+    expect(statementFor($document, 'route53:GetChange')['Resource'])
+        ->toBe('arn:aws:route53:::change/*');
+});

--- a/tests/Unit/Resources/Iam/DeployerRoleTest.php
+++ b/tests/Unit/Resources/Iam/DeployerRoleTest.php
@@ -1,6 +1,14 @@
 <?php
 
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+
+// The suite itself runs inside GitHub Actions (GITHUB_REPOSITORY set), so clear
+// it after each test to keep the inference tests deterministic.
+afterEach(function () {
+    putenv('GITHUB_REPOSITORY');
+    unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
+});
 
 it('names the deployer role shared per environment', function () {
     writeManifest([
@@ -47,4 +55,35 @@ it('defaults the branch to main when the manifest omits it', function () {
 
     expect($subject['token.actions.githubusercontent.com:sub'])
         ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
+});
+
+it('infers the repository from GITHUB_REPOSITORY when the manifest omits it', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => true,
+    ]);
+
+    putenv('GITHUB_REPOSITORY=codinglabsau/codinglabs');
+    $_ENV['GITHUB_REPOSITORY'] = $_SERVER['GITHUB_REPOSITORY'] = 'codinglabsau/codinglabs';
+
+    $subject = (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike'];
+
+    expect($subject['token.actions.githubusercontent.com:sub'])
+        ->toBe('repo:codinglabsau/codinglabs:ref:refs/heads/main');
+});
+
+it('throws when the repository cannot be inferred and is not set', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => true,
+    ]);
+
+    // No GITHUB_REPOSITORY and the temp manifest dir is not a git checkout, so
+    // there's no origin to parse — the trust policy must fail loudly, never
+    // silently build with a missing repo.
+    putenv('GITHUB_REPOSITORY');
+    unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
+
+    expect(fn () => (new DeployerRole())->assumeRolePolicyDocument())
+        ->toThrow(IntegrityCheckException::class);
 });

--- a/tests/Unit/Resources/Iam/DeployerRoleTest.php
+++ b/tests/Unit/Resources/Iam/DeployerRoleTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Codinglabs\Yolo\Resources\Iam\DeployerRole;
+
+it('names the deployer role shared per environment', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+    ]);
+
+    expect((new DeployerRole())->name())->toBe('yolo-testing-deployer');
+});
+
+it('federates to the GitHub OIDC provider scoped to the repo and branch', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo', 'branch' => 'release'],
+    ]);
+
+    expect((new DeployerRole())->assumeRolePolicyDocument())->toBe([
+        'Version' => '2012-10-17',
+        'Statement' => [
+            [
+                'Effect' => 'Allow',
+                'Principal' => ['Federated' => 'arn:aws:iam::111111111111:oidc-provider/token.actions.githubusercontent.com'],
+                'Action' => 'sts:AssumeRoleWithWebIdentity',
+                'Condition' => [
+                    'StringEquals' => [
+                        'token.actions.githubusercontent.com:aud' => 'sts.amazonaws.com',
+                    ],
+                    'StringLike' => [
+                        'token.actions.githubusercontent.com:sub' => 'repo:my-org/my-repo:ref:refs/heads/release',
+                    ],
+                ],
+            ],
+        ],
+    ]);
+});
+
+it('defaults the branch to main when the manifest omits it', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+    ]);
+
+    $subject = (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike'];
+
+    expect($subject['token.actions.githubusercontent.com:sub'])
+        ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
+});

--- a/tests/Unit/Resources/Iam/DeployerRoleTest.php
+++ b/tests/Unit/Resources/Iam/DeployerRoleTest.php
@@ -3,27 +3,38 @@
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
-// The suite itself runs inside GitHub Actions (GITHUB_REPOSITORY set), so clear
-// it after each test to keep the inference tests deterministic.
+// The suite runs inside GitHub Actions (GITHUB_REPOSITORY set). Most tests pin
+// the repo via an explicit env-level `repository` so inference is deterministic;
+// clear GITHUB_REPOSITORY after each test so the env / unresolvable cases are too.
 afterEach(function () {
     putenv('GITHUB_REPOSITORY');
     unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
 });
 
-it('names the deployer role shared per environment', function () {
+function deployerManifest(array $environment = []): void
+{
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
+        'repository' => 'my-org/my-repo',
+        ...$environment,
     ]);
+}
 
-    expect((new DeployerRole())->name())->toBe('yolo-testing-deployer');
+function deployerSubjectFor(array $environment): string
+{
+    deployerManifest($environment);
+
+    return (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike']['token.actions.githubusercontent.com:sub'];
+}
+
+it('names the deployer role per app and environment', function () {
+    deployerManifest();
+
+    expect((new DeployerRole())->name())->toBe('yolo-testing-my-app-deployer');
 });
 
 it('federates to the GitHub OIDC provider scoped to the repo and branch', function () {
-    writeManifest([
-        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo', 'branch' => 'release'],
-    ]);
+    deployerManifest(['branch' => 'release']);
 
     expect((new DeployerRole())->assumeRolePolicyDocument())->toBe([
         'Version' => '2012-10-17',
@@ -45,57 +56,30 @@ it('federates to the GitHub OIDC provider scoped to the repo and branch', functi
     ]);
 });
 
-it('defaults the branch to main when the manifest omits it', function () {
-    writeManifest([
-        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
-    ]);
-
-    $subject = (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike'];
-
-    expect($subject['token.actions.githubusercontent.com:sub'])
-        ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
-});
-
-function subjectClaimFor(array $deployer): string
-{
-    writeManifest([
-        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo', ...$deployer],
-    ]);
-
-    return (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike']['token.actions.githubusercontent.com:sub'];
-}
-
-it('scopes the trust to a tag pattern (production)', function () {
-    expect(subjectClaimFor(['tag' => 'v*']))
-        ->toBe('repo:my-org/my-repo:ref:refs/tags/v*');
-});
-
-it('treats tag: true as any tag', function () {
-    expect(subjectClaimFor(['tag' => true]))
-        ->toBe('repo:my-org/my-repo:ref:refs/tags/*');
-});
-
-it('scopes the trust to a GitHub environment', function () {
-    expect(subjectClaimFor(['environment' => 'production']))
-        ->toBe('repo:my-org/my-repo:environment:production');
+it('defaults to the main branch when no ref is set', function () {
+    expect(deployerSubjectFor([]))->toBe('repo:my-org/my-repo:ref:refs/heads/main');
 });
 
 it('scopes the trust to a branch (staging)', function () {
-    expect(subjectClaimFor(['branch' => 'main']))
-        ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
+    expect(deployerSubjectFor(['branch' => 'develop']))->toBe('repo:my-org/my-repo:ref:refs/heads/develop');
 });
 
-it('throws when more than one trust trigger is set', function () {
-    expect(fn () => subjectClaimFor(['branch' => 'main', 'tag' => 'v*']))
+it('scopes the trust to a tag pattern (production)', function () {
+    expect(deployerSubjectFor(['tag' => 'v*']))->toBe('repo:my-org/my-repo:ref:refs/tags/v*');
+});
+
+it('treats tag: true as any tag', function () {
+    expect(deployerSubjectFor(['tag' => true]))->toBe('repo:my-org/my-repo:ref:refs/tags/*');
+});
+
+it('throws when both a branch and a tag are set', function () {
+    expect(fn () => deployerSubjectFor(['branch' => 'main', 'tag' => 'v*']))
         ->toThrow(IntegrityCheckException::class);
 });
 
 it('infers the repository from GITHUB_REPOSITORY when the manifest omits it', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => true,
     ]);
 
     putenv('GITHUB_REPOSITORY=codinglabsau/codinglabs');
@@ -107,15 +91,13 @@ it('infers the repository from GITHUB_REPOSITORY when the manifest omits it', fu
         ->toBe('repo:codinglabsau/codinglabs:ref:refs/heads/main');
 });
 
-it('throws when the repository cannot be inferred and is not set', function () {
+it('throws when the repository cannot be resolved', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => true,
     ]);
 
-    // No GITHUB_REPOSITORY and the temp manifest dir is not a git checkout, so
-    // there's no origin to parse — the trust policy must fail loudly, never
-    // silently build with a missing repo.
+    // No manifest repository, no GITHUB_REPOSITORY, and the temp manifest dir is
+    // not a git checkout — the trust must fail loudly, never build with a blank repo.
     putenv('GITHUB_REPOSITORY');
     unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
 

--- a/tests/Unit/Resources/Iam/DeployerRoleTest.php
+++ b/tests/Unit/Resources/Iam/DeployerRoleTest.php
@@ -57,6 +57,41 @@ it('defaults the branch to main when the manifest omits it', function () {
         ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
 });
 
+function subjectClaimFor(array $deployer): string
+{
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo', ...$deployer],
+    ]);
+
+    return (new DeployerRole())->assumeRolePolicyDocument()['Statement'][0]['Condition']['StringLike']['token.actions.githubusercontent.com:sub'];
+}
+
+it('scopes the trust to a tag pattern (production)', function () {
+    expect(subjectClaimFor(['tag' => 'v*']))
+        ->toBe('repo:my-org/my-repo:ref:refs/tags/v*');
+});
+
+it('treats tag: true as any tag', function () {
+    expect(subjectClaimFor(['tag' => true]))
+        ->toBe('repo:my-org/my-repo:ref:refs/tags/*');
+});
+
+it('scopes the trust to a GitHub environment', function () {
+    expect(subjectClaimFor(['environment' => 'production']))
+        ->toBe('repo:my-org/my-repo:environment:production');
+});
+
+it('scopes the trust to a branch (staging)', function () {
+    expect(subjectClaimFor(['branch' => 'main']))
+        ->toBe('repo:my-org/my-repo:ref:refs/heads/main');
+});
+
+it('throws when more than one trust trigger is set', function () {
+    expect(fn () => subjectClaimFor(['branch' => 'main', 'tag' => 'v*']))
+        ->toThrow(IntegrityCheckException::class);
+});
+
 it('infers the repository from GITHUB_REPOSITORY when the manifest omits it', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],

--- a/tests/Unit/Resources/Iam/GithubOidcProviderTest.php
+++ b/tests/Unit/Resources/Iam/GithubOidcProviderTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Resources\Iam\GithubOidcProvider;
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+});
+
+it('derives the provider ARN from the account id and the GitHub URL', function () {
+    expect((new GithubOidcProvider())->arn())
+        ->toBe('arn:aws:iam::111111111111:oidc-provider/token.actions.githubusercontent.com');
+});
+
+it('creates the provider with the sts audience and pinned thumbprints', function () {
+    $captured = [];
+
+    bindRoutedIamClient([], $captured);
+
+    (new GithubOidcProvider())->create();
+
+    $create = collect($captured)->firstWhere('name', 'CreateOpenIDConnectProvider');
+
+    expect($create)->not->toBeNull();
+    expect($create['args']['Url'])->toBe('https://token.actions.githubusercontent.com');
+    expect($create['args']['ClientIDList'])->toBe(['sts.amazonaws.com']);
+    expect($create['args']['ThumbprintList'])->toBe(GithubOidcProvider::THUMBPRINTS);
+
+    // Shared account singleton — Name tag only, never a yolo:environment tag.
+    expect($create['args']['Tags'])->toBe([
+        ['Key' => 'Name', 'Value' => 'token.actions.githubusercontent.com'],
+    ]);
+});
+
+it('reports the provider as existing when the ARN is in the account list', function () {
+    $captured = [];
+
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result([
+            'OpenIDConnectProviderList' => [
+                ['Arn' => 'arn:aws:iam::111111111111:oidc-provider/token.actions.githubusercontent.com'],
+            ],
+        ]),
+    ], $captured);
+
+    expect((new GithubOidcProvider())->exists())->toBeTrue();
+});
+
+it('reports the provider as absent when the list is empty', function () {
+    $captured = [];
+
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => []]),
+    ], $captured);
+
+    expect((new GithubOidcProvider())->exists())->toBeFalse();
+});

--- a/tests/Unit/Resources/Iam/IamDescriptionsAreSafeTest.php
+++ b/tests/Unit/Resources/Iam/IamDescriptionsAreSafeTest.php
@@ -1,7 +1,9 @@
 <?php
 
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
+use Codinglabs\Yolo\Resources\Iam\DeployerRole;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskPolicy;
+use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
 use Codinglabs\Yolo\Resources\Iam\EcsExecutionRole;
 use Codinglabs\Yolo\Steps\Iam\SyncMediaConvertRoleStep;
 
@@ -31,6 +33,14 @@ it('EcsExecutionRole description is safe for the IAM API', function () {
 
 it('SyncMediaConvertRoleStep description is safe for the IAM API', function () {
     expect(SyncMediaConvertRoleStep::DESCRIPTION)->toMatch(IAM_DESCRIPTION_PATTERN);
+});
+
+it('DeployerRole description is safe for the IAM API', function () {
+    expect((new DeployerRole())->description())->toMatch(IAM_DESCRIPTION_PATTERN);
+});
+
+it('DeployerPolicy description is safe for the IAM API', function () {
+    expect((new DeployerPolicy())->description())->toMatch(IAM_DESCRIPTION_PATTERN);
 });
 
 it('rejects an em dash so the regex actually catches the original bug', function () {

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -8,42 +8,56 @@ use Codinglabs\Yolo\Steps\Iam\SyncDeployerPolicyStep;
 use Codinglabs\Yolo\Steps\Iam\SyncGithubOidcProviderStep;
 use Codinglabs\Yolo\Steps\Iam\AttachDeployerRolePoliciesStep;
 
-/** An existing deployer policy the mock can return from ListPolicies. */
+// The suite runs in GitHub Actions (GITHUB_REPOSITORY set). Clear it after each
+// test; provisioning tests pin the repo via an explicit env-level `repository`.
+afterEach(function () {
+    putenv('GITHUB_REPOSITORY');
+    unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
+});
+
 function existingDeployerPolicy(): array
 {
     return [
-        'PolicyName' => 'yolo-testing-deployer-policy',
-        'Arn' => 'arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy',
+        'PolicyName' => 'yolo-testing-my-app-deployer-policy',
+        'Arn' => 'arn:aws:iam::111111111111:policy/yolo-testing-my-app-deployer-policy',
         'DefaultVersionId' => 'v1',
     ];
 }
 
-/** An existing deployer role the mock can return from ListRoles. */
 function existingDeployerRole(): array
 {
     return [
-        'RoleName' => 'yolo-testing-deployer',
-        'Arn' => 'arn:aws:iam::111111111111:role/yolo-testing-deployer',
+        'RoleName' => 'yolo-testing-my-app-deployer',
+        'Arn' => 'arn:aws:iam::111111111111:role/yolo-testing-my-app-deployer',
     ];
 }
 
-function manifestWithDeployer(): void
+/** A manifest with a resolvable GitHub repository — the deployer provisions. */
+function manifestWithDeployer(array $environment = []): void
 {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo'],
+        'repository' => 'my-org/my-repo',
+        ...$environment,
     ]);
 }
 
-function manifestWithoutDeployer(): void
+/**
+ * No resolvable repository — GITHUB_REPOSITORY cleared, no manifest override, and
+ * the temp dir isn't a git checkout — so the deployer steps skip.
+ */
+function manifestWithoutRepository(): void
 {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
     ]);
+
+    putenv('GITHUB_REPOSITORY');
+    unset($_ENV['GITHUB_REPOSITORY'], $_SERVER['GITHUB_REPOSITORY']);
 }
 
-it('skips every deployer step when the manifest has no deployer block', function () {
-    manifestWithoutDeployer();
+it('skips every deployer step when no GitHub repository is resolvable', function () {
+    manifestWithoutRepository();
 
     $captured = [];
     bindRoutedIamClient([], $captured);
@@ -108,7 +122,7 @@ it('creates the deployer policy when absent', function () {
 
     $create = collect($captured)->firstWhere('name', 'CreatePolicy');
     expect($create)->not->toBeNull();
-    expect($create['args']['PolicyName'])->toBe('yolo-testing-deployer-policy');
+    expect($create['args']['PolicyName'])->toBe('yolo-testing-my-app-deployer-policy');
 });
 
 it('creates the deployer role with the OIDC trust policy when absent', function () {
@@ -123,7 +137,7 @@ it('creates the deployer role with the OIDC trust policy when absent', function 
 
     $create = collect($captured)->firstWhere('name', 'CreateRole');
     expect($create)->not->toBeNull();
-    expect($create['args']['RoleName'])->toBe('yolo-testing-deployer');
+    expect($create['args']['RoleName'])->toBe('yolo-testing-my-app-deployer');
     expect($create['args']['AssumeRolePolicyDocument'])->toContain('sts:AssumeRoleWithWebIdentity');
 });
 
@@ -142,19 +156,14 @@ it('attaches the deployer policy to the deployer role', function () {
 
     $captured = [];
     bindRoutedIamClient([
-        'ListPolicies' => new Result(['Policies' => [
-            [
-                'PolicyName' => 'yolo-testing-deployer-policy',
-                'Arn' => 'arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy',
-            ],
-        ]]),
+        'ListPolicies' => new Result(['Policies' => [existingDeployerPolicy()]]),
     ], $captured);
 
     expect((new AttachDeployerRolePoliciesStep())([]))->toBe(StepResult::SYNCED);
 
     $attach = collect($captured)->firstWhere('name', 'AttachRolePolicy');
-    expect($attach['args']['RoleName'])->toBe('yolo-testing-deployer');
-    expect($attach['args']['PolicyArn'])->toBe('arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy');
+    expect($attach['args']['RoleName'])->toBe('yolo-testing-my-app-deployer');
+    expect($attach['args']['PolicyArn'])->toBe('arn:aws:iam::111111111111:policy/yolo-testing-my-app-deployer-policy');
 });
 
 it('does not create a new policy version when the deployer document is unchanged', function () {
@@ -189,11 +198,8 @@ it('reconciles the deployer policy by creating a new default version when it dri
     expect($version['args']['SetAsDefault'])->toBeTrue();
 });
 
-it('reconciles the deployer role trust policy when the manifest branch changes', function () {
-    writeManifest([
-        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
-        'deployer' => ['repository' => 'my-org/my-repo', 'branch' => 'release'],
-    ]);
+it('reconciles the deployer role trust policy when the env ref changes', function () {
+    manifestWithDeployer(['branch' => 'release']);
 
     $captured = [];
     bindRoutedIamClient([

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Iam\SyncDeployerRoleStep;
+use Codinglabs\Yolo\Steps\Iam\SyncDeployerPolicyStep;
+use Codinglabs\Yolo\Steps\Iam\SyncGithubOidcProviderStep;
+use Codinglabs\Yolo\Steps\Iam\AttachDeployerRolePoliciesStep;
+
+function manifestWithDeployer(): void
+{
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo'],
+    ]);
+}
+
+function manifestWithoutDeployer(): void
+{
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+}
+
+it('skips every deployer step when the manifest has no deployer block', function () {
+    manifestWithoutDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([], $captured);
+
+    expect((new SyncGithubOidcProviderStep())([]))->toBe(StepResult::SKIPPED);
+    expect((new SyncDeployerPolicyStep())([]))->toBe(StepResult::SKIPPED);
+    expect((new SyncDeployerRoleStep())([]))->toBe(StepResult::SKIPPED);
+    expect((new AttachDeployerRolePoliciesStep())([]))->toBe(StepResult::SKIPPED);
+
+    expect($captured)->toBeEmpty();
+});
+
+it('creates the OIDC provider when absent', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => []]),
+    ], $captured);
+
+    expect((new SyncGithubOidcProviderStep())([]))->toBe(StepResult::CREATED);
+    expect(array_column($captured, 'name'))->toContain('CreateOpenIDConnectProvider');
+});
+
+it('reports the OIDC provider as synced when it already exists', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result([
+            'OpenIDConnectProviderList' => [
+                ['Arn' => 'arn:aws:iam::111111111111:oidc-provider/token.actions.githubusercontent.com'],
+            ],
+        ]),
+    ], $captured);
+
+    expect((new SyncGithubOidcProviderStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('CreateOpenIDConnectProvider');
+});
+
+it('would-create the OIDC provider on a dry-run without calling create', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => []]),
+    ], $captured);
+
+    expect((new SyncGithubOidcProviderStep())(['dry-run' => true]))->toBe(StepResult::WOULD_CREATE);
+    expect(array_column($captured, 'name'))->not->toContain('CreateOpenIDConnectProvider');
+});
+
+it('creates the deployer policy when absent', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => []]),
+    ], $captured);
+
+    expect((new SyncDeployerPolicyStep())([]))->toBe(StepResult::CREATED);
+
+    $create = collect($captured)->firstWhere('name', 'CreatePolicy');
+    expect($create)->not->toBeNull();
+    expect($create['args']['PolicyName'])->toBe('yolo-testing-deployer-policy');
+});
+
+it('creates the deployer role with the OIDC trust policy when absent', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListRoles' => new Result(['Roles' => []]),
+    ], $captured);
+
+    expect((new SyncDeployerRoleStep())([]))->toBe(StepResult::CREATED);
+
+    $create = collect($captured)->firstWhere('name', 'CreateRole');
+    expect($create)->not->toBeNull();
+    expect($create['args']['RoleName'])->toBe('yolo-testing-deployer');
+    expect($create['args']['AssumeRolePolicyDocument'])->toContain('sts:AssumeRoleWithWebIdentity');
+});
+
+it('would-sync the policy attachment on a dry-run', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([], $captured);
+
+    expect((new AttachDeployerRolePoliciesStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($captured)->toBeEmpty();
+});
+
+it('attaches the deployer policy to the deployer role', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => [
+            [
+                'PolicyName' => 'yolo-testing-deployer-policy',
+                'Arn' => 'arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy',
+            ],
+        ]]),
+    ], $captured);
+
+    expect((new AttachDeployerRolePoliciesStep())([]))->toBe(StepResult::SYNCED);
+
+    $attach = collect($captured)->firstWhere('name', 'AttachRolePolicy');
+    expect($attach['args']['RoleName'])->toBe('yolo-testing-deployer');
+    expect($attach['args']['PolicyArn'])->toBe('arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy');
+});

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -2,10 +2,30 @@
 
 use Aws\Result;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
 use Codinglabs\Yolo\Steps\Iam\SyncDeployerRoleStep;
 use Codinglabs\Yolo\Steps\Iam\SyncDeployerPolicyStep;
 use Codinglabs\Yolo\Steps\Iam\SyncGithubOidcProviderStep;
 use Codinglabs\Yolo\Steps\Iam\AttachDeployerRolePoliciesStep;
+
+/** An existing deployer policy the mock can return from ListPolicies. */
+function existingDeployerPolicy(): array
+{
+    return [
+        'PolicyName' => 'yolo-testing-deployer-policy',
+        'Arn' => 'arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy',
+        'DefaultVersionId' => 'v1',
+    ];
+}
+
+/** An existing deployer role the mock can return from ListRoles. */
+function existingDeployerRole(): array
+{
+    return [
+        'RoleName' => 'yolo-testing-deployer',
+        'Arn' => 'arn:aws:iam::111111111111:role/yolo-testing-deployer',
+    ];
+}
 
 function manifestWithDeployer(): void
 {
@@ -135,4 +155,75 @@ it('attaches the deployer policy to the deployer role', function () {
     $attach = collect($captured)->firstWhere('name', 'AttachRolePolicy');
     expect($attach['args']['RoleName'])->toBe('yolo-testing-deployer');
     expect($attach['args']['PolicyArn'])->toBe('arn:aws:iam::111111111111:policy/yolo-testing-deployer-policy');
+});
+
+it('does not create a new policy version when the deployer document is unchanged', function () {
+    manifestWithDeployer();
+
+    $document = json_encode((new DeployerPolicy())->document());
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => [existingDeployerPolicy()]]),
+        'GetPolicyVersion' => new Result(['PolicyVersion' => ['Document' => rawurlencode($document)]]),
+    ], $captured);
+
+    expect((new SyncDeployerPolicyStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('CreatePolicyVersion');
+});
+
+it('reconciles the deployer policy by creating a new default version when it drifts', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => [existingDeployerPolicy()]]),
+        // A stale document that no longer matches the rendered one.
+        'GetPolicyVersion' => new Result(['PolicyVersion' => ['Document' => rawurlencode('{"Version":"2012-10-17","Statement":[]}')]]),
+    ], $captured);
+
+    expect((new SyncDeployerPolicyStep())([]))->toBe(StepResult::SYNCED);
+
+    $version = collect($captured)->firstWhere('name', 'CreatePolicyVersion');
+    expect($version)->not->toBeNull();
+    expect($version['args']['SetAsDefault'])->toBeTrue();
+});
+
+it('reconciles the deployer role trust policy when the manifest branch changes', function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+        'deployer' => ['repository' => 'my-org/my-repo', 'branch' => 'release'],
+    ]);
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListRoles' => new Result(['Roles' => [existingDeployerRole()]]),
+    ], $captured);
+
+    expect((new SyncDeployerRoleStep())([]))->toBe(StepResult::SYNCED);
+
+    $update = collect($captured)->firstWhere('name', 'UpdateAssumeRolePolicy');
+    expect($update)->not->toBeNull();
+
+    $sub = json_decode($update['args']['PolicyDocument'], true)['Statement'][0]['Condition']['StringLike']['token.actions.githubusercontent.com:sub'];
+    expect($sub)->toBe('repo:my-org/my-repo:ref:refs/heads/release');
+});
+
+it('never mutates IAM on a dry-run against existing deployer resources', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => [existingDeployerPolicy()]]),
+        'ListRoles' => new Result(['Roles' => [existingDeployerRole()]]),
+    ], $captured);
+
+    expect((new SyncDeployerPolicyStep())(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect((new SyncDeployerRoleStep())(['dry-run' => true]))->toBe(StepResult::SYNCED);
+
+    expect(array_column($captured, 'name'))
+        ->not->toContain('CreatePolicyVersion')
+        ->not->toContain('UpdateAssumeRolePolicy')
+        ->not->toContain('CreatePolicy')
+        ->not->toContain('CreateRole');
 });


### PR DESCRIPTION
## What problems are you solving?

YOLO 1.0 (Fargate) consumer apps deploy from GitHub Actions, but the only documented CI auth was long-lived IAM-user access keys in repo secrets, and the deployer's IAM policy was hand-managed outside YOLO. This PR fixes both:

1. **Kills long-lived keys** — GitHub OIDC gives short-lived assumed-role creds scoped to a single repo + ref, nothing stored. Implements [LPX-625](https://linear.app/codinglabsau/issue/LPX-625) (covers [LPX-621](https://linear.app/codinglabsau/issue/LPX-621) gaps #3/#4).
2. **Stops the deployer policy drifting** — every deploy step that hits a new AWS API needs a matching deployer permission; co-locating the policy with the steps means a YOLO upgrade widens it on the next `sync:iam` instead of CI dying with `AccessDenied`.

### Part A — CI defers to the SDK default credential chain (detect, don't hard-code)

The CI branch of `RegistersAws::awsCredentials()` returns `null` and lets the AWS SDK default chain resolve whatever the runner provides — so **all auth methods work out of the box**: OIDC (`configure-aws-credentials` env vars, or the raw web-identity-token file), AWS IAM Identity Center (SSO), and legacy static keys (which still work but emit a **warning** nudging towards OIDC). Local `yolo deploy` is unaffected — it uses your AWS profile. The deployer role is purely additive; YOLO never assumes it (the GitHub Action does, before `yolo` runs).

Also fixes the CI preflight ([LPX-621](https://linear.app/codinglabsau/issue/LPX-621) #2): `Command::execute()` required `YOLO_<ENV>_AWS_PROFILE` whenever off-AWS, with no CI carve-out — so consumers had to set a throwaway `YOLO_PRODUCTION_AWS_PROFILE: ci` just to clear the gate. A new `requiresAwsProfile()` predicate requires a profile only when genuinely local (off AWS *and* not in CI); the account guard still STS-verifies whatever creds resolve. The dummy profile can now be dropped from consumer workflows.

### Part B — OIDC provider + deployer role in `sync:iam`

Each environment declares the **ref it deploys from** — a bare env key, not a config block. That one setting drives the deployer role's OIDC trust (and, in the follow-on, the local deploy guard). Defaults to `main`, so the common case needs no config:

```yaml
environments:
  staging:
    branch: develop           # push to develop
  production:
    tag: 'v*'                 # only a v* tag (true = any tag)
```

| Ref | OIDC `sub` | Typical use |
|---|---|---|
| `branch: main` (default) | `…:ref:refs/heads/main` | push to a branch — staging |
| `tag: 'v*'` (`true` = any) | `…:ref:refs/tags/v*` | tag push — production |

- **Auto-provisioned** when a GitHub repository is resolvable (the steps `SKIPPED` otherwise — no opt-in key). `repository` is inferred from the git origin / `GITHUB_REPOSITORY`, with an optional per-env override. A `vcs:` key is the future seam for non-GitHub.
- **App + environment specific** → `yolo-{env}-{app}-deployer`. Its trust (one repo + ref) and permissions (the app's ECR repo, buckets, cluster, service) are app-specific, so unlike the shared task/execution roles it can't be shared.
- Setting both `branch` and `tag` fails loudly (the trust subject is a security boundary).

Four steps appended to `SyncIamCommand`, mirroring the ECS task **policy → role → attach** triad (provider first — IAM validates the federated principal at role-create time):

| Step | Behaviour |
| --- | --- |
| `SyncGithubOidcProviderStep` | Idempotent `CreateOpenIDConnectProvider`, account-level singleton; exists → `SYNCED` |
| `SyncDeployerPolicyStep` | Permission policy; document drift reconciled via `createPolicyVersion` |
| `SyncDeployerRoleStep` | The role; trust reconciled on repo/ref change |
| `AttachDeployerRolePoliciesStep` | Attaches the policy |

**Trust:** `Federated` → OIDC provider ARN, `sts:AssumeRoleWithWebIdentity`, `aud StringEquals sts.amazonaws.com` + `sub StringLike` (the env's ref).

**Permission policy** — exactly the build+deploy call set, scoped tightly: ECR push on the app repo ARN (+ `GetAuthorizationToken` on `*`); `ecs:RegisterTaskDefinition`/describes on `*`, `UpdateService`/`RunTask`/`DescribeServices` scoped to this app's cluster/service/task-def ARNs; `iam:PassRole` on the task + execution role ARNs with `iam:PassedToService = ecs-tasks.amazonaws.com` (`RunTask`+`PassRole` because the deploy hooks — `migrate`, `hq:bootstrap` — run as one-off Fargate tasks); S3 on the artefacts + asset buckets; Route 53 `ChangeResourceRecordSets` on `hostedzone/*` (only when a domain is set); STS `GetCallerIdentity`; ELBv2/EC2 describes on `*`.

Bakes in the IAM `Description` ASCII constraint — `IamDescriptionsAreSafeTest` covers both new descriptions.

## Is there anything the reviewer needs to know to deploy this?

- **No impact on existing consumers** — when no GitHub repo is resolvable, all four steps `SKIPPED` (zero new API calls, verified). Adopters need `iam:Create{OpenIDConnectProvider,Role,Policy}` etc. on the operator identity running `sync:iam` (fails loudly with `AccessDenied` if missing).
- **Green-field ordering (caught + fixed in review):** the Route 53 statement scopes to `hostedzone/*` rather than resolving the zone live — resolving it during the IAM phase would couple to the hosted zone the later Solo phase creates and wedge the first `yolo sync`. `document()` is pure.
- **CI credential change** — deferring to the SDK chain is strictly more capable (now honours `AWS_SESSION_TOKEN`). Narrow edges: a self-hosted EC2 runner could reach its instance role via IMDS, and keys present only to Laravel's `.env` (not the process env) wouldn't be seen — neither applies to standard GitHub-hosted CI.
- **IAM 5-version cap** — `synchroniseDocument()` (shared pattern with `EcsTaskPolicy`) doesn't churn per-sync, but there's no version pruning; after 5 *genuine* changes the 6th `createPolicyVersion` fails. Follow-up to prune oldest versions (both policies).

### Consumer change (separate PR, codinglabs repo)

```yaml
permissions:
  id-token: write
  contents: read
steps:
  - uses: aws-actions/configure-aws-credentials@v4
    with:
      role-to-assume: arn:aws:iam::<account-id>:role/yolo-<env>-<app>-deployer
      aws-region: <region>
  - run: vendor/bin/yolo deploy <env>
```

### Not in this PR (follow-on)

The build-time **local deploy guard** (confirm when the current branch ≠ the env's ref, you're not on a matching tag, or the tree is dirty — skipped in CI/`--force`) and the **`yolo init` workflow scaffolder** (writes `deploy.yml` with the role ARN baked in). Both are deploy-command / init-command features that don't touch the role or policy.

## Testing

`vendor/bin/pest` — **262 passing**: trust-subject modes (branch/tag/`tag: true`/default/ambiguity guard), repository inference + the loud throw when unresolvable, the resolvable-repo provisioning gate, reconcile paths (`synchroniseDocument` no-op vs drift, trust reconcile, dry-run-mutates-nothing), the `parseGithubRepository` URL matrix, and the `requiresAwsProfile` gate (local vs CI vs on-AWS). Pint clean, PHPStan 0 errors. No real AWS account or DB touched — IAM/STS clients mocked.

🤖 Generated with [Claude Code](https://claude.ai/code)

