### PR TITLE
LPX-575: scaffold .dockerignore + document aws.alb in init

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -36,6 +36,7 @@ class InitCommand extends Command
         $this->gitIgnoreFilesAndDirectories();
         $this->initialiseManifest();
         $this->initialiseDockerfile();
+        $this->initialiseDockerignore();
         $this->initialiseEnv();
         $this->ensureSessionManagerPlugin();
 
@@ -70,6 +71,8 @@ class InitCommand extends Command
                 'php artisan migrate --path=database/migrations/landlord --force',
                 'php artisan tenants:artisan "migrate --path=database/migrations/tenant --database=tenant --force"',
             ]);
+
+            warning('Multi-tenant apps deploy as a single shared web service on v1 — dedicated per-tenant services are not available yet. Review the scaffolded tenants block before deploying.');
         } else {
             Manifest::put('domain', text('What is the domain?', placeholder: 'eg. codinglabs.com.au'));
 
@@ -91,6 +94,16 @@ class InitCommand extends Command
         }
 
         copy(Paths::stubs('Dockerfile.stub'), Paths::base('Dockerfile'));
+    }
+
+    protected function initialiseDockerignore(): void
+    {
+        if (file_exists(Paths::base('.dockerignore'))
+            && ! confirm('A .dockerignore already exists. Overwrite it with the YOLO default?', default: false)) {
+            return;
+        }
+
+        copy(Paths::stubs('.dockerignore.stub'), Paths::base('.dockerignore'));
     }
 
     /**

--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -71,8 +71,6 @@ class InitCommand extends Command
                 'php artisan migrate --path=database/migrations/landlord --force',
                 'php artisan tenants:artisan "migrate --path=database/migrations/tenant --database=tenant --force"',
             ]);
-
-            warning('Multi-tenant apps deploy as a single shared web service on v1 — dedicated per-tenant services are not available yet. Review the scaffolded tenants block before deploying.');
         } else {
             Manifest::put('domain', text('What is the domain?', placeholder: 'eg. codinglabs.com.au'));
 

--- a/stubs/.dockerignore.stub
+++ b/stubs/.dockerignore.stub
@@ -1,0 +1,46 @@
+# Scaffolded by `yolo init`. Trims the Docker build context for a direct
+# `docker build` and as belt-and-braces inside the yolo build pipeline.
+#
+# Do NOT ignore these — the image depends on them being in the context:
+#   .env                  the environment's .env, baked in at build time
+#   vendor                installed by the build hook, not by the Dockerfile
+#   public/build          compiled Vite assets
+#   docker/               generated supervisord.conf
+#   .yolo-entrypoint.sh   generated deploy-all entrypoint
+
+# VCS & CI
+.git
+.github
+.gitattributes
+.gitignore
+
+# YOLO working directory
+.yolo
+
+# Dependencies reinstalled during the build
+node_modules
+
+# Editor & OS cruft
+.idea
+.vscode
+**/.DS_Store
+
+# Tests & tooling caches
+tests
+.phpunit.cache
+.phpunit.result.cache
+.php-cs-fixer.cache
+.pest
+
+# Laravel runtime & dev artefacts (directories kept, contents dropped)
+public/hot
+storage/app/*
+storage/debugbar
+storage/framework/cache/*
+storage/framework/sessions/*
+storage/framework/testing/*
+storage/framework/views/*
+storage/logs/*.log
+
+# Per-environment env files — the canonical `.env` above is kept
+.env.*

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -19,6 +19,7 @@ environments:
       account-id: {AWS_ACCOUNT_ID}
       region: {AWS_REGION}
       # bucket: my-app-bucket   # optional app S3 bucket, injected as AWS_BUCKET
+      # alb: my-shared-alb      # optional ALB name to adopt/create; defaults to a per-env shared yolo-{env} ALB
 
     tasks:
       web:

--- a/tests/Unit/Commands/InitCommandTest.php
+++ b/tests/Unit/Commands/InitCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Commands\InitCommand;
+
+function dockerignorePatterns(): array
+{
+    return collect(explode("\n", file_get_contents(Paths::stubs('.dockerignore.stub'))))
+        ->map(fn ($line) => trim($line))
+        ->reject(fn ($line) => $line === '' || str_starts_with($line, '#'))
+        ->values()
+        ->all();
+}
+
+it('ships a .dockerignore stub that trims the obvious noise', function () {
+    expect(dockerignorePatterns())->toContain('node_modules', '.git', 'tests', '.env.*');
+});
+
+it('never ignores what the image is built from', function () {
+    // These live in the build context and the Dockerfile depends on them —
+    // ignoring any would silently break the deploy.
+    expect(dockerignorePatterns())->not->toContain('.env', 'vendor', 'public/build', 'docker', '.yolo-entrypoint.sh');
+});
+
+it('scaffolds a .dockerignore when none exists', function () {
+    $path = Paths::base('.dockerignore');
+
+    (function () {
+        $this->initialiseDockerignore();
+    })->call(new InitCommand());
+
+    expect(file_exists($path))->toBeTrue()
+        ->and(file_get_contents($path))->toBe(file_get_contents(Paths::stubs('.dockerignore.stub')));
+})->after(fn () => @unlink(Paths::base('.dockerignore')));


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Closes the remaining work on [LPX-575](https://linear.app/codinglabsau/issue/LPX-575) (`init` command).

**What problems are you solving?**
- `yolo init` scaffolded a `Dockerfile` but no `.dockerignore`, so a direct `docker build` baked `.git`, `node_modules`, `tests`, IDE dirs and local env files into the image. Adds a `stubs/.dockerignore.stub` and writes it during `init` (mirrors `initialiseDockerfile()`, with the same overwrite prompt).
- Documents the optional `aws.alb` key in `yolo.yml.stub` as a commented example, completing the issue's "add `alb:`" bullet.

**Out of scope / decisions:**
- The issue's first bullet (update `stubs/yolo.yml.stub` to v1) was already done on `main` — the stub has `tasks:` and dropped the alpha `autoscaling`/`codedeploy`/`php`/`nginx`/`supervisor` keys.
- `aws.alb` is a real, consumed manifest key (`Resources/Fargate/LoadBalancer.php`, `UsesElasticLoadBalancingV2.php`) — optional, defaulting to the auto-named per-env shared `yolo-{env}` ALB. Added as a commented stub line rather than an active key, matching the existing `# bucket:` pattern.

**Is there anything the reviewer needs to know to deploy this?**
- The `.dockerignore` stub **deliberately keeps** `.env`, `vendor`, `public/build`, `docker/` and `.yolo-entrypoint.sh`. The build hooks run `composer install` / `npm run build` in the build dir and `RestoreTemporaryEnvStep` renames `.env.{env}` → `.env` *before* `docker build`; the Dockerfile only `COPY`s. Ignoring any of those would silently ship a broken image. A test (`tests/Unit/Commands/InitCommandTest.php`) guards this so it can't regress.
- No effect on existing deploys — `init` is a scaffolding-only command.
- 266 Pest pass, Pint + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.ai/code)