### PR TITLE
LPX-580: rename ECS Exec command from `command` to `run`

### DIFF
--- a/src/Commands/InitCommand.php
+++ b/src/Commands/InitCommand.php
@@ -94,7 +94,7 @@ class InitCommand extends Command
     }
 
     /**
-     * `yolo command` opens a shell / runs one-off commands in a running container
+     * `yolo run` opens a shell / runs one-off commands in a running container
      * via ECS Exec, which needs AWS's Session Manager plugin on this machine.
      * Offer to install it at setup so it's there before it's needed. (A future
      * `yolo doctor` will report its status alongside Docker / the AWS CLI.)
@@ -107,7 +107,7 @@ class InitCommand extends Command
             return;
         }
 
-        note("The AWS Session Manager plugin isn't installed — `yolo command` needs it to open a shell or run one-off commands in a running container.");
+        note("The AWS Session Manager plugin isn't installed — `yolo run` needs it to open a shell or run one-off commands in a running container.");
 
         if (PHP_OS_FAMILY === 'Darwin' && $this->input->isInteractive() && (new ExecutableFinder())->find('brew')) {
             if (confirm('Install it now with Homebrew? (you may be prompted for your password)', default: true)) {
@@ -120,7 +120,7 @@ class InitCommand extends Command
             }
         }
 
-        warning('Install it before using `yolo command`: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html');
+        warning('Install it before using `yolo run`: https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html');
     }
 
     protected function gitIgnoreFilesAndDirectories(): void

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -15,7 +15,7 @@ use function Laravel\Prompts\note;
 use function Laravel\Prompts\error;
 use function Laravel\Prompts\warning;
 
-class CommandCommand extends Command
+class RunCommand extends Command
 {
     // Today every process runs in the single web container; when queue/scheduler
     // become their own services this becomes per-group.
@@ -24,7 +24,7 @@ class CommandCommand extends Command
     protected function configure(): void
     {
         $this
-            ->setName('command')
+            ->setName('run')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('command', null, InputOption::VALUE_REQUIRED, 'Run a one-off command instead of opening an interactive shell')
             ->addOption('group', null, InputOption::VALUE_REQUIRED, 'Comma-separated task groups to fan the command out across (e.g. web,queue)')
@@ -34,7 +34,7 @@ class CommandCommand extends Command
     public function handle(): int
     {
         if (! (new ExecutableFinder())->find('session-manager-plugin')) {
-            error("session-manager-plugin isn't installed — run `yolo init` (or see the AWS docs) before using `yolo command`.");
+            error("session-manager-plugin isn't installed — run `yolo init` (or see the AWS docs) before using `yolo run`.");
 
             return self::FAILURE;
         }
@@ -43,10 +43,11 @@ class CommandCommand extends Command
         $command = $this->option('command');
 
         // An explicit --group fans out across every listed group; the default is
-        // an ordered fallback — the scheduler, dropping to web where it lives today.
+        // an ordered fallback — scheduler → queue → web. All three collapse into
+        // the web container today, so the first two lookups just fall through.
         $groups = ($group = $this->option('group'))
             ? array_map('trim', explode(',', $group))
-            : ['scheduler', 'web'];
+            : ['scheduler', 'queue', 'web'];
 
         $fanOut = (bool) $group;
 

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -23,7 +23,7 @@ class Yolo
         Commands\DeployCommand::class,
 
         // Exec
-        Commands\CommandCommand::class,
+        Commands\RunCommand::class,
 
         // Sync
         Commands\SyncCommand::class,

--- a/tests/Unit/Commands/RunCommandTest.php
+++ b/tests/Unit/Commands/RunCommandTest.php
@@ -1,9 +1,9 @@
 <?php
 
-use Codinglabs\Yolo\Commands\CommandCommand;
+use Codinglabs\Yolo\Commands\RunCommand;
 
 it('builds the execute-command invocation with a profile', function () {
-    $args = CommandCommand::executeCommandArgs(
+    $args = RunCommand::executeCommandArgs(
         cluster: 'yolo-production-codinglabs',
         task: 'arn:aws:ecs:ap-southeast-2:111:task/abc',
         command: '/bin/sh',
@@ -24,7 +24,7 @@ it('builds the execute-command invocation with a profile', function () {
 });
 
 it('omits --profile when none is configured (e.g. running on AWS)', function () {
-    $args = CommandCommand::executeCommandArgs(
+    $args = RunCommand::executeCommandArgs(
         cluster: 'yolo-production-codinglabs',
         task: 'task-arn',
         command: 'php artisan migrate --force',


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- The ECS Exec wrapper (interactive shell + one-off commands on a running Fargate task) shipped earlier under the name `command`. [LPX-580](https://linear.app/codinglabsau/issue/LPX-580) specced it as `run` — this reconciles the command with the agreed final API and lets the issue close.
- Renames `command` → `run` (class `CommandCommand` → `RunCommand`, both files via `git mv` to keep history) and updates the `yolo init` session-manager-plugin prompts that referenced `yolo command`.
- Restores `queue` to the default fallback chain: `scheduler → queue → web` (was `scheduler → web`). All three collapse into the web container today, so the first two lookups simply fall through — this is forward-compat for when queue/scheduler become their own services.

**Is there anything the reviewer needs to know to deploy this?**
- Pure CLI-surface change — no AWS calls, no runtime behaviour change beyond the command name. The `aws ecs execute-command` invocation builder is untouched.
- `--detached` (a `RunTask` one-off) was considered and **explicitly dropped** as out of scope: migrations already run detached via deploy hooks, ad-hoc long backfills are rare, and `nohup`/`setsid` inside an exec session covers laptop-drop resilience. Easy to bolt on later if a real need surfaces.
- Final surface: `yolo run <env>` (shell), `yolo run <env> --command="…"` (one-off), `yolo run <env> --group=web,queue --command="…"` (fan-out).
- Verified: pint clean, phpstan clean, 265 tests pass.

🤖 Generated with [Claude Code](https://claude.ai/code)