### PR TITLE
LPX-581 follow-up: marker-driven yolo:app + audit de-noise

### DIFF
--- a/src/Audit/Audit.php
+++ b/src/Audit/Audit.php
@@ -26,6 +26,18 @@ class Audit
     public const STATUS_UNATTRIBUTED = 'unattributed';
 
     /**
+     * Deploy ephemera the audit ignores: ECS task definitions (immutable
+     * revisions pile up on every deploy and old ones can never be re-tagged) and
+     * tasks (ephemeral runtime). They're versioned/runtime artefacts, not standing
+     * infrastructure you'd leave behind, so auditing them is pure noise.
+     *
+     * @var array<string, array<int, string>>
+     */
+    private const IGNORED_TYPES = [
+        'ecs' => ['task-definition', 'task'],
+    ];
+
+    /**
      * App names that have a live ECS cluster for this environment, derived from
      * cluster ARNs by the yolo-{env}-{app} naming convention. The bare yolo-{env}
      * cluster (none exists, but defensively) and non-YOLO clusters are ignored.
@@ -61,6 +73,7 @@ class Audit
     public static function classify(array $taggedResources, array $liveApps): array
     {
         $resources = collect($taggedResources)
+            ->reject(fn (array $resource) => static::isIgnored(Arn::parse($resource['ResourceARN'])))
             ->map(function (array $resource) use ($liveApps) {
                 $tags = Aws::flattenTags($resource['Tags'] ?? []);
                 $app = $tags[self::APP_TAG] ?? null;
@@ -95,6 +108,11 @@ class Audit
      * segment when there is one (e.g. ecs/service, elasticloadbalancing/targetgroup,
      * s3). Display only; no behaviour keys off it.
      */
+    protected static function isIgnored(?Arn $arn): bool
+    {
+        return $arn !== null && in_array($arn->resourceType, self::IGNORED_TYPES[$arn->service] ?? [], true);
+    }
+
     protected static function type(?Arn $arn): string
     {
         if ($arn === null) {

--- a/src/Resources/AppScoped.php
+++ b/src/Resources/AppScoped.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources;
+
+/**
+ * Marker for a resource that belongs to a single application (the exclusive,
+ * per-app resources — not shared infrastructure). Tagging inspects this marker
+ * to stamp the `yolo:app` owner tag, which is what lets `yolo audit` attribute a
+ * resource to its app and flag drift. Declare it and ResolvesTags does the rest
+ * — there's no per-resource tag to remember.
+ */
+interface AppScoped {}

--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -8,6 +8,8 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\CloudFront;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\Storage\AssetBucket;
 use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -24,8 +26,10 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * own `/builds` route. The keyed name is stamped into the distribution's
  * Comment (and the OAC's Name) for lookup, and surfaced as the `Name` tag.
  */
-class AssetDistribution implements Resource, SynchronisesConfiguration
+class AssetDistribution implements AppScoped, Resource, SynchronisesConfiguration
 {
+    use ResolvesTags;
+
     protected const ORIGIN_ID = 'asset-bucket';
 
     // Custom cache policy: like CachingOptimized but with `Origin` in the cache
@@ -52,11 +56,6 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
     public function name(): string
     {
         return Helpers::keyedResourceName('assets', exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/EcrRepository.php
+++ b/src/Resources/Fargate/EcrRepository.php
@@ -7,18 +7,17 @@ use Codinglabs\Yolo\Aws\Ecr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class EcrRepository implements Resource
+class EcrRepository implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Manifest::name();
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/EcsCluster.php
+++ b/src/Resources/Fargate/EcsCluster.php
@@ -7,18 +7,17 @@ use Codinglabs\Yolo\Aws\Ecs;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class EcsCluster implements Resource
+class EcsCluster implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Manifest::get('ecs.cluster', Helpers::keyedResourceName(exclusive: true));
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/EcsService.php
+++ b/src/Resources/Fargate/EcsService.php
@@ -8,20 +8,19 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class EcsService implements Resource
+class EcsService implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     protected const INITIAL_DESIRED_COUNT = 1;
 
     public function name(): string
     {
         return Helpers::keyedResourceName('web', exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/EcsTaskSecurityGroup.php
+++ b/src/Resources/Fargate/EcsTaskSecurityGroup.php
@@ -9,6 +9,8 @@ use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Enums\SecurityGroup;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -16,19 +18,16 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * (the load-balancer-to-task port-allow rule) lives in SyncTaskSecurityGroupStep
  * because it's a separate AWS concept with its own reconciliation surface.
  */
-class EcsTaskSecurityGroup implements Resource
+class EcsTaskSecurityGroup implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Manifest::get(
             'aws.ecs.security-group',
             Helpers::keyedResourceName(SecurityGroup::ECS_TASK_SECURITY_GROUP, exclusive: true),
         );
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/ListenerRule.php
+++ b/src/Resources/Fargate/ListenerRule.php
@@ -7,6 +7,8 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
 /**
@@ -15,8 +17,10 @@ use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
  * priority via a CRC32 hash of the rule's name so the same app lands on the same
  * priority across re-creates.
  */
-class ListenerRule implements Resource
+class ListenerRule implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     protected ?array $cachedRule = null;
 
     public function __construct(protected string $httpsListenerArn) {}
@@ -24,11 +28,6 @@ class ListenerRule implements Resource
     public function name(): string
     {
         return Helpers::keyedResourceName(exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/TargetGroup.php
+++ b/src/Resources/Fargate/TargetGroup.php
@@ -8,19 +8,18 @@ use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class TargetGroup implements Resource, SynchronisesConfiguration
+class TargetGroup implements AppScoped, Resource, SynchronisesConfiguration
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Helpers::keyedResourceName(exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Fargate/TaskLogGroup.php
+++ b/src/Resources/Fargate/TaskLogGroup.php
@@ -7,21 +7,20 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\CloudWatchLogs;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
-class TaskLogGroup implements Resource
+class TaskLogGroup implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Manifest::get(
             'tasks.web.log-group',
             sprintf('/yolo/%s', Helpers::keyedResourceName(exclusive: true))
         );
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Iam/DeployerPolicy.php
+++ b/src/Resources/Iam/DeployerPolicy.php
@@ -8,7 +8,9 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Iam;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\Fargate\EcsCluster;
 use Codinglabs\Yolo\Resources\Fargate\EcsService;
 use Codinglabs\Yolo\Resources\Storage\AssetBucket;
@@ -28,16 +30,13 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  *
  * Document drift is reconciled via createPolicyVersion (see EcsTaskPolicy).
  */
-class DeployerPolicy implements Resource
+class DeployerPolicy implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Helpers::keyedResourceName(Iam::DEPLOYER_POLICY, exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -7,7 +7,9 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Iam;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
@@ -22,16 +24,13 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * repo + ref) and its permissions (the app's ECR repo, buckets, cluster, service)
  * are app-specific, so unlike the shared task/execution roles it can't be shared.
  */
-class DeployerRole implements Resource
+class DeployerRole implements AppScoped, Resource
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Helpers::keyedResourceName(Iam::DEPLOYER_ROLE, exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Resources/ResolvesTags.php
+++ b/src/Resources/ResolvesTags.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources;
+
+use Codinglabs\Yolo\Manifest;
+
+/**
+ * The single source of a resource's tags: its `Name`, plus the `yolo:app` owner
+ * tag when the resource is marked AppScoped. The `yolo:environment` baseline is
+ * still added by Aws::tags()/expectedTags() at write time.
+ *
+ * Driving yolo:app off the AppScoped marker means a new app resource gets the
+ * tag just by declaring the interface — no remembering to add it to tags(), the
+ * gap that previously let resources slip through untagged. The instanceof check
+ * is also ready for shared resources to adopt this trait later (they'd resolve
+ * to Name only).
+ *
+ * @phpstan-require-implements Resource
+ */
+trait ResolvesTags
+{
+    public function tags(): array
+    {
+        return [
+            'Name' => $this->name(),
+            ...($this instanceof AppScoped ? ['yolo:app' => Manifest::name()] : []),
+        ];
+    }
+}

--- a/src/Resources/Storage/AssetBucket.php
+++ b/src/Resources/Storage/AssetBucket.php
@@ -5,8 +5,9 @@ namespace Codinglabs\Yolo\Resources\Storage;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\S3;
 use Codinglabs\Yolo\Helpers;
-use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 
 /**
@@ -24,16 +25,13 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * (reloads, DevTools "Disable cache"), where a response-headers-policy CORS
  * header is silently dropped.
  */
-class AssetBucket implements Resource, SynchronisesConfiguration
+class AssetBucket implements AppScoped, Resource, SynchronisesConfiguration
 {
+    use ResolvesTags;
+
     public function name(): string
     {
         return Helpers::keyedResourceName('assets', exclusive: true);
-    }
-
-    public function tags(): array
-    {
-        return ['Name' => $this->name(), 'yolo:app' => Manifest::name()];
     }
 
     public function exists(): bool

--- a/src/Steps/Storage/SyncS3ArtefactBucketStep.php
+++ b/src/Steps/Storage/SyncS3ArtefactBucketStep.php
@@ -5,6 +5,7 @@ namespace Codinglabs\Yolo\Steps\Storage;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\AwsResources;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -20,10 +21,13 @@ class SyncS3ArtefactBucketStep implements Step
         try {
             AwsResources::bucket($bucketName);
 
-            // Reconcile the hardening onto the existing bucket — safe to re-apply
-            // (it's never public and tiny), so older buckets pick it up on sync.
+            // Reconcile the hardening and tags onto the existing bucket — safe to
+            // re-apply, so older buckets pick up the hardening and the yolo:app
+            // owner tag on sync. (This step predates the create-or-sync Resource
+            // pattern, so the tag sync is explicit here.)
             if (! $dryRun) {
                 $this->harden($bucketName);
+                $this->tag($bucketName);
             }
 
             return StepResult::SYNCED;
@@ -37,15 +41,7 @@ class SyncS3ArtefactBucketStep implements Step
                     'Bucket' => $bucketName,
                 ]);
 
-                Aws::s3()->putBucketTagging([
-                    'Bucket' => $bucketName,
-                    'Tagging' => [
-                        ...Aws::tags([
-                            'Name' => $bucketName,
-                        ], wrap: 'TagSet'),
-                    ],
-                ]);
-
+                $this->tag($bucketName);
                 $this->harden($bucketName);
 
                 // todo: this requires the ELB account ID, which is not the same as the account ID.
@@ -79,6 +75,23 @@ class SyncS3ArtefactBucketStep implements Step
      * tamper-evidence for a clobbered or malicious `.env`). Both are declarative
      * puts — idempotent, safe to re-apply on every sync.
      */
+    /**
+     * Stamp the bucket with the YOLO baseline plus its yolo:app owner so `yolo
+     * audit` can attribute it. putBucketTagging is a full replace, idempotent on
+     * re-sync. The artefacts bucket is exclusive to one app, so yolo:app is the
+     * app name.
+     */
+    protected function tag(string $bucketName): void
+    {
+        Aws::s3()->putBucketTagging([
+            'Bucket' => $bucketName,
+            'Tagging' => Aws::tags([
+                'Name' => $bucketName,
+                'yolo:app' => Manifest::name(),
+            ], wrap: 'TagSet'),
+        ]);
+    }
+
     protected function harden(string $bucketName): void
     {
         Aws::s3()->putPublicAccessBlock([

--- a/src/Steps/Storage/SyncS3ArtefactBucketStep.php
+++ b/src/Steps/Storage/SyncS3ArtefactBucketStep.php
@@ -69,13 +69,6 @@ class SyncS3ArtefactBucketStep implements Step
     }
 
     /**
-     * The artefact bucket holds the application's `.env` files, so it must never
-     * be publicly reachable and its objects should be recoverable. Lock down all
-     * four Block Public Access settings and enable versioning (recovery +
-     * tamper-evidence for a clobbered or malicious `.env`). Both are declarative
-     * puts — idempotent, safe to re-apply on every sync.
-     */
-    /**
      * Stamp the bucket with the YOLO baseline plus its yolo:app owner so `yolo
      * audit` can attribute it. putBucketTagging is a full replace, idempotent on
      * re-sync. The artefacts bucket is exclusive to one app, so yolo:app is the
@@ -92,6 +85,13 @@ class SyncS3ArtefactBucketStep implements Step
         ]);
     }
 
+    /**
+     * The artefact bucket holds the application's `.env` files, so it must never
+     * be publicly reachable and its objects should be recoverable. Lock down all
+     * four Block Public Access settings and enable versioning (recovery +
+     * tamper-evidence for a clobbered or malicious `.env`). Both are declarative
+     * puts — idempotent, safe to re-apply on every sync.
+     */
     protected function harden(string $bucketName): void
     {
         Aws::s3()->putPublicAccessBlock([

--- a/tests/Unit/Resources/ResolvesTagsTest.php
+++ b/tests/Unit/Resources/ResolvesTagsTest.php
@@ -1,0 +1,76 @@
+<?php
+
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\AppScoped;
+use Codinglabs\Yolo\Resources\ResolvesTags;
+
+/**
+ * A minimal Resource using the trait, optionally marked AppScoped — so we can
+ * assert the marker (not a hand-written tag) is what drives yolo:app.
+ */
+function fakeAppResource(): Resource
+{
+    return new class() implements AppScoped, Resource
+    {
+        use ResolvesTags;
+
+        public function name(): string
+        {
+            return 'yolo-testing-my-app-thing';
+        }
+
+        public function exists(): bool
+        {
+            return true;
+        }
+
+        public function arn(): string
+        {
+            return 'arn:aws:fake';
+        }
+
+        public function create(): void {}
+
+        public function synchroniseTags(): void {}
+    };
+}
+
+function fakeSharedResource(): Resource
+{
+    return new class() implements Resource
+    {
+        use ResolvesTags;
+
+        public function name(): string
+        {
+            return 'yolo-testing-shared-thing';
+        }
+
+        public function exists(): bool
+        {
+            return true;
+        }
+
+        public function arn(): string
+        {
+            return 'arn:aws:fake';
+        }
+
+        public function create(): void {}
+
+        public function synchroniseTags(): void {}
+    };
+}
+
+it('stamps yolo:app on a resource marked AppScoped', function () {
+    expect(fakeAppResource()->tags())->toBe([
+        'Name' => 'yolo-testing-my-app-thing',
+        'yolo:app' => 'my-app',
+    ]);
+});
+
+it('omits yolo:app on a resource that is not AppScoped', function () {
+    expect(fakeSharedResource()->tags())->toBe([
+        'Name' => 'yolo-testing-shared-thing',
+    ]);
+});

--- a/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
+++ b/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
@@ -104,13 +104,14 @@ it('locks down and versions a newly created artefact bucket', function () {
     expect($versioning['args']['VersioningConfiguration']['Status'])->toBe('Enabled');
 });
 
-it('reconciles BPA and versioning onto an existing artefact bucket', function () {
+it('reconciles BPA, versioning and the yolo:app tag onto an existing artefact bucket', function () {
     $captured = [];
 
     bindMockS3Client([
         'HeadBucket' => new Result(),   // exists
         'PutPublicAccessBlock' => new Result(),
         'PutBucketVersioning' => new Result(),
+        'PutBucketTagging' => new Result(),
     ], $captured);
 
     expect((new SyncS3ArtefactBucketStep())([]))->toBe(StepResult::SYNCED);
@@ -118,7 +119,16 @@ it('reconciles BPA and versioning onto an existing artefact bucket', function ()
     $names = array_column($captured, 'name');
     expect($names)->toContain('PutPublicAccessBlock')
         ->toContain('PutBucketVersioning')
+        ->toContain('PutBucketTagging')   // older buckets backfill yolo:app on sync
         ->not->toContain('CreateBucket');
+
+    // The step predates the create-or-sync Resource pattern, so this is the
+    // explicit tag sync that lets `yolo audit` attribute the bucket to its app.
+    $tagging = collect($captured)->firstWhere('name', 'PutBucketTagging');
+    $tags = collect($tagging['args']['Tagging']['TagSet'])
+        ->mapWithKeys(fn (array $tag) => [$tag['Key'] => $tag['Value']]);
+
+    expect($tags['yolo:app'])->toBe('my-app');
 });
 
 it('does not mutate the artefact bucket during a dry-run', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Follow-up to #42, from running `yolo audit` against the real codinglabs deploy.

**What problems are you solving?**
- Running the audit showed most resources as `unattributed`. Two causes: (1) `yolo:app` was hand-written into each resource's `tags()`, so it was easy to miss one (`EcrRepository` was), and (2) the inventory was flooded with ECS task-definition revisions and tasks.

**How it works**
- **`interface AppScoped` + `trait ResolvesTags`** — a resource's tags are now resolved in *one* place: `Name`, plus `yolo:app` when the resource is `instanceof AppScoped`. App resources just declare the marker; there's nothing per-resource to remember, so a new app resource can't silently ship untagged. Applied to the 11 app-scoped Resource classes.
- **`SyncS3ArtefactBucketStep`** predates the create-or-sync Resource pattern and only tagged on *create* — exactly the "pure existence check, never re-syncs tags" gap. It now syncs `yolo:app` onto existing buckets too, so older buckets backfill on the next sync.
- **The audit ignores ECS task-definitions and tasks** — deploy ephemera (immutable revisions accumulate and can never be re-tagged; tasks are runtime), which were the bulk of the noise.

**Scope (as discussed)**
- This does the **new-style Resource classes** cleanly. **Shared** resources (ALB, listeners, shared IAM, network) and other **step-based** taggers keep their current `tags()` and adopt the marker later — they carry no `yolo:app` by design, so they correctly read as `unattributed` (shared infra), never drift.
- `$exclusive` stays the *naming* driver; the marker is the *tagging* driver. They correlate and could be unified in the backfill — left out of scope here.

**Is there anything the reviewer needs to know to deploy this?**
- **Self-heals on next `yolo sync`** — tag-sync is additive, so existing resources gain `yolo:app` on their next sync. Until then they read as `unattributed`, never drift. No backfill migration.
- After this, on codinglabs the live app's resources attribute correctly, the alpha-era leftovers (CodeDeploy app, launch template, legacy EC2 SG) stand out in `unattributed`, and the task-def noise is gone.

282 tests green, PHPStan + Pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)