### PR TITLE
LPX-597: ALB attribute polish — deletion protection, access logs, hardened defaults

### DIFF
--- a/src/Resources/Fargate/LoadBalancer.php
+++ b/src/Resources/Fargate/LoadBalancer.php
@@ -3,16 +3,31 @@
 namespace Codinglabs\Yolo\Resources\Fargate;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\Network\PublicSubnet;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 use Codinglabs\Yolo\Resources\Network\LoadBalancerSecurityGroup;
 
-class LoadBalancer implements Resource
+/**
+ * The application load balancer fronting the app's web tasks. Env-scoped, so
+ * shared by default (auto-named yolo-{env}) — multiple apps in an environment
+ * route off the one ALB via host-based listener rules — or pinned to a specific
+ * name with `aws.alb`.
+ *
+ * Beyond identity + tags, this resource also owns the ALB's hardened attribute
+ * defaults (deletion protection, access logs, dropped invalid headers, idle
+ * timeout, HTTP/2) and reconciles them onto an existing ALB via
+ * SynchronisesConfiguration so a changed default reaches an already-provisioned
+ * load balancer.
+ */
+class LoadBalancer implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
 
@@ -44,7 +59,7 @@ class LoadBalancer implements Resource
 
     public function create(): void
     {
-        Aws::elasticLoadBalancingV2()->createLoadBalancer([
+        $arn = Aws::elasticLoadBalancingV2()->createLoadBalancer([
             'Name' => $this->name(),
             'Type' => 'application',
             'Scheme' => 'internet-facing',
@@ -54,11 +69,107 @@ class LoadBalancer implements Resource
             ],
             'Subnets' => PublicSubnet::ids(),
             ...Aws::tags($this->tags()),
-        ]);
+        ])['LoadBalancers'][0]['LoadBalancerArn'];
+
+        // A fresh ALB starts on AWS defaults (no deletion protection, access logs
+        // off, invalid headers passed through); bring our hardened attributes onto
+        // it. The artefacts bucket access-logs policy is provisioned earlier in the
+        // sync (Storage runs before Compute), so enabling access logs validates.
+        $this->reconcileAttributes($arn, current: []);
     }
 
     public function synchroniseTags(): void
     {
         Aws::synchroniseElbV2Tags($this->arn(), $this->tags());
+    }
+
+    /**
+     * Push the hardened attribute defaults onto an existing ALB. Tag sync doesn't
+     * cover load-balancer attributes, so without this a changed default would never
+     * reach an already-provisioned load balancer. Diffs first so a clean sync makes
+     * no needless write.
+     */
+    public function synchroniseConfiguration(): void
+    {
+        $arn = $this->arn();
+
+        $this->reconcileAttributes($arn, $this->currentAttributes($arn));
+    }
+
+    /**
+     * Batch every managed attribute into a single modifyLoadBalancerAttributes
+     * call, but only when at least one has drifted from the desired value.
+     *
+     * @param  array<string, string>  $current  live attributes (empty on create)
+     */
+    protected function reconcileAttributes(string $arn, array $current): void
+    {
+        $desired = $this->desiredAttributes();
+
+        $drifted = collect($desired)
+            ->contains(fn (string $value, string $key) => ($current[$key] ?? null) !== $value);
+
+        if (! $drifted) {
+            return;
+        }
+
+        Aws::elasticLoadBalancingV2()->modifyLoadBalancerAttributes([
+            'LoadBalancerArn' => $arn,
+            'Attributes' => collect($desired)
+                ->map(fn (string $value, string $key) => ['Key' => $key, 'Value' => $value])
+                ->values()
+                ->all(),
+        ]);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    protected function currentAttributes(string $arn): array
+    {
+        return collect(
+            Aws::elasticLoadBalancingV2()->describeLoadBalancerAttributes([
+                'LoadBalancerArn' => $arn,
+            ])['Attributes']
+        )
+            ->mapWithKeys(fn (array $attribute) => [$attribute['Key'] => $attribute['Value']])
+            ->all();
+    }
+
+    /**
+     * The full set of ALB attributes YOLO manages, as the string key/value pairs
+     * the ELBv2 API expects. One source of truth shared by create and sync so the
+     * two paths can't drift apart.
+     *
+     * These are hardcoded sensible defaults, deliberately not manifest-configurable:
+     * deletion protection is always on (a future destroy command lifts it
+     * deterministically before deleting); access logs and dropped invalid headers
+     * are always-correct hardening; HTTP/2 and the 60s idle timeout are pinned to
+     * AWS's own defaults so they can't silently drift. Anything that turns out to
+     * need tuning can earn a manifest knob in a later release.
+     *
+     * @return array<string, string>
+     */
+    public function desiredAttributes(): array
+    {
+        return [
+            'deletion_protection.enabled' => 'true',
+            'access_logs.s3.enabled' => 'true',
+            'access_logs.s3.bucket' => Paths::s3ArtefactsBucket(),
+            'access_logs.s3.prefix' => $this->accessLogsPrefix(),
+            'routing.http.drop_invalid_header_fields.enabled' => 'true',
+            'routing.http2.enabled' => 'true',
+            'idle_timeout.timeout_seconds' => '60',
+        ];
+    }
+
+    /**
+     * Access logs land under alb-access-logs/{env}/{name}/ in the artefacts
+     * bucket, so a shared ALB's logs are grouped by its name and split from any
+     * other yolo-managed objects. AWS appends /AWSLogs/{account}/... beneath it.
+     */
+    public function accessLogsPrefix(): string
+    {
+        return sprintf('alb-access-logs/%s/%s', Helpers::environment(), $this->name());
     }
 }

--- a/src/Resources/Storage/S3ArtefactBucket.php
+++ b/src/Resources/Storage/S3ArtefactBucket.php
@@ -5,6 +5,7 @@ namespace Codinglabs\Yolo\Resources\Storage;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
@@ -16,6 +17,10 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * its objects must be recoverable, so Block Public Access (all four settings)
  * and versioning are reconciled onto it on every sync — both declarative,
  * idempotent puts. The yolo:app owner tag lets `yolo audit` attribute it.
+ *
+ * It also doubles as the destination for the ALB's access logs, so sync grants
+ * the ELB log-delivery service principal write access under the alb-access-logs/
+ * prefix.
  */
 class S3ArtefactBucket implements Resource, SynchronisesConfiguration
 {
@@ -78,6 +83,53 @@ class S3ArtefactBucket implements Resource, SynchronisesConfiguration
         Aws::s3()->putBucketVersioning([
             'Bucket' => $this->name(),
             'VersioningConfiguration' => ['Status' => 'Enabled'],
+        ]);
+
+        $this->grantAlbAccessLogDelivery();
+    }
+
+    /**
+     * Grant Elastic Load Balancing permission to deliver ALB access logs into this
+     * bucket under the alb-access-logs/ prefix. Enabling access logs on the load
+     * balancer (LoadBalancer resource) fails AWS's write-test without this, so the
+     * policy must exist before sync:compute runs — Storage runs ahead of Compute,
+     * so it does.
+     *
+     * Uses the log-delivery service principal (recommended for the SSE-S3-encrypted
+     * artefacts bucket; no customer-managed KMS key in play) rather than a
+     * per-Region ELB account ID. SourceAccount + SourceArn scope the grant to this
+     * account's load balancers, so it is never public and coexists with the
+     * bucket's BlockPublicPolicy. putBucketPolicy is a full replace and the
+     * artefacts bucket carries no other policy, so this is idempotent on re-sync.
+     */
+    protected function grantAlbAccessLogDelivery(): void
+    {
+        $accountId = Aws::accountId();
+
+        Aws::s3()->putBucketPolicy([
+            'Bucket' => $this->name(),
+            'Policy' => json_encode([
+                'Version' => '2012-10-17',
+                'Statement' => [
+                    [
+                        'Sid' => 'AllowELBAccessLogDelivery',
+                        'Effect' => 'Allow',
+                        'Principal' => ['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'],
+                        'Action' => 's3:PutObject',
+                        'Resource' => sprintf('arn:aws:s3:::%s/alb-access-logs/*', $this->name()),
+                        'Condition' => [
+                            'StringEquals' => ['aws:SourceAccount' => $accountId],
+                            'ArnLike' => [
+                                'aws:SourceArn' => sprintf(
+                                    'arn:aws:elasticloadbalancing:%s:%s:loadbalancer/*',
+                                    Manifest::get('aws.region'),
+                                    $accountId,
+                                ),
+                            ],
+                        ],
+                    ],
+                ],
+            ]),
         ]);
     }
 }

--- a/tests/Unit/Resources/Fargate/LoadBalancerTest.php
+++ b/tests/Unit/Resources/Fargate/LoadBalancerTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Resources\Fargate\LoadBalancer;
+use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
+
+/**
+ * Bind an ELBv2 client that records every command (name + args) and returns the
+ * supplied load-balancer attributes from DescribeLoadBalancerAttributes. Returns
+ * the recorder so tests can read `$recorder->calls`.
+ *
+ * @param  array<int, array{Key: string, Value: string}>  $attributes
+ */
+function bindRecordingLoadBalancerClient(array $attributes = []): object
+{
+    $recorder = new class($attributes) extends MockHandler
+    {
+        /** @var array<int, array{name: string, args: array<string, mixed>}> */
+        public array $calls = [];
+
+        public function __construct(public array $attributes) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            return Create::promiseFor(match ($cmd->getName()) {
+                'DescribeLoadBalancers' => new Result([
+                    'LoadBalancers' => [[
+                        'LoadBalancerName' => 'yolo-testing',
+                        'LoadBalancerArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/app/yolo-testing/abc',
+                    ]],
+                ]),
+                'DescribeLoadBalancerAttributes' => new Result(['Attributes' => $this->attributes]),
+                default => new Result([]),
+            });
+        }
+    };
+
+    Helpers::app()->instance('elasticLoadBalancingV2', new ElasticLoadBalancingV2Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+/**
+ * Flatten a captured Attributes argument list into an associative Key => Value map.
+ *
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $calls
+ * @return array<string, string>
+ */
+function modifiedAttributes(array $calls): array
+{
+    $modify = collect($calls)->firstWhere('name', 'ModifyLoadBalancerAttributes');
+
+    return collect($modify['args']['Attributes'])
+        ->mapWithKeys(fn (array $attribute) => [$attribute['Key'] => $attribute['Value']])
+        ->all();
+}
+
+/**
+ * The live-attribute shape DescribeLoadBalancerAttributes returns for an ALB that
+ * already carries every attribute YOLO manages — used to prove a clean sync makes
+ * no write. Defaults match the desired values (deletion protection on in every
+ * environment).
+ *
+ * @param  array<string, string>  $overrides
+ * @return array<int, array{Key: string, Value: string}>
+ */
+function syncedLoadBalancerAttributes(array $overrides = []): array
+{
+    $attributes = array_merge([
+        'deletion_protection.enabled' => 'true',
+        'access_logs.s3.enabled' => 'true',
+        'access_logs.s3.bucket' => 'yolo-testing-my-app-artefacts',
+        'access_logs.s3.prefix' => 'alb-access-logs/testing/yolo-testing',
+        'routing.http.drop_invalid_header_fields.enabled' => 'true',
+        'routing.http2.enabled' => 'true',
+        'idle_timeout.timeout_seconds' => '60',
+    ], $overrides);
+
+    return collect($attributes)
+        ->map(fn (string $value, string $key) => ['Key' => $key, 'Value' => $value])
+        ->values()
+        ->all();
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+});
+
+it('pins the full hardened attribute shape', function () {
+    // Hardcoded sensible defaults — the argument shape create + sync both push
+    // through modifyLoadBalancerAttributes. Deletion protection is always on.
+    expect((new LoadBalancer())->desiredAttributes())->toBe([
+        'deletion_protection.enabled' => 'true',
+        'access_logs.s3.enabled' => 'true',
+        'access_logs.s3.bucket' => 'yolo-testing-my-app-artefacts',
+        'access_logs.s3.prefix' => 'alb-access-logs/testing/yolo-testing',
+        'routing.http.drop_invalid_header_fields.enabled' => 'true',
+        'routing.http2.enabled' => 'true',
+        'idle_timeout.timeout_seconds' => '60',
+    ]);
+});
+
+it('makes no write when every managed attribute already matches', function () {
+    $recorder = bindRecordingLoadBalancerClient(syncedLoadBalancerAttributes());
+
+    (new LoadBalancer())->synchroniseConfiguration();
+
+    expect(collect($recorder->calls)->pluck('name'))->not->toContain('ModifyLoadBalancerAttributes');
+});
+
+it('modifies the load balancer when a managed attribute has drifted', function () {
+    $recorder = bindRecordingLoadBalancerClient(
+        syncedLoadBalancerAttributes(['routing.http.drop_invalid_header_fields.enabled' => 'false'])
+    );
+
+    (new LoadBalancer())->synchroniseConfiguration();
+
+    expect(collect($recorder->calls)->pluck('name'))->toContain('ModifyLoadBalancerAttributes');
+    expect(modifiedAttributes($recorder->calls)['routing.http.drop_invalid_header_fields.enabled'])->toBe('true');
+});

--- a/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
+++ b/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
@@ -177,3 +177,59 @@ it('does not flip public access on an existing app bucket', function () {
     expect((new SyncS3BucketStep())([]))->toBe(StepResult::SYNCED);
     expect(array_column($captured, 'name'))->not->toContain('PutPublicAccessBlock');
 });
+
+it('grants ELB access-log delivery to the log-delivery service principal on a new artefact bucket', function () {
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => [s3NotFound(), new Result(['@metadata' => ['statusCode' => 200]])],
+        'CreateBucket' => new Result(),
+        'PutBucketTagging' => new Result(),
+        'PutPublicAccessBlock' => new Result(),
+        'PutBucketVersioning' => new Result(),
+        'PutBucketPolicy' => new Result(),
+    ], $captured);
+
+    expect((new SyncS3ArtefactBucketStep())([]))->toBe(StepResult::CREATED);
+
+    $policy = collect($captured)->firstWhere('name', 'PutBucketPolicy');
+    expect($policy)->not->toBeNull();
+
+    $statement = json_decode($policy['args']['Policy'], true)['Statement'][0];
+
+    expect($statement['Effect'])->toBe('Allow')
+        ->and($statement['Principal'])->toBe(['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'])
+        ->and($statement['Action'])->toBe('s3:PutObject')
+        ->and($statement['Resource'])->toBe('arn:aws:s3:::yolo-testing-my-app-artefacts/alb-access-logs/*')
+        ->and($statement['Condition']['StringEquals']['aws:SourceAccount'])->toBe('111111111111')
+        ->and($statement['Condition']['ArnLike']['aws:SourceArn'])
+        ->toBe('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/*');
+});
+
+it('backfills the ELB access-log delivery policy onto an existing artefact bucket', function () {
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => new Result(),   // exists
+        'PutPublicAccessBlock' => new Result(),
+        'PutBucketVersioning' => new Result(),
+        'PutBucketPolicy' => new Result(),
+        'PutBucketTagging' => new Result(),
+    ], $captured);
+
+    expect((new SyncS3ArtefactBucketStep())([]))->toBe(StepResult::SYNCED);
+
+    expect(array_column($captured, 'name'))->toContain('PutBucketPolicy');
+});
+
+it('does not write the log-delivery policy during a dry-run', function () {
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => new Result(),   // exists
+    ], $captured);
+
+    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::SYNCED);
+
+    expect(array_column($captured, 'name'))->not->toContain('PutBucketPolicy');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Closes [LPX-597](https://linear.app/codinglabsau/issue/LPX-597/alb-attribute-polish-deletion-protection-access-logs-hardened-defaults)

**What problems are you solving?**

Sets sensible, hardened defaults on the ALBs YOLO provisions — flips on `loadBalancerAttributes`, no new resources, **no new manifest config**. These need to land before any production cutover (the ALB *is* the public endpoint).

The `LoadBalancer` resource now implements `SynchronisesConfiguration` (same pattern as `TargetGroup`), so the attributes are set on create **and** reconciled onto an already-provisioned ALB on subsequent syncs — diff-first, so a clean sync makes no write. All managed attributes batch into a single `modifyLoadBalancerAttributes` call.

All values are hardcoded sensible defaults — deliberately not manifest-configurable. Anything that turns out to need tuning earns a knob in a later release.

- `deletion_protection.enabled` → `true` in **every** environment (a staging ALB is no less painful to lose by accident). A future `destroy:compute` lifts protection deterministically before deleting.
- `access_logs.s3.enabled` → on, landing under `alb-access-logs/{env}/{name}/` in the artefacts bucket
- `routing.http.drop_invalid_header_fields.enabled` → on (drops smuggling-style malformed headers)
- `routing.http2.enabled` → pinned on so it can't drift
- `idle_timeout.timeout_seconds` → 60 (AWS's own default, pinned)

Also replaces the long-standing `// todo: ... ELB account ID` (now in the `S3ArtefactBucket` resource after the LPX-612 migration) with a real bucket policy granting the **log-delivery service principal** (`logdelivery.elasticloadbalancing.amazonaws.com`) `s3:PutObject` under the `alb-access-logs/` prefix, scoped to this account's load balancers via `aws:SourceAccount`/`aws:SourceArn`.

**Is there anything the reviewer needs to know to deploy this?**

- **Deletion protection is on everywhere and has no manifest off-switch.** Deleting a YOLO ALB now requires turning the attribute off out-of-band (or the future `destroy:compute`, which will own the deterministic "lift protection → delete" flow). That's the point: you can't accidentally `delete-load-balancer` a live endpoint.
- **Ordering is load-bearing and already correct:** Storage syncs before Compute, so the artefacts-bucket log-delivery policy is in place before `SyncLoadBalancerStep` enables access logs. Enabling access logs triggers AWS's write-test against the bucket — without the policy that modify call would fail. This is the one path I can't exercise without a real `yolo sync` (no live AWS run), so it's the thing to watch on the first real sync.
- **Service-principal policy, not the per-Region ELB account ID:** valid because the artefacts bucket uses default SSE-S3 (no customer-managed KMS key). AWS's recommended approach; never treated as a public policy, so it coexists with the bucket's `BlockPublicPolicy`.
- **Shared-ALB log destination caveat:** an ALB can only log to one bucket+prefix. The default ALB is shared (`yolo-{env}`) but the artefacts bucket is app-scoped, so on a shared ALB the `access_logs.s3.bucket` attribute is last-writer-wins across apps. Inherent ALB constraint, out of scope here — flagging it.
- No IAM change needed: `sync` runs locally with admin creds; the CI deployer role only does ELB *describe* during `deploy`.

**Tests:** 288 pass · PHPStan clean · Pint clean. `LoadBalancerTest` pins the full attribute argument shape, the clean-sync no-write, and drift detection; `SyncS3BucketHardeningTest` covers the log-delivery policy on create + backfill + dry-run.

> Note: rebased onto main after [#46](https://github.com/codinglabsau/yolo/pull/46) (LPX-612) landed — the artefacts-bucket logic moved into the new `S3ArtefactBucket` resource's `synchroniseConfiguration()`, and `LoadBalancer` now uses `PublicSubnet`/`LoadBalancerSecurityGroup` + `ResolvesTags`.

🤖 Generated with [Claude Code](https://claude.ai/code)