### PR TITLE
LPX-598: enable ECS deployment circuit breaker with auto-rollback

### DIFF
--- a/src/Resources/Fargate/EcsService.php
+++ b/src/Resources/Fargate/EcsService.php
@@ -104,10 +104,7 @@ class EcsService implements AppScoped, Resource
             'desiredCount' => self::INITIAL_DESIRED_COUNT,
             'launchType' => 'FARGATE',
             ...Manifest::isHeadless() ? [] : ['healthCheckGracePeriodSeconds' => $this->gracePeriod()],
-            'deploymentConfiguration' => [
-                'minimumHealthyPercent' => 100,
-                'maximumPercent' => 200,
-            ],
+            'deploymentConfiguration' => static::deploymentConfiguration(),
             'networkConfiguration' => [
                 'awsvpcConfiguration' => [
                     'subnets' => PublicSubnet::ids(),
@@ -127,6 +124,29 @@ class EcsService implements AppScoped, Resource
             'tags' => Aws::ecsTags($this->tags()),
             'propagateTags' => 'SERVICE',
             'enableExecuteCommand' => $this->enableExecuteCommand(),
+        ];
+    }
+
+    /**
+     * Roll one task in at a time (minimumHealthyPercent 100 keeps the old version
+     * serving until the new one is healthy; maximumPercent 200 allows the extra
+     * task), with the deployment circuit breaker aborting and rolling back to the
+     * last healthy revision on a failed rollout. The breaker is also what makes
+     * ECS set the deployment's rolloutState to FAILED — the signal
+     * WaitForDeploymentHealthyStep fast-fails on — so without it a crash-looping
+     * deploy is never marked failed and the health-wait eats its full timeout.
+     *
+     * @return array<string, mixed>
+     */
+    public static function deploymentConfiguration(): array
+    {
+        return [
+            'deploymentCircuitBreaker' => [
+                'enable' => true,
+                'rollback' => true,
+            ],
+            'minimumHealthyPercent' => 100,
+            'maximumPercent' => 200,
         ];
     }
 

--- a/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
@@ -121,3 +121,17 @@ describe('updatePayload', function () {
         expect((new EcsService())->updatePayload())->not->toHaveKey('desiredCount');
     });
 });
+
+describe('deploymentConfiguration', function () {
+    it('enables the circuit breaker with rollback so a failed rollout self-reverts', function () {
+        expect(EcsService::deploymentConfiguration()['deploymentCircuitBreaker'])
+            ->toBe(['enable' => true, 'rollback' => true]);
+    });
+
+    it('keeps one-at-a-time rolling capacity (100% min healthy, 200% max)', function () {
+        $config = EcsService::deploymentConfiguration();
+
+        expect($config['minimumHealthyPercent'])->toBe(100);
+        expect($config['maximumPercent'])->toBe(200);
+    });
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

- ECS services are created without a deployment circuit breaker, so a failed rollout (crash-looping image, failing health check) never self-reverts — it sits in-progress until someone manually aborts it. The old version keeps serving (no outage), but the deploy just hangs.
- `WaitForDeploymentHealthyStep` already fast-fails on `rolloutState === 'FAILED'`, but **ECS only ever sets that state when the circuit breaker is enabled.** So today that branch is effectively dead code: a genuinely broken deploy is never marked FAILED, and the health-wait eats its full 600s timeout before throwing a generic error.

This adds `deploymentCircuitBreaker => ['enable' => true, 'rollback' => true]` to the service create payload. A failed rollout now aborts and auto-reverts to the last healthy revision, and the existing fast-fail path actually fires (~2 min, with the real reason, instead of a 10-min timeout). Extracted `deploymentConfiguration()` so the rollout config is unit-testable without the live AWS lookups `createPayload()` makes.

**Is there anything the reviewer needs to know to deploy this?**

- **Create-only.** It lands in the `createService` payload, so only newly-created ECS services pick it up. Existing live services (e.g. CL's `codinglabs`) keep their current config until recreated — `SyncEcsServiceStep` reconciles only exec-command + grace-period, not deployment config. Fine for the LP cutover: every tenant service is created fresh.
- **No change on a healthy deploy.** Rolling config is unchanged (100% min healthy / 200% max). The only new behaviour is on *failure*: ECS aborts + rolls back instead of hanging.
- Scoped down from the original 9-item LPX-598 to this single item. The other two survivors (revision pinning, concurrent-deploy guard) were dropped as low-value — see the issue for the reasoning.

🤖 Generated with [Claude Code](https://claude.ai/code)