### PR TITLE
feat: verbose attribute-level diffs in sync output

### DIFF
--- a/src/Aws/CloudWatchLogs.php
+++ b/src/Aws/CloudWatchLogs.php
@@ -26,4 +26,22 @@ class CloudWatchLogs
 
         throw new ResourceDoesNotExistException("Could not find CloudWatch log group $name");
     }
+
+    /**
+     * The account-level resource policy with the given name decoded to an array,
+     * or null when no such policy exists. Used to diff the EventBridge log-delivery
+     * grant before re-putting it.
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function resourcePolicy(string $name): ?array
+    {
+        foreach (Aws::cloudWatchLogs()->describeResourcePolicies()['resourcePolicies'] ?? [] as $policy) {
+            if (($policy['policyName'] ?? null) === $name) {
+                return json_decode((string) $policy['policyDocument'], true);
+            }
+        }
+
+        return null;
+    }
 }

--- a/src/Aws/Iam.php
+++ b/src/Aws/Iam.php
@@ -3,10 +3,31 @@
 namespace Codinglabs\Yolo\Aws;
 
 use Codinglabs\Yolo\Aws;
+use Aws\Exception\AwsException;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 class Iam
 {
+    /**
+     * The managed policies attached to a role, as [{PolicyName, PolicyArn}], or
+     * an empty list when the role does not yet exist (a dry-run can reach the
+     * attach step before the role's own create step has run).
+     *
+     * @return array<int, array<string, string>>
+     */
+    public static function attachedRolePolicies(string $roleName): array
+    {
+        try {
+            return Aws::iam()->listAttachedRolePolicies(['RoleName' => $roleName])['AttachedPolicies'] ?? [];
+        } catch (AwsException $e) {
+            if ($e->getAwsErrorCode() === 'NoSuchEntity') {
+                return [];
+            }
+
+            throw $e;
+        }
+    }
+
     public static function role(string $name): array
     {
         $roles = Aws::iam()->listRoles();

--- a/src/Aws/S3.php
+++ b/src/Aws/S3.php
@@ -3,11 +3,80 @@
 namespace Codinglabs\Yolo\Aws;
 
 use Codinglabs\Yolo\Aws;
+use Aws\S3\Exception\S3Exception;
 
 class S3
 {
     public static function bucketExists(string $name): bool
     {
         return Aws::s3()->doesBucketExistV2($name);
+    }
+
+    /**
+     * The bucket's Block Public Access configuration, or null when none is set
+     * (a fresh bucket has none — AWS throws NoSuchPublicAccessBlockConfiguration).
+     *
+     * @return array<string, bool>|null
+     */
+    public static function publicAccessBlock(string $bucket): ?array
+    {
+        try {
+            return Aws::s3()->getPublicAccessBlock(['Bucket' => $bucket])['PublicAccessBlockConfiguration'] ?? null;
+        } catch (S3Exception $e) {
+            if ($e->getAwsErrorCode() === 'NoSuchPublicAccessBlockConfiguration') {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * The bucket's versioning status ('Enabled' / 'Suspended'), or null when
+     * versioning was never configured (the result simply omits Status).
+     */
+    public static function bucketVersioning(string $bucket): ?string
+    {
+        return Aws::s3()->getBucketVersioning(['Bucket' => $bucket])['Status'] ?? null;
+    }
+
+    /**
+     * The bucket's CORS rules, or null when none are configured (AWS throws
+     * NoSuchCORSConfiguration).
+     *
+     * @return array<int, array<string, mixed>>|null
+     */
+    public static function bucketCors(string $bucket): ?array
+    {
+        try {
+            return Aws::s3()->getBucketCors(['Bucket' => $bucket])['CORSRules'] ?? null;
+        } catch (S3Exception $e) {
+            if ($e->getAwsErrorCode() === 'NoSuchCORSConfiguration') {
+                return null;
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
+     * The bucket's resource policy decoded to an array, or null when none is
+     * attached (AWS throws NoSuchBucketPolicy).
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function bucketPolicy(string $bucket): ?array
+    {
+        try {
+            $policy = Aws::s3()->getBucketPolicy(['Bucket' => $bucket])['Policy'] ?? null;
+
+            return $policy === null ? null : json_decode((string) $policy, true);
+        } catch (S3Exception $e) {
+            if ($e->getAwsErrorCode() === 'NoSuchBucketPolicy') {
+                return null;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Change.php
+++ b/src/Change.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Codinglabs\Yolo;
+
+/**
+ * A single reconciled attribute — the unit of detail a sync step reports so the
+ * operator sees exactly what drifted (and what it became) rather than a flat
+ * SYNCED. `from` is the live value (null = absent / never set), `to` the desired
+ * value the sync would apply or did apply.
+ *
+ * Values arrive as scalars, bools or whole config documents; `make()` formats
+ * them into the display strings the renderer prints, so the renderer stays dumb.
+ * Resources comparing opaque documents (a bucket policy, an event pattern) build
+ * a Change directly with their own semantic from/to labels (e.g. 'absent' →
+ * 'managed') rather than dumping a JSON blob.
+ */
+final class Change
+{
+    public function __construct(
+        public readonly string $attribute,
+        public readonly ?string $from,
+        public readonly ?string $to,
+    ) {}
+
+    public static function make(string $attribute, mixed $from, mixed $to): self
+    {
+        return new self($attribute, self::format($from), self::format($to));
+    }
+
+    /**
+     * Render the comparison as a single line for non-coloured output.
+     */
+    public function describe(): string
+    {
+        return sprintf('%s: %s → %s', $this->attribute, $this->from ?? '<absent>', $this->to ?? '<absent>');
+    }
+
+    protected static function format(mixed $value): ?string
+    {
+        return match (true) {
+            $value === null => null,
+            is_bool($value) => $value ? 'true' : 'false',
+            is_array($value) => json_encode($value),
+            default => (string) $value,
+        };
+    }
+}

--- a/src/Concerns/AttachesRolePolicies.php
+++ b/src/Concerns/AttachesRolePolicies.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Codinglabs\Yolo\Concerns;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Aws\Iam;
+use Codinglabs\Yolo\Enums\StepResult;
+
+/**
+ * Diff a role's managed-policy attachments against the desired set and reconcile
+ * additively — attaching only what's missing, recording each as a Change, and
+ * writing nothing under --dry-run. Replaces the old blind attachRolePolicy (which
+ * fired on every sync and always reported WOULD_SYNC) so an already-attached role
+ * reports a clean SYNCED and a dry-run reports exactly which policies it'd attach.
+ */
+trait AttachesRolePolicies
+{
+    use RecordsChanges;
+
+    /**
+     * @param  array<int, string>  $desiredArns
+     */
+    protected function attachRolePolicies(string $roleName, array $desiredArns, bool $dryRun): StepResult
+    {
+        $attached = collect(Iam::attachedRolePolicies($roleName))->pluck('PolicyArn');
+
+        $missing = array_values(array_filter(
+            $desiredArns,
+            fn (string $arn) => ! $attached->contains($arn),
+        ));
+
+        if ($missing === []) {
+            return StepResult::SYNCED;
+        }
+
+        foreach ($missing as $arn) {
+            $this->recordChange(Change::make('attached-policy', null, $arn));
+        }
+
+        if ($dryRun) {
+            return StepResult::WOULD_SYNC;
+        }
+
+        foreach ($missing as $arn) {
+            Aws::iam()->attachRolePolicy([
+                'RoleName' => $roleName,
+                'PolicyArn' => $arn,
+            ]);
+        }
+
+        return StepResult::SYNCED;
+    }
+
+    /**
+     * The deterministic ARN of a customer-managed policy by name. Constructed
+     * rather than looked up so the diff works even on a dry-run where the policy's
+     * own create step hasn't run yet.
+     */
+    protected function customerManagedPolicyArn(string $name): string
+    {
+        return sprintf('arn:aws:iam::%s:policy/%s', Aws::accountId(), $name);
+    }
+}

--- a/src/Concerns/RecordsChanges.php
+++ b/src/Concerns/RecordsChanges.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Codinglabs\Yolo\Concerns;
+
+use Codinglabs\Yolo\Change;
+
+/**
+ * Lets a step accumulate the attribute-level changes it reconciled (or, under
+ * --dry-run, would reconcile) so the stepped-command runner can surface them in
+ * its Changes report. The runner reads them back via changes() after invoking
+ * the step. Steps backed by a Resource get this for free through
+ * SynchronisesResource; steps with bespoke reconcile logic use it directly.
+ */
+trait RecordsChanges
+{
+    /** @var array<int, Change> */
+    protected array $recordedChanges = [];
+
+    /**
+     * @return array<int, Change>
+     */
+    public function changes(): array
+    {
+        return $this->recordedChanges;
+    }
+
+    protected function recordChange(Change $change): void
+    {
+        $this->recordedChanges[] = $change;
+    }
+
+    /**
+     * @param  array<int, Change>  $changes
+     */
+    protected function recordChanges(array $changes): void
+    {
+        foreach ($changes as $change) {
+            $this->recordedChanges[] = $change;
+        }
+    }
+}

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -2,6 +2,7 @@
 
 namespace Codinglabs\Yolo\Concerns;
 
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Str;
 use Laravel\Prompts\Prompt;
 use Codinglabs\Yolo\Manifest;
@@ -171,7 +172,7 @@ trait RunsSteppedCommands
     /**
      * Render the progress frame for a step, invoke it, and time it.
      *
-     * @return array{status: StepResult|string, elapsed: int}
+     * @return array{status: StepResult|string, elapsed: int, changes: array<int, Change>}
      */
     protected function invokeStep(Step $step, ?Progress $progress, string $label, int $now): array
     {
@@ -193,7 +194,14 @@ trait RunsSteppedCommands
 
         $progress?->advance();
 
-        return ['status' => $status, 'elapsed' => time() - $started];
+        return [
+            'status' => $status,
+            'elapsed' => time() - $started,
+            // Steps that reconcile config (directly, or via SynchronisesResource)
+            // record the attributes they changed so the Changes report can surface
+            // each current → desired comparison.
+            'changes' => method_exists($step, 'changes') ? $step->changes() : [],
+        ];
     }
 
     /**
@@ -230,6 +238,8 @@ trait RunsSteppedCommands
             );
         }
 
+        $this->renderChanges($ran, $multiDomain);
+
         if ($skipped->isNotEmpty()) {
             if ($this->output->isVerbose()) {
                 table(
@@ -250,6 +260,46 @@ trait RunsSteppedCommands
         }
 
         info(sprintf('Synced %s in %ds.', $environment, $elapsed));
+    }
+
+    /**
+     * Print the per-attribute detail behind the status column: which attributes
+     * each step reconciled (or, under --dry-run, would reconcile), as a
+     * current → desired comparison. Steps that changed nothing are omitted, so a
+     * clean sync stays quiet and drift stands out.
+     *
+     * @param  Collection<int, array{domain: string, step: Step, status: StepResult|string, changes: array<int, Change>}>  $ran
+     */
+    protected function renderChanges(Collection $ran, bool $multiDomain): void
+    {
+        $withChanges = $ran->filter(fn (array $result) => $result['changes'] !== []);
+
+        if ($withChanges->isEmpty()) {
+            return;
+        }
+
+        $this->output->writeln('');
+        $this->output->writeln(sprintf(
+            '  <options=bold>%s</>',
+            $this->option('dry-run') ? 'Pending changes' : 'Changes applied',
+        ));
+
+        $withChanges->each(function (array $result) use ($multiDomain) {
+            $label = $multiDomain
+                ? sprintf('%s · %s', $result['domain'], static::normaliseStep($result['step']))
+                : static::normaliseStep($result['step']);
+
+            $this->output->writeln(sprintf('  <fg=cyan>%s</>', $label));
+
+            foreach ($result['changes'] as $change) {
+                $this->output->writeln(sprintf(
+                    '    %s: <fg=red>%s</> <fg=gray>→</> <fg=green>%s</>',
+                    $change->attribute,
+                    $change->from ?? 'absent',
+                    $change->to ?? 'absent',
+                ));
+            }
+        });
     }
 
     protected function handleSteps(string $environment): int
@@ -375,7 +425,6 @@ trait RunsSteppedCommands
 
             // red
             StepResult::MANIFEST_INVALID => '<fg=red>MANIFEST INVALID</>',
-            StepResult::OUT_OF_SYNC => '<fg=red>OUT OF SYNC</>',
             StepResult::TIMEOUT => '<fg=red>TIMEOUT</>',
             default => is_string($status) ? $status : '',
         };

--- a/src/Concerns/SynchronisesResource.php
+++ b/src/Concerns/SynchronisesResource.php
@@ -11,27 +11,41 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * Generic create-or-sync orchestration for steps backed by a Resource.
  * Steps with extra gating (cert state, manifest predicates, ingress rules)
  * keep their orchestration but delegate identity / create / tag-sync here.
+ *
+ * Config-drift detail is surfaced, not swallowed: for a resource that can drift
+ * (SynchronisesConfiguration) the diff is computed even under --dry-run (with
+ * apply=false, so nothing is written) and recorded so the runner can report
+ * exactly which attributes changed. An existing-but-drifted resource therefore
+ * reports WOULD_SYNC (dry-run) / SYNCED-with-changes (real run) instead of a
+ * silent SYNCED that hid the writes.
  */
 trait SynchronisesResource
 {
+    use RecordsChanges;
+
     protected function syncResource(Resource $resource, array $options): StepResult
     {
-        if ($resource->exists()) {
-            if (! Arr::get($options, 'dry-run')) {
-                $resource->synchroniseTags();
+        $dryRun = (bool) Arr::get($options, 'dry-run');
 
-                // Resources whose live config can drift (currently just the
-                // CloudFront distribution) reconcile it here too; tag-only sync
-                // would never push a config change onto an existing resource.
-                if ($resource instanceof SynchronisesConfiguration) {
-                    $resource->synchroniseConfiguration();
+        if ($resource->exists()) {
+            if (! $dryRun) {
+                $resource->synchroniseTags();
+            }
+
+            if ($resource instanceof SynchronisesConfiguration) {
+                $changes = $resource->synchroniseConfiguration(apply: ! $dryRun);
+
+                $this->recordChanges($changes);
+
+                if ($changes !== []) {
+                    return $dryRun ? StepResult::WOULD_SYNC : StepResult::SYNCED;
                 }
             }
 
             return StepResult::SYNCED;
         }
 
-        if (Arr::get($options, 'dry-run')) {
+        if ($dryRun) {
             return StepResult::WOULD_CREATE;
         }
 

--- a/src/Enums/StepResult.php
+++ b/src/Enums/StepResult.php
@@ -9,7 +9,6 @@ enum StepResult
     case WOULD_CREATE;
 
     case SYNCED;
-    case OUT_OF_SYNC;
     case WOULD_SYNC;
 
     case CUSTOM_MANAGED;

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -195,6 +195,40 @@ class Helpers
         return $validated;
     }
 
+    /**
+     * Compare two policy / config documents for semantic equality, ignoring the
+     * key ordering AWS is free to reshuffle on read. Object keys are sorted
+     * recursively; list order is preserved (it can be meaningful). Either side
+     * may be null (no document present).
+     *
+     * @param  array<string, mixed>|null  $a
+     * @param  array<string, mixed>|null  $b
+     */
+    public static function documentsEqual(?array $a, ?array $b): bool
+    {
+        return static::canonicaliseDocument($a) === static::canonicaliseDocument($b);
+    }
+
+    /**
+     * @param  array<mixed>|null  $document
+     */
+    protected static function canonicaliseDocument(?array $document): ?string
+    {
+        if ($document === null) {
+            return null;
+        }
+
+        $sort = function (array $value) use (&$sort): array {
+            if (! array_is_list($value)) {
+                ksort($value);
+            }
+
+            return array_map(fn ($item) => is_array($item) ? $sort($item) : $item, $value);
+        };
+
+        return json_encode($sort($document));
+    }
+
     public static function payloadHasDifferences(array $expected, array $actual): bool
     {
         foreach ($expected as $key => $value) {

--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Resources\CloudFront;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Str;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
@@ -123,9 +124,11 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
      * CORS-S3Origin origin-request policy after it was created), so sync
      * reconciles the behaviour fields we own. CloudFront updates trigger a full
      * edge redeploy (~15 min), so we only call updateDistribution when a managed
-     * field has drifted.
+     * field has drifted, and we return the drifted fields so sync can report each
+     * current → desired comparison. A dry-run ($apply false) never creates the
+     * cache policy and never calls updateDistribution.
      */
-    public function synchroniseConfiguration(): void
+    public function synchroniseConfiguration(bool $apply = true): array
     {
         $id = CloudFront::distributionByComment($this->name())['Id'];
 
@@ -133,19 +136,42 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
         $config = (array) $response['DistributionConfig'];
         $behaviour = (array) $config['DefaultCacheBehavior'];
 
-        $reconciled = array_merge($behaviour, static::reconcilableBehaviour($this->ensureCachePolicy()));
+        $desired = static::reconcilableBehaviour($this->resolveCachePolicyId($apply));
 
-        if ($reconciled == $behaviour) {
-            return;
+        $changes = collect($desired)
+            ->filter(fn (mixed $value, string $key) => ($behaviour[$key] ?? null) !== $value)
+            ->map(fn (mixed $value, string $key) => Change::make($key, $behaviour[$key] ?? null, $value))
+            ->values()
+            ->all();
+
+        if ($changes === [] || ! $apply) {
+            return $changes;
         }
 
-        $config['DefaultCacheBehavior'] = $reconciled;
+        $config['DefaultCacheBehavior'] = array_merge($behaviour, $desired);
 
         Aws::cloudFront()->updateDistribution([
             'Id' => $id,
             'DistributionConfig' => $config,
             'IfMatch' => (string) $response['ETag'],
         ]);
+
+        return $changes;
+    }
+
+    /**
+     * The cache policy id for diffing. An existing distribution was created with
+     * the policy already in place, so the lookup all but always resolves; the
+     * dry-run fallback ('(pending …)') only shows if it were somehow missing, and
+     * never creates the policy as a side effect of a read-only --dry-run.
+     */
+    protected function resolveCachePolicyId(bool $apply): string
+    {
+        try {
+            return CloudFront::cachePolicyByName(static::CACHE_POLICY_NAME)['Id'];
+        } catch (ResourceDoesNotExistException) {
+            return $apply ? $this->ensureCachePolicy() : sprintf('(pending: %s)', static::CACHE_POLICY_NAME);
+        }
     }
 
     /**

--- a/src/Resources/CloudWatchLogs/IvsLogGroup.php
+++ b/src/Resources/CloudWatchLogs/IvsLogGroup.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Resources\CloudWatchLogs;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
@@ -68,10 +69,12 @@ class IvsLogGroup implements Resource, SynchronisesConfiguration
         Aws::synchroniseCloudWatchLogsTags($this->arn(), $this->tags());
     }
 
-    public function synchroniseConfiguration(): void
+    public function synchroniseConfiguration(bool $apply = true): array
     {
-        $this->reconcileRetention();
-        $this->putEventBridgeResourcePolicy();
+        return [
+            ...$this->reconcileRetention($apply),
+            ...$this->reconcileEventBridgeResourcePolicy($apply),
+        ];
     }
 
     public function retentionDays(): int
@@ -79,42 +82,76 @@ class IvsLogGroup implements Resource, SynchronisesConfiguration
         return (int) Manifest::get('aws.ivs.log-retention-days', 14);
     }
 
-    protected function reconcileRetention(): void
+    /**
+     * @return array<int, Change>
+     */
+    protected function reconcileRetention(bool $apply): array
     {
         $logGroup = CloudWatchLogs::logGroup($this->name());
+        $current = $logGroup['retentionInDays'] ?? null;
 
-        if (($logGroup['retentionInDays'] ?? null) === $this->retentionDays()) {
-            return;
+        if ($current === $this->retentionDays()) {
+            return [];
         }
 
-        Aws::cloudWatchLogs()->putRetentionPolicy([
-            'logGroupName' => $this->name(),
-            'retentionInDays' => $this->retentionDays(),
-        ]);
+        if ($apply) {
+            Aws::cloudWatchLogs()->putRetentionPolicy([
+                'logGroupName' => $this->name(),
+                'retentionInDays' => $this->retentionDays(),
+            ]);
+        }
+
+        return [Change::make('retention-days', $current, $this->retentionDays())];
     }
 
     /**
      * Grant EventBridge permission to deliver IVS events into any /aws/ivs/ log
-     * group. Idempotent put, so it's safe to re-apply on every sync.
+     * group. Diffs the live resource policy against the desired document first, so
+     * a clean sync makes no write and a dry-run reports the change.
+     *
+     * @return array<int, Change>
      */
-    protected function putEventBridgeResourcePolicy(): void
+    protected function reconcileEventBridgeResourcePolicy(bool $apply): array
     {
-        Aws::cloudWatchLogs()->putResourcePolicy([
-            'policyName' => Helpers::keyedResourceName('ivs-eventbridge-policy', exclusive: false),
-            'policyDocument' => json_encode([
-                'Version' => '2012-10-17',
-                'Statement' => [[
-                    'Sid' => 'EventBridgeToCloudWatchLogs',
-                    'Effect' => 'Allow',
-                    'Principal' => ['Service' => 'events.amazonaws.com'],
-                    'Action' => ['logs:CreateLogStream', 'logs:PutLogEvents'],
-                    'Resource' => sprintf(
-                        'arn:aws:logs:%s:%s:log-group:/aws/ivs/*',
-                        Manifest::get('aws.region'),
-                        Aws::accountId(),
-                    ),
-                ]],
-            ]),
-        ]);
+        $current = CloudWatchLogs::resourcePolicy($this->eventBridgePolicyName());
+
+        if (Helpers::documentsEqual($current, $this->eventBridgePolicyDocument())) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::cloudWatchLogs()->putResourcePolicy([
+                'policyName' => $this->eventBridgePolicyName(),
+                'policyDocument' => json_encode($this->eventBridgePolicyDocument()),
+            ]);
+        }
+
+        return [Change::make('eventbridge-resource-policy', $current === null ? null : 'present', 'events.amazonaws.com → /aws/ivs/*')];
+    }
+
+    protected function eventBridgePolicyName(): string
+    {
+        return Helpers::keyedResourceName('ivs-eventbridge-policy', exclusive: false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function eventBridgePolicyDocument(): array
+    {
+        return [
+            'Version' => '2012-10-17',
+            'Statement' => [[
+                'Sid' => 'EventBridgeToCloudWatchLogs',
+                'Effect' => 'Allow',
+                'Principal' => ['Service' => 'events.amazonaws.com'],
+                'Action' => ['logs:CreateLogStream', 'logs:PutLogEvents'],
+                'Resource' => sprintf(
+                    'arn:aws:logs:%s:%s:log-group:/aws/ivs/*',
+                    Manifest::get('aws.region'),
+                    Aws::accountId(),
+                ),
+            ]],
+        ];
     }
 }

--- a/src/Resources/Ecs/EcsService.php
+++ b/src/Resources/Ecs/EcsService.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Resources\Ecs;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Aws\Ecs;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
@@ -66,29 +67,56 @@ class EcsService implements Resource
      */
     public function needsUpdate(): bool
     {
-        return static::serviceNeedsUpdate(
+        return $this->pendingChanges() !== [];
+    }
+
+    /**
+     * The service-level attributes that have drifted from the manifest — read
+     * live and diffed so the sync step can report each current → desired change.
+     *
+     * @return array<int, Change>
+     */
+    public function pendingChanges(): array
+    {
+        return static::serviceChanges(
             Ecs::service((new EcsCluster())->name(), $this->name()),
             $this->gracePeriod(),
             $this->enableExecuteCommand(),
         );
     }
 
-    /**
-     * Pure comparison — extracted so tests can pin headless / missing-grace-period
-     * behaviour without mocking the ECS client.
-     */
     public static function serviceNeedsUpdate(array $service, int $gracePeriod, bool $enableExecuteCommand): bool
     {
-        if (($service['enableExecuteCommand'] ?? false) !== $enableExecuteCommand) {
-            return true;
+        return static::serviceChanges($service, $gracePeriod, $enableExecuteCommand) !== [];
+    }
+
+    /**
+     * Pure comparison — extracted so tests can pin headless / missing-grace-period
+     * behaviour without mocking the ECS client. Exec-command drift is always
+     * reconciled; the grace period only when the service is ALB-attached (headless
+     * services have no grace period to reconcile).
+     *
+     * @return array<int, Change>
+     */
+    public static function serviceChanges(array $service, int $gracePeriod, bool $enableExecuteCommand): array
+    {
+        $changes = [];
+
+        $currentExecuteCommand = $service['enableExecuteCommand'] ?? false;
+
+        if ($currentExecuteCommand !== $enableExecuteCommand) {
+            $changes[] = Change::make('enableExecuteCommand', $currentExecuteCommand, $enableExecuteCommand);
         }
 
-        // Headless services have no ALB association and therefore no grace period to reconcile.
-        if (Manifest::isHeadless()) {
-            return false;
+        if (! Manifest::isHeadless()) {
+            $currentGracePeriod = $service['healthCheckGracePeriodSeconds'] ?? $gracePeriod;
+
+            if ($currentGracePeriod !== $gracePeriod) {
+                $changes[] = Change::make('healthCheckGracePeriodSeconds', $currentGracePeriod, $gracePeriod);
+            }
         }
 
-        return ($service['healthCheckGracePeriodSeconds'] ?? $gracePeriod) !== $gracePeriod;
+        return $changes;
     }
 
     public function update(): void

--- a/src/Resources/ElbV2/LoadBalancer.php
+++ b/src/Resources/ElbV2/LoadBalancer.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Resources\ElbV2;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
@@ -75,7 +76,7 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
         // off, invalid headers passed through); bring our hardened attributes onto
         // it. The artefacts bucket access-logs policy is provisioned earlier in the
         // sync (Storage runs before Compute), so enabling access logs validates.
-        $this->reconcileAttributes($arn, current: []);
+        $this->reconcileAttributes($arn, current: [], apply: true);
     }
 
     public function synchroniseTags(): void
@@ -87,30 +88,35 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
      * Push the hardened attribute defaults onto an existing ALB. Tag sync doesn't
      * cover load-balancer attributes, so without this a changed default would never
      * reach an already-provisioned load balancer. Diffs first so a clean sync makes
-     * no needless write.
+     * no needless write, and returns the drifted attributes so sync can report them.
      */
-    public function synchroniseConfiguration(): void
+    public function synchroniseConfiguration(bool $apply = true): array
     {
         $arn = $this->arn();
 
-        $this->reconcileAttributes($arn, $this->currentAttributes($arn));
+        return $this->reconcileAttributes($arn, $this->currentAttributes($arn), $apply);
     }
 
     /**
-     * Batch every managed attribute into a single modifyLoadBalancerAttributes
-     * call, but only when at least one has drifted from the desired value.
+     * Batch every drifted attribute into a single modifyLoadBalancerAttributes
+     * call (only when something drifted and $apply is set), and return the diff
+     * as Change[] so the operator sees each current → desired comparison.
      *
      * @param  array<string, string>  $current  live attributes (empty on create)
+     * @return array<int, Change>
      */
-    protected function reconcileAttributes(string $arn, array $current): void
+    protected function reconcileAttributes(string $arn, array $current, bool $apply): array
     {
         $desired = $this->desiredAttributes();
 
-        $drifted = collect($desired)
-            ->contains(fn (string $value, string $key) => ($current[$key] ?? null) !== $value);
+        $changes = collect($desired)
+            ->filter(fn (string $value, string $key) => ($current[$key] ?? null) !== $value)
+            ->map(fn (string $value, string $key) => Change::make($key, $current[$key] ?? null, $value))
+            ->values()
+            ->all();
 
-        if (! $drifted) {
-            return;
+        if ($changes === [] || ! $apply) {
+            return $changes;
         }
 
         Aws::elasticLoadBalancingV2()->modifyLoadBalancerAttributes([
@@ -120,6 +126,8 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
                 ->values()
                 ->all(),
         ]);
+
+        return $changes;
     }
 
     /**

--- a/src/Resources/ElbV2/TargetGroup.php
+++ b/src/Resources/ElbV2/TargetGroup.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Resources\ElbV2;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\Enums\Scope;
@@ -57,7 +58,7 @@ class TargetGroup implements Resource, SynchronisesConfiguration
         ])['TargetGroups'][0]['TargetGroupArn'];
 
         // A fresh target group defaults to 300s deregistration; bring it to ours.
-        $this->reconcileDeregistrationDelay($arn);
+        $this->reconcileDeregistrationDelay($arn, apply: true);
     }
 
     public function synchroniseTags(): void
@@ -70,21 +71,25 @@ class TargetGroup implements Resource, SynchronisesConfiguration
      * and the deregistration delay. Create sets these once; without this a
      * changed default or manifest override would never reach an already-deployed
      * app, since tag sync doesn't cover them. Each reconcile diffs first so a
-     * clean sync makes no needless write. (The service grace period is a
-     * separate, service-level setting reconciled by EcsService.)
+     * clean sync makes no needless write, and returns the drifted attributes so
+     * sync can report each current → desired comparison. (The service grace
+     * period is a separate, service-level setting reconciled by EcsService.)
      */
-    public function synchroniseConfiguration(): void
+    public function synchroniseConfiguration(bool $apply = true): array
     {
         $live = ElbV2::targetGroup($this->name());
 
-        $this->reconcileHealthCheck($live);
-        $this->reconcileDeregistrationDelay($live['TargetGroupArn']);
+        return [
+            ...$this->reconcileHealthCheck($live, $apply),
+            ...$this->reconcileDeregistrationDelay($live['TargetGroupArn'], $apply),
+        ];
     }
 
     /**
      * @param  array<string, mixed>  $live
+     * @return array<int, Change>
      */
-    protected function reconcileHealthCheck(array $live): void
+    protected function reconcileHealthCheck(array $live, bool $apply): array
     {
         $desired = static::reconcilableHealthCheck();
 
@@ -97,14 +102,32 @@ class TargetGroup implements Resource, SynchronisesConfiguration
             'Matcher' => ['HttpCode' => $live['Matcher']['HttpCode'] ?? null],
         ];
 
-        if ($current == $desired) {
-            return;
+        $changes = [];
+
+        foreach ($desired as $key => $value) {
+            if ($key === 'Matcher') {
+                if (($current['Matcher']['HttpCode'] ?? null) !== ($value['HttpCode'] ?? null)) {
+                    $changes[] = Change::make('Matcher.HttpCode', $current['Matcher']['HttpCode'] ?? null, $value['HttpCode'] ?? null);
+                }
+
+                continue;
+            }
+
+            if (($current[$key] ?? null) !== $value) {
+                $changes[] = Change::make($key, $current[$key] ?? null, $value);
+            }
+        }
+
+        if ($changes === [] || ! $apply) {
+            return $changes;
         }
 
         Aws::elasticLoadBalancingV2()->modifyTargetGroup([
             'TargetGroupArn' => $live['TargetGroupArn'],
             ...$desired,
         ]);
+
+        return $changes;
     }
 
     /**
@@ -113,8 +136,10 @@ class TargetGroup implements Resource, SynchronisesConfiguration
      * any real request needs. Bump tasks.web.shutdown-grace-period for apps with genuinely
      * long in-flight requests (uploads, exports, SSE) — anything still in flight
      * when the timer elapses has its connection closed.
+     *
+     * @return array<int, Change>
      */
-    protected function reconcileDeregistrationDelay(string $arn): void
+    protected function reconcileDeregistrationDelay(string $arn, bool $apply): array
     {
         $desired = (string) $this->deregistrationDelay();
 
@@ -125,15 +150,19 @@ class TargetGroup implements Resource, SynchronisesConfiguration
         );
 
         if ($current === $desired) {
-            return;
+            return [];
         }
 
-        Aws::elasticLoadBalancingV2()->modifyTargetGroupAttributes([
-            'TargetGroupArn' => $arn,
-            'Attributes' => [
-                ['Key' => 'deregistration_delay.timeout_seconds', 'Value' => $desired],
-            ],
-        ]);
+        if ($apply) {
+            Aws::elasticLoadBalancingV2()->modifyTargetGroupAttributes([
+                'TargetGroupArn' => $arn,
+                'Attributes' => [
+                    ['Key' => 'deregistration_delay.timeout_seconds', 'Value' => $desired],
+                ],
+            ]);
+        }
+
+        return [Change::make('deregistration_delay.timeout_seconds', $current, $desired)];
     }
 
     public function deregistrationDelay(): int

--- a/src/Resources/EventBridge/IvsEventBridgeRule.php
+++ b/src/Resources/EventBridge/IvsEventBridgeRule.php
@@ -3,6 +3,8 @@
 namespace Codinglabs\Yolo\Resources\EventBridge;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Aws\EventBridge;
 use Codinglabs\Yolo\Resources\Resource;
@@ -56,9 +58,36 @@ class IvsEventBridgeRule implements Resource, SynchronisesConfiguration
         Aws::synchroniseEventBridgeTags($this->arn(), $this->tags());
     }
 
-    public function synchroniseConfiguration(): void
+    /**
+     * Reconcile the rule's event pattern, state and description, read-compared
+     * against the live rule so a clean sync makes no write and a dry-run reports
+     * the drift. Returns the drifted attributes as Change[].
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
     {
+        $live = EventBridge::rule($this->name());
+
+        $changes = [];
+
+        if (! Helpers::documentsEqual(json_decode($live['EventPattern'] ?? 'null', true), $this->eventPattern())) {
+            $changes[] = Change::make('event-pattern', $live['EventPattern'] ?? null, json_encode($this->eventPattern()));
+        }
+
+        if (($live['State'] ?? null) !== 'ENABLED') {
+            $changes[] = Change::make('state', $live['State'] ?? null, 'ENABLED');
+        }
+
+        if (($live['Description'] ?? null) !== $this->description()) {
+            $changes[] = Change::make('description', $live['Description'] ?? null, $this->description());
+        }
+
+        if ($changes === [] || ! $apply) {
+            return $changes;
+        }
+
         $this->putRule();
+
+        return $changes;
     }
 
     public function eventPattern(): array
@@ -66,11 +95,16 @@ class IvsEventBridgeRule implements Resource, SynchronisesConfiguration
         return ['source' => ['aws.ivs']];
     }
 
+    public function description(): string
+    {
+        return 'YOLO managed IVS state change events';
+    }
+
     protected function putRule(): void
     {
         Aws::eventBridge()->putRule([
             'Name' => $this->name(),
-            'Description' => 'YOLO managed IVS state change events',
+            'Description' => $this->description(),
             'EventPattern' => json_encode($this->eventPattern()),
             'State' => 'ENABLED',
         ]);

--- a/src/Resources/S3/AssetBucket.php
+++ b/src/Resources/S3/AssetBucket.php
@@ -4,6 +4,8 @@ namespace Codinglabs\Yolo\Resources\S3;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
@@ -86,23 +88,40 @@ class AssetBucket implements Resource, SynchronisesConfiguration
     /**
      * Allow any origin to read the assets (GET/HEAD). They're public,
      * content-hashed build files behind CloudFront — `*` is correct and keeps
-     * the cached response origin-agnostic. Idempotent: a re-sync re-puts the
-     * same rule, so existing buckets pick it up without a re-create.
+     * the cached response origin-agnostic. Diffs the live CORS rules against the
+     * desired set first, so a clean sync makes no write and a dry-run reports the
+     * change; returns the drift as Change[].
      */
-    public function synchroniseConfiguration(): void
+    public function synchroniseConfiguration(bool $apply = true): array
     {
-        Aws::s3()->putBucketCors([
-            'Bucket' => $this->name(),
-            'CORSConfiguration' => [
-                'CORSRules' => [
-                    [
-                        'AllowedMethods' => ['GET', 'HEAD'],
-                        'AllowedOrigins' => ['*'],
-                        'AllowedHeaders' => ['*'],
-                        'MaxAgeSeconds' => 86400,
-                    ],
-                ],
+        $current = S3::bucketCors($this->name());
+
+        if (Helpers::documentsEqual($current, $this->corsRules())) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketCors([
+                'Bucket' => $this->name(),
+                'CORSConfiguration' => ['CORSRules' => $this->corsRules()],
+            ]);
+        }
+
+        return [Change::make('cors', $current === null ? null : 'present', 'GET,HEAD from *')];
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    protected function corsRules(): array
+    {
+        return [
+            [
+                'AllowedMethods' => ['GET', 'HEAD'],
+                'AllowedOrigins' => ['*'],
+                'AllowedHeaders' => ['*'],
+                'MaxAgeSeconds' => 86400,
             ],
-        ]);
+        ];
     }
 }

--- a/src/Resources/S3/S3ArtefactBucket.php
+++ b/src/Resources/S3/S3ArtefactBucket.php
@@ -5,6 +5,8 @@ namespace Codinglabs\Yolo\Resources\S3;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
@@ -68,24 +70,72 @@ class S3ArtefactBucket implements Resource, SynchronisesConfiguration
         ]);
     }
 
-    public function synchroniseConfiguration(): void
+    /**
+     * Reconcile Block Public Access, versioning and the ALB log-delivery policy,
+     * each read-compared-then-written so a clean sync is a no-op and a dry-run
+     * reports exactly what would change. Returns the drifted attributes as
+     * Change[].
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
     {
+        return [
+            ...$this->reconcilePublicAccessBlock($apply),
+            ...$this->reconcileVersioning($apply),
+            ...$this->reconcileAlbAccessLogDelivery($apply),
+        ];
+    }
+
+    /**
+     * @return array<int, Change>
+     */
+    protected function reconcilePublicAccessBlock(bool $apply): array
+    {
+        $desired = [
+            'BlockPublicAcls' => true,
+            'IgnorePublicAcls' => true,
+            'BlockPublicPolicy' => true,
+            'RestrictPublicBuckets' => true,
+        ];
+
+        $current = S3::publicAccessBlock($this->name());
+
+        $changes = collect($desired)
+            ->filter(fn (bool $value, string $key) => ($current[$key] ?? null) !== $value)
+            ->map(fn (bool $value, string $key) => Change::make("block-public-access.$key", $current[$key] ?? null, $value))
+            ->values()
+            ->all();
+
+        if ($changes === [] || ! $apply) {
+            return $changes;
+        }
+
         Aws::s3()->putPublicAccessBlock([
             'Bucket' => $this->name(),
-            'PublicAccessBlockConfiguration' => [
-                'BlockPublicAcls' => true,
-                'IgnorePublicAcls' => true,
-                'BlockPublicPolicy' => true,
-                'RestrictPublicBuckets' => true,
-            ],
+            'PublicAccessBlockConfiguration' => $desired,
         ]);
 
-        Aws::s3()->putBucketVersioning([
-            'Bucket' => $this->name(),
-            'VersioningConfiguration' => ['Status' => 'Enabled'],
-        ]);
+        return $changes;
+    }
 
-        $this->grantAlbAccessLogDelivery();
+    /**
+     * @return array<int, Change>
+     */
+    protected function reconcileVersioning(bool $apply): array
+    {
+        $current = S3::bucketVersioning($this->name());
+
+        if ($current === 'Enabled') {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketVersioning([
+                'Bucket' => $this->name(),
+                'VersioningConfiguration' => ['Status' => 'Enabled'],
+            ]);
+        }
+
+        return [Change::make('versioning', $current, 'Enabled')];
     }
 
     /**
@@ -99,37 +149,59 @@ class S3ArtefactBucket implements Resource, SynchronisesConfiguration
      * artefacts bucket; no customer-managed KMS key in play) rather than a
      * per-Region ELB account ID. SourceAccount + SourceArn scope the grant to this
      * account's load balancers, so it is never public and coexists with the
-     * bucket's BlockPublicPolicy. putBucketPolicy is a full replace and the
-     * artefacts bucket carries no other policy, so this is idempotent on re-sync.
+     * bucket's BlockPublicPolicy. The artefacts bucket carries no other policy, so
+     * a full-replace put is safe — but we diff against the live policy first so a
+     * clean sync makes no write and a dry-run can report the change.
+     *
+     * @return array<int, Change>
      */
-    protected function grantAlbAccessLogDelivery(): void
+    protected function reconcileAlbAccessLogDelivery(bool $apply): array
+    {
+        $desired = $this->albAccessLogDeliveryPolicy();
+        $current = S3::bucketPolicy($this->name());
+
+        if (Helpers::documentsEqual($current, $desired)) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketPolicy([
+                'Bucket' => $this->name(),
+                'Policy' => json_encode($desired),
+            ]);
+        }
+
+        return [Change::make('bucket-policy', $current === null ? null : 'present', 'alb-access-log-delivery')];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function albAccessLogDeliveryPolicy(): array
     {
         $accountId = Aws::accountId();
 
-        Aws::s3()->putBucketPolicy([
-            'Bucket' => $this->name(),
-            'Policy' => json_encode([
-                'Version' => '2012-10-17',
-                'Statement' => [
-                    [
-                        'Sid' => 'AllowELBAccessLogDelivery',
-                        'Effect' => 'Allow',
-                        'Principal' => ['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'],
-                        'Action' => 's3:PutObject',
-                        'Resource' => sprintf('arn:aws:s3:::%s/alb-access-logs/*', $this->name()),
-                        'Condition' => [
-                            'StringEquals' => ['aws:SourceAccount' => $accountId],
-                            'ArnLike' => [
-                                'aws:SourceArn' => sprintf(
-                                    'arn:aws:elasticloadbalancing:%s:%s:loadbalancer/*',
-                                    Manifest::get('aws.region'),
-                                    $accountId,
-                                ),
-                            ],
+        return [
+            'Version' => '2012-10-17',
+            'Statement' => [
+                [
+                    'Sid' => 'AllowELBAccessLogDelivery',
+                    'Effect' => 'Allow',
+                    'Principal' => ['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'],
+                    'Action' => 's3:PutObject',
+                    'Resource' => sprintf('arn:aws:s3:::%s/alb-access-logs/*', $this->name()),
+                    'Condition' => [
+                        'StringEquals' => ['aws:SourceAccount' => $accountId],
+                        'ArnLike' => [
+                            'aws:SourceArn' => sprintf(
+                                'arn:aws:elasticloadbalancing:%s:%s:loadbalancer/*',
+                                Manifest::get('aws.region'),
+                                $accountId,
+                            ),
                         ],
                     ],
                 ],
-            ]),
-        ]);
+            ],
+        ];
     }
 }

--- a/src/Resources/SynchronisesConfiguration.php
+++ b/src/Resources/SynchronisesConfiguration.php
@@ -2,14 +2,23 @@
 
 namespace Codinglabs\Yolo\Resources;
 
+use Codinglabs\Yolo\Change;
+
 /**
  * Optional Resource capability: reconcile live configuration (beyond tags) when
  * the resource already exists. The base Resource contract only guarantees tag
- * sync; resources whose config can drift after creation — currently just the
- * CloudFront distribution — implement this so `sync` pushes config changes onto
- * the existing resource instead of only fixing tags.
+ * sync; resources whose config can drift after creation implement this so `sync`
+ * pushes config changes onto the existing resource instead of only fixing tags.
+ *
+ * Every implementation reads live state and diffs it against desired, returning
+ * the attributes that differ as Change[] (empty = in sync). It applies the fix
+ * only when $apply is true — a dry-run passes false to compute the diff WITHOUT
+ * writing, which is how `sync --dry-run` reports what it would change.
  */
 interface SynchronisesConfiguration
 {
-    public function synchroniseConfiguration(): void;
+    /**
+     * @return array<int, Change>
+     */
+    public function synchroniseConfiguration(bool $apply = true): array;
 }

--- a/src/Steps/Sync/App/AttachDeployerRolePoliciesStep.php
+++ b/src/Steps/Sync/App/AttachDeployerRolePoliciesStep.php
@@ -2,31 +2,28 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
 use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
+use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
 
 class AttachDeployerRolePoliciesStep implements Step
 {
+    use AttachesRolePolicies;
+
     public function __invoke(array $options): StepResult
     {
         if (Helpers::githubRepository() === null) {
             return StepResult::SKIPPED;
         }
 
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        Aws::iam()->attachRolePolicy([
-            'RoleName' => (new DeployerRole())->name(),
-            'PolicyArn' => (new DeployerPolicy())->arn(),
-        ]);
-
-        return StepResult::SYNCED;
+        return $this->attachRolePolicies(
+            (new DeployerRole())->name(),
+            [$this->customerManagedPolicyArn((new DeployerPolicy())->name())],
+            (bool) Arr::get($options, 'dry-run'),
+        );
     }
 }

--- a/src/Steps/Sync/App/AttachMediaConvertRolePoliciesStep.php
+++ b/src/Steps/Sync/App/AttachMediaConvertRolePoliciesStep.php
@@ -2,15 +2,17 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
 use Codinglabs\Yolo\Resources\Iam\MediaConvertRole;
 
 class AttachMediaConvertRolePoliciesStep implements Step
 {
+    use AttachesRolePolicies;
+
     protected array $managedPolicies = [
         'arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess',
         'arn:aws:iam::aws:policy/AmazonS3FullAccess',
@@ -22,19 +24,10 @@ class AttachMediaConvertRolePoliciesStep implements Step
             return StepResult::SKIPPED;
         }
 
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        $roleName = (new MediaConvertRole())->name();
-
-        foreach ($this->managedPolicies as $policyArn) {
-            Aws::iam()->attachRolePolicy([
-                'RoleName' => $roleName,
-                'PolicyArn' => $policyArn,
-            ]);
-        }
-
-        return StepResult::SYNCED;
+        return $this->attachRolePolicies(
+            (new MediaConvertRole())->name(),
+            $this->managedPolicies,
+            (bool) Arr::get($options, 'dry-run'),
+        );
     }
 }

--- a/src/Steps/Sync/App/SyncEcsServiceStep.php
+++ b/src/Steps/Sync/App/SyncEcsServiceStep.php
@@ -18,7 +18,9 @@ class SyncEcsServiceStep implements Step
 
         // Task definition revision adoption is owned by `yolo deploy`, not sync —
         // sync reconciles only the slow-moving service-level knobs.
-        if ($service->exists() && $service->needsUpdate()) {
+        if ($service->exists() && ($changes = $service->pendingChanges()) !== []) {
+            $this->recordChanges($changes);
+
             if (Arr::get($options, 'dry-run')) {
                 return StepResult::WOULD_SYNC;
             }

--- a/src/Steps/Sync/App/SyncRdsSecurityGroupStep.php
+++ b/src/Steps/Sync/App/SyncRdsSecurityGroupStep.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
@@ -11,6 +12,7 @@ use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\Ec2\RdsSecurityGroup;
 use Codinglabs\Yolo\Resources\Ec2\EcsTaskSecurityGroup;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * Provisions the RDS security group and authorises the Fargate tasks to reach
@@ -35,10 +37,13 @@ class SyncRdsSecurityGroupStep implements Step
             return StepResult::CUSTOM_MANAGED;
         }
 
+        $dryRun = (bool) Arr::get($options, 'dry-run');
         $result = $this->syncResource($securityGroup, $options);
 
-        if ($securityGroup->exists()) {
-            $this->ensureTaskIngressRule($securityGroup->arn(), (bool) Arr::get($options, 'dry-run'));
+        if ($securityGroup->exists() && $this->reconcileTaskIngressRule($securityGroup->arn(), $dryRun) && $dryRun && $result === StepResult::SYNCED) {
+            // The group already exists but the ingress rule is missing, so a
+            // dry-run has a pending change to report rather than a clean SYNCED.
+            $result = StepResult::WOULD_SYNC;
         }
 
         return $result;
@@ -47,17 +52,21 @@ class SyncRdsSecurityGroupStep implements Step
     /**
      * Additively ensure a 3306-from-task-SG ingress rule exists, identified by its
      * content (AWS rejects duplicate permissions anyway, so no marker tag is
-     * needed). Never revokes, and a no-op under --dry-run.
+     * needed). Never revokes, records the change it makes, and writes nothing under
+     * --dry-run. Returns whether the rule is missing (a change is pending/applied).
      */
-    protected function ensureTaskIngressRule(string $groupId, bool $dryRun): void
+    protected function reconcileTaskIngressRule(string $groupId, bool $dryRun): bool
     {
-        if ($dryRun) {
-            return;
-        }
+        try {
+            // Name lookup throws ResourceDoesNotExistException if the task SG is
+            // missing — sync:compute provisions it before this step runs, but a
+            // dry-run on a fresh environment can reach here before it exists.
+            $taskSecurityGroupId = (new EcsTaskSecurityGroup())->arn();
+        } catch (ResourceDoesNotExistException) {
+            $this->recordChange(Change::make('ingress 3306/tcp from task security group', null, 'authorised (task SG pending)'));
 
-        // Name lookup throws ResourceDoesNotExistException if the task SG is
-        // missing — sync:compute provisions it before this step runs.
-        $taskSecurityGroupId = (new EcsTaskSecurityGroup())->arn();
+            return true;
+        }
 
         $alreadyAuthorised = collect(Ec2::securityGroupRules($groupId))->contains(
             fn (array $rule) => ! ($rule['IsEgress'] ?? false)
@@ -67,24 +76,30 @@ class SyncRdsSecurityGroupStep implements Step
         );
 
         if ($alreadyAuthorised) {
-            return;
+            return false;
         }
 
-        Aws::ec2()->authorizeSecurityGroupIngress([
-            'GroupId' => $groupId,
-            'IpPermissions' => [
-                [
-                    'IpProtocol' => 'tcp',
-                    'FromPort' => 3306,
-                    'ToPort' => 3306,
-                    'UserIdGroupPairs' => [
-                        [
-                            'GroupId' => $taskSecurityGroupId,
-                            'Description' => 'Enable Fargate tasks to connect to RDS',
+        $this->recordChange(Change::make('ingress 3306/tcp from task security group', null, $taskSecurityGroupId));
+
+        if (! $dryRun) {
+            Aws::ec2()->authorizeSecurityGroupIngress([
+                'GroupId' => $groupId,
+                'IpPermissions' => [
+                    [
+                        'IpProtocol' => 'tcp',
+                        'FromPort' => 3306,
+                        'ToPort' => 3306,
+                        'UserIdGroupPairs' => [
+                            [
+                                'GroupId' => $taskSecurityGroupId,
+                                'Description' => 'Enable Fargate tasks to connect to RDS',
+                            ],
                         ],
                     ],
                 ],
-            ],
-        ]);
+            ]);
+        }
+
+        return true;
     }
 }

--- a/src/Steps/Sync/App/SyncTaskLogGroupStep.php
+++ b/src/Steps/Sync/App/SyncTaskLogGroupStep.php
@@ -2,6 +2,7 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -16,7 +17,9 @@ class SyncTaskLogGroupStep implements Step
     {
         $logGroup = new TaskLogGroup();
 
-        if ($logGroup->exists() && $logGroup->currentRetentionInDays() !== $logGroup->retentionInDays()) {
+        if ($logGroup->exists() && ($current = $logGroup->currentRetentionInDays()) !== $logGroup->retentionInDays()) {
+            $this->recordChange(Change::make('retention-days', $current, $logGroup->retentionInDays()));
+
             if (Arr::get($options, 'dry-run')) {
                 return StepResult::WOULD_SYNC;
             }

--- a/src/Steps/Sync/Environment/AttachEcsExecutionRolePoliciesStep.php
+++ b/src/Steps/Sync/Environment/AttachEcsExecutionRolePoliciesStep.php
@@ -2,14 +2,16 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
-use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
 use Codinglabs\Yolo\Resources\Iam\EcsExecutionRole;
 
 class AttachEcsExecutionRolePoliciesStep implements Step
 {
+    use AttachesRolePolicies;
+
     /**
      * AWS-managed policy granting ECR image pull + CloudWatch Logs write — the
      * baseline an ECS agent needs to launch a Fargate task.
@@ -18,15 +20,10 @@ class AttachEcsExecutionRolePoliciesStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        Aws::iam()->attachRolePolicy([
-            'RoleName' => (new EcsExecutionRole())->name(),
-            'PolicyArn' => static::POLICY_ARN,
-        ]);
-
-        return StepResult::SYNCED;
+        return $this->attachRolePolicies(
+            (new EcsExecutionRole())->name(),
+            [static::POLICY_ARN],
+            (bool) Arr::get($options, 'dry-run'),
+        );
     }
 }

--- a/src/Steps/Sync/Environment/AttachEcsTaskRolePoliciesStep.php
+++ b/src/Steps/Sync/Environment/AttachEcsTaskRolePoliciesStep.php
@@ -2,26 +2,23 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
-use Codinglabs\Yolo\Aws;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskPolicy;
+use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
 
 class AttachEcsTaskRolePoliciesStep implements Step
 {
+    use AttachesRolePolicies;
+
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        Aws::iam()->attachRolePolicy([
-            'RoleName' => (new EcsTaskRole())->name(),
-            'PolicyArn' => (new EcsTaskPolicy())->arn(),
-        ]);
-
-        return StepResult::SYNCED;
+        return $this->attachRolePolicies(
+            (new EcsTaskRole())->name(),
+            [$this->customerManagedPolicyArn((new EcsTaskPolicy())->name())],
+            (bool) Arr::get($options, 'dry-run'),
+        );
     }
 }

--- a/src/Steps/Sync/Environment/SyncLoadBalancerSecurityGroupStep.php
+++ b/src/Steps/Sync/Environment/SyncLoadBalancerSecurityGroupStep.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Helpers;
@@ -50,42 +51,50 @@ class SyncLoadBalancerSecurityGroupStep implements Step
 
     protected function reconcileRules(string $groupId, bool $dryRun): StepResult
     {
+        $drifted = false;
+
         foreach ($this->expectedRules() as $tag => $expectedRule) {
+            $rule = $expectedRule($groupId);
+            $permission = $rule['IpPermissions'][0];
+            $label = sprintf('ingress %d/tcp from %s', $permission['FromPort'], $permission['IpRanges'][0]['CidrIp']);
+
             $liveRules = Ec2::securityGroupRules($groupId, $tag);
 
             if (empty($liveRules)) {
-                if ($dryRun) {
-                    return StepResult::OUT_OF_SYNC;
-                }
+                $drifted = true;
+                $this->recordChange(Change::make($label, null, 'authorised'));
 
-                Aws::ec2()->authorizeSecurityGroupIngress($expectedRule($groupId));
+                if (! $dryRun) {
+                    Aws::ec2()->authorizeSecurityGroupIngress($rule);
+                }
 
                 continue;
             }
 
-            $desired = static::mapRule($expectedRule($groupId)['IpPermissions'][0]);
+            $desired = static::mapRule($permission);
 
             if (Helpers::payloadHasDifferences($desired, $liveRules[0])) {
-                if ($dryRun) {
-                    return StepResult::OUT_OF_SYNC;
-                }
+                $drifted = true;
+                $this->recordChange(Change::make($label, 'drifted', 'reconciled'));
 
-                Aws::ec2()->modifySecurityGroupRules([
-                    'GroupId' => $groupId,
-                    'SecurityGroupRules' => [
-                        [
-                            'SecurityGroupRuleId' => $liveRules[0]['SecurityGroupRuleId'],
-                            'SecurityGroupRule' => [
-                                ...$desired,
-                                'Description' => $expectedRule($groupId)['IpPermissions'][0]['IpRanges'][0]['Description'],
+                if (! $dryRun) {
+                    Aws::ec2()->modifySecurityGroupRules([
+                        'GroupId' => $groupId,
+                        'SecurityGroupRules' => [
+                            [
+                                'SecurityGroupRuleId' => $liveRules[0]['SecurityGroupRuleId'],
+                                'SecurityGroupRule' => [
+                                    ...$desired,
+                                    'Description' => $permission['IpRanges'][0]['Description'],
+                                ],
                             ],
                         ],
-                    ],
-                ]);
+                    ]);
+                }
             }
         }
 
-        return StepResult::SYNCED;
+        return $drifted && $dryRun ? StepResult::WOULD_SYNC : StepResult::SYNCED;
     }
 
     /**

--- a/tests/Unit/ChangeTest.php
+++ b/tests/Unit/ChangeTest.php
@@ -1,0 +1,31 @@
+<?php
+
+use Codinglabs\Yolo\Change;
+
+it('formats scalar, bool, null and array values into display strings', function () {
+    expect(Change::make('count', 1, 2)->from)->toBe('1');
+    expect(Change::make('count', 1, 2)->to)->toBe('2');
+
+    $bool = Change::make('flag', false, true);
+    expect($bool->from)->toBe('false');
+    expect($bool->to)->toBe('true');
+
+    $absent = Change::make('versioning', null, 'Enabled');
+    expect($absent->from)->toBeNull();
+    expect($absent->to)->toBe('Enabled');
+
+    expect(Change::make('rules', ['a' => 1], ['a' => 2])->to)->toBe('{"a":2}');
+});
+
+it('keeps explicit string from/to for document-level comparisons', function () {
+    $change = new Change('bucket-policy', null, 'alb-access-log-delivery');
+
+    expect($change->attribute)->toBe('bucket-policy');
+    expect($change->from)->toBeNull();
+    expect($change->to)->toBe('alb-access-log-delivery');
+});
+
+it('renders a single-line comparison, marking an absent side', function () {
+    expect(Change::make('idle_timeout', 30, 60)->describe())->toBe('idle_timeout: 30 → 60');
+    expect(Change::make('versioning', null, 'Enabled')->describe())->toBe('versioning: <absent> → Enabled');
+});

--- a/tests/Unit/Concerns/RunDomainsRenderTest.php
+++ b/tests/Unit/Concerns/RunDomainsRenderTest.php
@@ -1,11 +1,14 @@
 <?php
 
+use Codinglabs\Yolo\Change;
+use Illuminate\Support\Arr;
 use Laravel\Prompts\Prompt;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Commands\SyncCommand;
 use Codinglabs\Yolo\Commands\SyncAppCommand;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
 
@@ -14,6 +17,19 @@ class RunDomainsFakeStep implements Step
     public function __invoke(array $options): StepResult
     {
         return StepResult::CREATED;
+    }
+}
+
+/** A step that reconciled (or, on a dry-run, would reconcile) one attribute. */
+class RunDomainsChangeStep implements Step
+{
+    use RecordsChanges;
+
+    public function __invoke(array $options): StepResult
+    {
+        $this->recordChange(Change::make('idle_timeout', 30, 60));
+
+        return Arr::get($options, 'dry-run') ? StepResult::WOULD_SYNC : StepResult::SYNCED;
     }
 }
 
@@ -78,4 +94,39 @@ it('auto-proceeds without a prompt when non-interactive', function () {
     );
 
     expect($output)->toContain('Synced testing');
+});
+
+it('reports each reconciled attribute under an applied-changes section', function () {
+    $output = runDomainsCapture(
+        ['Network' => [RunDomainsChangeStep::class]],
+        ['--no-progress' => true],
+    );
+
+    expect($output)
+        ->toContain('Changes applied')
+        ->toContain('idle_timeout')
+        ->toContain('30')
+        ->toContain('60');
+});
+
+it('frames the attribute changes as pending on a dry-run', function () {
+    $output = runDomainsCapture(
+        ['Network' => [RunDomainsChangeStep::class]],
+        ['--no-progress' => true, '--dry-run' => true],
+    );
+
+    expect($output)
+        ->toContain('Pending changes')
+        ->toContain('idle_timeout');
+});
+
+it('omits the changes section entirely when nothing drifted', function () {
+    $output = runDomainsCapture(
+        ['Network' => [RunDomainsFakeStep::class]],
+        ['--no-progress' => true],
+    );
+
+    expect($output)
+        ->not->toContain('Changes applied')
+        ->not->toContain('Pending changes');
 });

--- a/tests/Unit/Concerns/SynchronisesResourceTest.php
+++ b/tests/Unit/Concerns/SynchronisesResourceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+
+/** A Resource whose existence and config drift the test controls. */
+class FakeConfigResource implements Resource, SynchronisesConfiguration
+{
+    public ?bool $appliedWith = null;
+
+    public bool $tagsSynced = false;
+
+    public bool $created = false;
+
+    /** @param  array<int, Change>  $changes */
+    public function __construct(public bool $present, public array $changes = []) {}
+
+    public function name(): string
+    {
+        return 'fake';
+    }
+
+    public function scope(): Scope
+    {
+        return Scope::App;
+    }
+
+    public function tags(): array
+    {
+        return [];
+    }
+
+    public function exists(): bool
+    {
+        return $this->present;
+    }
+
+    public function arn(): string
+    {
+        return 'arn:fake';
+    }
+
+    public function create(): void
+    {
+        $this->created = true;
+    }
+
+    public function synchroniseTags(): void
+    {
+        $this->tagsSynced = true;
+    }
+
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $this->appliedWith = $apply;
+
+        return $this->changes;
+    }
+}
+
+class SyncFakeResourceStep implements Step
+{
+    use SynchronisesResource;
+
+    public function __construct(public Resource $resource) {}
+
+    public function __invoke(array $options): StepResult
+    {
+        return $this->syncResource($this->resource, $options);
+    }
+}
+
+it('reports a clean existing resource as SYNCED with no recorded changes', function () {
+    $resource = new FakeConfigResource(present: true, changes: []);
+    $step = new SyncFakeResourceStep($resource);
+
+    expect($step([]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBe([]);
+    expect($resource->tagsSynced)->toBeTrue();
+    expect($resource->appliedWith)->toBeTrue();
+});
+
+it('reports SYNCED and records the changes a real sync applied to a drifted resource', function () {
+    $change = Change::make('flag', false, true);
+    $resource = new FakeConfigResource(present: true, changes: [$change]);
+    $step = new SyncFakeResourceStep($resource);
+
+    expect($step([]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBe([$change]);
+    expect($resource->appliedWith)->toBeTrue();
+});
+
+it('reports WOULD_SYNC and records changes without applying them on a dry-run', function () {
+    $change = Change::make('flag', false, true);
+    $resource = new FakeConfigResource(present: true, changes: [$change]);
+    $step = new SyncFakeResourceStep($resource);
+
+    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($step->changes())->toBe([$change]);
+    // Diff computed (apply=false) but neither config nor tags were written.
+    expect($resource->appliedWith)->toBeFalse();
+    expect($resource->tagsSynced)->toBeFalse();
+});
+
+it('would-create an absent resource on a dry-run and creates it for real', function () {
+    expect((new SyncFakeResourceStep(new FakeConfigResource(present: false)))(['dry-run' => true]))
+        ->toBe(StepResult::WOULD_CREATE);
+
+    $resource = new FakeConfigResource(present: false);
+    expect((new SyncFakeResourceStep($resource))([]))->toBe(StepResult::CREATED);
+    expect($resource->created)->toBeTrue();
+});

--- a/tests/Unit/HelpersDocumentsEqualTest.php
+++ b/tests/Unit/HelpersDocumentsEqualTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use Codinglabs\Yolo\Helpers;
+
+it('treats documents equal regardless of object key ordering', function () {
+    $a = ['Version' => '2012-10-17', 'Statement' => [['Effect' => 'Allow', 'Action' => 's3:PutObject']]];
+    $b = ['Statement' => [['Action' => 's3:PutObject', 'Effect' => 'Allow']], 'Version' => '2012-10-17'];
+
+    expect(Helpers::documentsEqual($a, $b))->toBeTrue();
+});
+
+it('detects a genuine value difference', function () {
+    $a = ['Effect' => 'Allow'];
+    $b = ['Effect' => 'Deny'];
+
+    expect(Helpers::documentsEqual($a, $b))->toBeFalse();
+});
+
+it('keeps list order significant', function () {
+    expect(Helpers::documentsEqual(['Action' => ['a', 'b']], ['Action' => ['b', 'a']]))->toBeFalse();
+});
+
+it('treats a null (absent) document as unequal to a present one, and null equal to null', function () {
+    expect(Helpers::documentsEqual(null, ['x' => 1]))->toBeFalse();
+    expect(Helpers::documentsEqual(null, null))->toBeTrue();
+});

--- a/tests/Unit/Resources/EventBridge/IvsEventBridgeRuleTest.php
+++ b/tests/Unit/Resources/EventBridge/IvsEventBridgeRuleTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Aws\EventBridge\EventBridgeClient;
+use Codinglabs\Yolo\Resources\EventBridge\IvsEventBridgeRule;
+
+/**
+ * Bind an EventBridge client returning the supplied DescribeRule shape and
+ * recording every command name. Returns the recorder for `$recorder->calls`.
+ *
+ * @param  array<string, mixed>  $rule
+ */
+function bindRecordingEventBridgeClient(array $rule): object
+{
+    $recorder = new class($rule) extends MockHandler
+    {
+        /** @var array<int, string> */
+        public array $calls = [];
+
+        public function __construct(public array $rule) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = $cmd->getName();
+
+            return Create::promiseFor(match ($cmd->getName()) {
+                'DescribeRule' => new Result($this->rule),
+                default => new Result([]),
+            });
+        }
+    };
+
+    Helpers::app()->instance('eventBridge', new EventBridgeClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+function liveIvsRule(array $overrides = []): array
+{
+    return array_merge([
+        'Name' => 'yolo-testing-my-app-ivs-state-change',
+        'Arn' => 'arn:aws:events:ap-southeast-2:111111111111:rule/yolo-testing-my-app-ivs-state-change',
+        'EventPattern' => json_encode(['source' => ['aws.ivs']]),
+        'State' => 'ENABLED',
+        'Description' => 'YOLO managed IVS state change events',
+    ], $overrides);
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'ivs' => true],
+    ]);
+});
+
+it('returns no change and does not put the rule when it already matches', function () {
+    $recorder = bindRecordingEventBridgeClient(liveIvsRule());
+
+    expect((new IvsEventBridgeRule())->synchroniseConfiguration())->toBe([]);
+    expect($recorder->calls)->not->toContain('PutRule');
+});
+
+it('detects a state drift and re-puts the rule', function () {
+    $recorder = bindRecordingEventBridgeClient(liveIvsRule(['State' => 'DISABLED']));
+
+    $changes = (new IvsEventBridgeRule())->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->attribute)->toBe('state');
+    expect($changes[0]->from)->toBe('DISABLED');
+    expect($changes[0]->to)->toBe('ENABLED');
+    expect($recorder->calls)->toContain('PutRule');
+});
+
+it('ignores event-pattern key ordering but detects a real pattern change', function () {
+    // Same pattern, no drift.
+    $recorder = bindRecordingEventBridgeClient(liveIvsRule(['EventPattern' => json_encode(['source' => ['aws.ivs']])]));
+    expect((new IvsEventBridgeRule())->synchroniseConfiguration())->toBe([]);
+
+    // A genuinely different pattern is drift.
+    bindRecordingEventBridgeClient(liveIvsRule(['EventPattern' => json_encode(['source' => ['aws.s3']])]));
+    expect(collect((new IvsEventBridgeRule())->synchroniseConfiguration())->pluck('attribute'))->toContain('event-pattern');
+});
+
+it('computes the diff without writing under apply:false', function () {
+    $recorder = bindRecordingEventBridgeClient(liveIvsRule(['State' => 'DISABLED']));
+
+    expect((new IvsEventBridgeRule())->synchroniseConfiguration(apply: false))->toHaveCount(1);
+    expect($recorder->calls)->not->toContain('PutRule');
+});

--- a/tests/Unit/Resources/Fargate/LoadBalancerTest.php
+++ b/tests/Unit/Resources/Fargate/LoadBalancerTest.php
@@ -131,3 +131,30 @@ it('modifies the load balancer when a managed attribute has drifted', function (
     expect(collect($recorder->calls)->pluck('name'))->toContain('ModifyLoadBalancerAttributes');
     expect(modifiedAttributes($recorder->calls)['routing.http.drop_invalid_header_fields.enabled'])->toBe('true');
 });
+
+it('returns the drifted attribute as a current → desired change', function () {
+    bindRecordingLoadBalancerClient(syncedLoadBalancerAttributes(['idle_timeout.timeout_seconds' => '30']));
+
+    $changes = (new LoadBalancer())->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->attribute)->toBe('idle_timeout.timeout_seconds');
+    expect($changes[0]->from)->toBe('30');
+    expect($changes[0]->to)->toBe('60');
+});
+
+it('returns no changes when every managed attribute matches', function () {
+    bindRecordingLoadBalancerClient(syncedLoadBalancerAttributes());
+
+    expect((new LoadBalancer())->synchroniseConfiguration())->toBe([]);
+});
+
+it('computes the diff without writing under apply:false', function () {
+    $recorder = bindRecordingLoadBalancerClient(syncedLoadBalancerAttributes(['routing.http2.enabled' => 'false']));
+
+    $changes = (new LoadBalancer())->synchroniseConfiguration(apply: false);
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->attribute)->toBe('routing.http2.enabled');
+    expect(collect($recorder->calls)->pluck('name'))->not->toContain('ModifyLoadBalancerAttributes');
+});

--- a/tests/Unit/Resources/Fargate/TargetGroupTest.php
+++ b/tests/Unit/Resources/Fargate/TargetGroupTest.php
@@ -124,3 +124,37 @@ it('caps the deregistration delay when it is still on the AWS 300s default', fun
 
     expect($recorder->calls)->toContain('ModifyTargetGroupAttributes');
 });
+
+it('returns the drifted health-check field as a current → desired change', function () {
+    bindRecordingElbV2Client(liveTargetGroup(['HealthCheckIntervalSeconds' => 30]), deregistrationDelayAttributes('10'));
+
+    $change = collect((new TargetGroup())->synchroniseConfiguration())
+        ->firstWhere('attribute', 'HealthCheckIntervalSeconds');
+
+    expect($change)->not->toBeNull();
+    expect($change->from)->toBe('30');
+    expect($change->to)->toBe('10');
+});
+
+it('returns the deregistration delay as a change when on the AWS default', function () {
+    bindRecordingElbV2Client(liveTargetGroup(), deregistrationDelayAttributes('300'));
+
+    $change = collect((new TargetGroup())->synchroniseConfiguration())
+        ->firstWhere('attribute', 'deregistration_delay.timeout_seconds');
+
+    expect($change->from)->toBe('300');
+    expect($change->to)->toBe('10');
+});
+
+it('returns no changes when health-check and deregistration both match', function () {
+    bindRecordingElbV2Client(liveTargetGroup(), deregistrationDelayAttributes('10'));
+
+    expect((new TargetGroup())->synchroniseConfiguration())->toBe([]);
+});
+
+it('computes the diff without writing under apply:false', function () {
+    $recorder = bindRecordingElbV2Client(liveTargetGroup(['HealthCheckIntervalSeconds' => 30]), deregistrationDelayAttributes('10'));
+
+    expect((new TargetGroup())->synchroniseConfiguration(apply: false))->not->toBeEmpty();
+    expect($recorder->calls)->not->toContain('ModifyTargetGroup');
+});

--- a/tests/Unit/Resources/Logging/IvsLogGroupTest.php
+++ b/tests/Unit/Resources/Logging/IvsLogGroupTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+use Codinglabs\Yolo\Resources\CloudWatchLogs\IvsLogGroup;
+
+/**
+ * Bind a CloudWatch Logs client whose DescribeLogGroups returns one IVS log group
+ * with the supplied retention and whose DescribeResourcePolicies returns the
+ * supplied policies. Records command names for write assertions.
+ *
+ * @param  array<int, array<string, mixed>>  $resourcePolicies
+ */
+function bindRecordingCloudWatchLogsClient(?int $retentionInDays, array $resourcePolicies = []): object
+{
+    $recorder = new class($retentionInDays, $resourcePolicies) extends MockHandler
+    {
+        /** @var array<int, string> */
+        public array $calls = [];
+
+        public function __construct(public ?int $retentionInDays, public array $resourcePolicies) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = $cmd->getName();
+
+            return Create::promiseFor(match ($cmd->getName()) {
+                'DescribeLogGroups' => new Result(['logGroups' => [array_filter([
+                    'logGroupName' => '/aws/ivs/yolo-testing-my-app',
+                    'arn' => 'arn:aws:logs:ap-southeast-2:111111111111:log-group:/aws/ivs/yolo-testing-my-app',
+                    'retentionInDays' => $this->retentionInDays,
+                ], fn ($value) => $value !== null)]]),
+                'DescribeResourcePolicies' => new Result(['resourcePolicies' => $this->resourcePolicies]),
+                default => new Result([]),
+            });
+        }
+    };
+
+    Helpers::app()->instance('cloudWatchLogs', new CloudWatchLogsClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'ivs' => true],
+    ]);
+});
+
+it('reconciles retention and the eventbridge resource policy when both have drifted', function () {
+    $recorder = bindRecordingCloudWatchLogsClient(retentionInDays: 7, resourcePolicies: []);
+
+    $attributes = collect((new IvsLogGroup())->synchroniseConfiguration())->pluck('attribute');
+
+    expect($attributes)->toContain('retention-days')->toContain('eventbridge-resource-policy');
+    expect($recorder->calls)->toContain('PutRetentionPolicy')->toContain('PutResourcePolicy');
+});
+
+it('does not touch retention when it already matches the manifest default', function () {
+    // Retention matches (14), but the resource policy is absent — proving retention
+    // is diffed (not blindly re-put) while the missing policy is still reported.
+    $recorder = bindRecordingCloudWatchLogsClient(retentionInDays: 14, resourcePolicies: []);
+
+    $attributes = collect((new IvsLogGroup())->synchroniseConfiguration())->pluck('attribute');
+
+    expect($attributes)->not->toContain('retention-days')->toContain('eventbridge-resource-policy');
+    expect($recorder->calls)->not->toContain('PutRetentionPolicy');
+});
+
+it('computes the diff without writing under apply:false', function () {
+    $recorder = bindRecordingCloudWatchLogsClient(retentionInDays: 7, resourcePolicies: []);
+
+    expect((new IvsLogGroup())->synchroniseConfiguration(apply: false))->not->toBeEmpty();
+    expect($recorder->calls)
+        ->not->toContain('PutRetentionPolicy')
+        ->not->toContain('PutResourcePolicy');
+});

--- a/tests/Unit/Resources/Storage/AssetBucketTest.php
+++ b/tests/Unit/Resources/Storage/AssetBucketTest.php
@@ -1,7 +1,56 @@
 <?php
 
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\S3\S3Client;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
 use Codinglabs\Yolo\Resources\S3\AssetBucket;
 use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+
+/**
+ * Bind an S3 client whose calls are routed by command name and recorded so tests
+ * can assert which writes fired. Returns the recorder for `$recorder->calls`.
+ *
+ * @param  array<string, Result>  $byCommand
+ */
+function bindRecordingAssetS3Client(array $byCommand): object
+{
+    $recorder = new class($byCommand) extends MockHandler
+    {
+        /** @var array<int, string> */
+        public array $calls = [];
+
+        public function __construct(public array $byCommand) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = $cmd->getName();
+
+            return Create::promiseFor($this->byCommand[$cmd->getName()] ?? new Result());
+        }
+    };
+
+    Helpers::app()->instance('s3', new S3Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+function matchingCorsRules(): array
+{
+    return [[
+        'AllowedMethods' => ['GET', 'HEAD'],
+        'AllowedOrigins' => ['*'],
+        'AllowedHeaders' => ['*'],
+        'MaxAgeSeconds' => 86400,
+    ]];
+}
 
 beforeEach(function () {
     writeManifest([
@@ -23,4 +72,32 @@ it('tags the bucket with its name and app owner', function () {
 
 it('reconciles a CORS configuration so the origin serves Access-Control-Allow-Origin', function () {
     expect(new AssetBucket())->toBeInstanceOf(SynchronisesConfiguration::class);
+});
+
+it('returns no change and writes nothing when the CORS rules already match', function () {
+    $recorder = bindRecordingAssetS3Client(['GetBucketCors' => new Result(['CORSRules' => matchingCorsRules()])]);
+
+    expect((new AssetBucket())->synchroniseConfiguration())->toBe([]);
+    expect($recorder->calls)->not->toContain('PutBucketCors');
+});
+
+it('returns a cors change and puts the rules when they drift', function () {
+    $recorder = bindRecordingAssetS3Client([
+        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET'], 'AllowedOrigins' => ['https://example.com']]]]),
+    ]);
+
+    $changes = (new AssetBucket())->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->attribute)->toBe('cors');
+    expect($recorder->calls)->toContain('PutBucketCors');
+});
+
+it('computes the cors diff without writing under apply:false', function () {
+    $recorder = bindRecordingAssetS3Client([
+        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET']]]]),
+    ]);
+
+    expect((new AssetBucket())->synchroniseConfiguration(apply: false))->toHaveCount(1);
+    expect($recorder->calls)->not->toContain('PutBucketCors');
 });

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -141,14 +141,30 @@ it('creates the deployer role with the OIDC trust policy when absent', function 
     expect($create['args']['AssumeRolePolicyDocument'])->toContain('sts:AssumeRoleWithWebIdentity');
 });
 
-it('would-sync the policy attachment on a dry-run', function () {
+it('would-sync the policy attachment on a dry-run without attaching', function () {
     manifestWithDeployer();
 
     $captured = [];
+    // No AttachedPolicies returned → the deployer policy is not attached yet, so a
+    // dry-run reports the pending attachment but never calls AttachRolePolicy.
     bindRoutedIamClient([], $captured);
 
     expect((new AttachDeployerRolePoliciesStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
-    expect($captured)->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('AttachRolePolicy');
+});
+
+it('reports the policy attachment as synced when it is already attached', function () {
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListAttachedRolePolicies' => new Result(['AttachedPolicies' => [
+            ['PolicyName' => 'yolo-testing-my-app-deployer-policy', 'PolicyArn' => 'arn:aws:iam::111111111111:policy/yolo-testing-my-app-deployer-policy'],
+        ]]),
+    ], $captured);
+
+    expect((new AttachDeployerRolePoliciesStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('AttachRolePolicy');
 });
 
 it('attaches the deployer policy to the deployer role', function () {

--- a/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
+++ b/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
@@ -131,18 +131,21 @@ it('reconciles BPA, versioning and the yolo:app tag onto an existing artefact bu
     expect($tags['yolo:app'])->toBe('my-app');
 });
 
-it('does not mutate the artefact bucket during a dry-run', function () {
+it('reports drift but does not mutate the artefact bucket during a dry-run', function () {
     $captured = [];
 
     bindMockS3Client([
         'HeadBucket' => new Result(),   // exists
     ], $captured);
 
-    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    // The live config reads back empty here, so a dry-run sees drift (WOULD_SYNC)
+    // but writes nothing.
+    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
 
     $names = array_column($captured, 'name');
     expect($names)->not->toContain('PutPublicAccessBlock')
-        ->not->toContain('PutBucketVersioning');
+        ->not->toContain('PutBucketVersioning')
+        ->not->toContain('PutBucketPolicy');
 });
 
 it('blocks public access on a newly created app bucket', function () {
@@ -229,7 +232,7 @@ it('does not write the log-delivery policy during a dry-run', function () {
         'HeadBucket' => new Result(),   // exists
     ], $captured);
 
-    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
 
     expect(array_column($captured, 'name'))->not->toContain('PutBucketPolicy');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

The scope-first sync commands (`sync` / `sync:account` / `sync:environment` / `sync:app`) only ever reported a flat per-step verdict — you couldn't see *which* operations would run or which attributes were out of sync. Worse, `--dry-run` was quietly lying about drift.

- **Verbose, attribute-level output.** Every config-bearing step now diffs live state against desired and prints each `attribute: current → desired` under a **Changes** section — `Pending changes` on a dry-run, `Changes applied` on a real run. Clean resources stay silent so drift stands out.
- **Dry-run no longer lies.** Two bugs fixed: (1) `SynchronisesResource::syncResource()` never computed the config diff in dry-run, so an existing resource always reported `SYNCED` even when a real run would write; (2) the diff-first reconcilers (ALB attrs, target group, CloudFront, ECS service, log retention, SG ingress) computed the diff internally then threw it away. `synchroniseConfiguration()` is now `(bool $apply): array` — computes the diff even under `--dry-run` (apply=false, no writes) and returns `Change[]`.
- **True comparisons everywhere — no inconsistent blind puts.** The blind idempotent puts are converted to read-compare-write: S3 block-public-access / versioning / bucket-policy, asset-bucket CORS, the IVS EventBridge rule + log resource-policy, and the four IAM policy attaches. JSON documents (policies, event patterns) diff via a new key-order-independent `Helpers::documentsEqual`.
- **`StepResult` rationalised.** Dropped the orphan red `OUT_OF_SYNC` — its only two callers (LB security-group rules) now use yellow `WOULD_SYNC`, consistent with `WOULD_CREATE`.
- New `Change` value object + `RecordsChanges` / `AttachesRolePolicies` traits; `invokeStep` captures `$step->changes()` and `renderResults` prints them.

Sample output:

```
  Changes applied
  Network · Sync load balancer security group
    ingress 443/tcp from 0.0.0.0/0: absent → authorised
  Load balancer · Sync load balancer
    routing.http2.enabled: false → true
    idle_timeout.timeout_seconds: 30 → 60
```

**Is there anything the reviewer needs to know to deploy this?**

- **No behaviour change to what sync writes** — same create/modify calls, same conditions. This only surfaces the diffs that were already being computed (or converts a blind put into a diffed write that lands the identical result). A clean resource still makes zero writes.
- **Extra read calls per sync.** The converted reconcilers now make additional `Get*`/`List*` calls each sync (`getPublicAccessBlock`, `getBucketVersioning`, `getBucketPolicy`, `getBucketCors`, `describeResourcePolicies`, `describeRule`, `listAttachedRolePolicies`). Trivial at LP scale; first place to look if a huge multi-tenant sync ever feels slow.
- **Deployer policy needs the new read action.** The IAM attach steps now call `iam:ListAttachedRolePolicies` to diff before attaching — confirm the deployer/sync principal can read it (the role-sync principal already manages these roles, so it should). The wrapper treats a not-yet-created role (`NoSuchEntity`) as "nothing attached", so a fresh-env dry-run reports the attaches it would make without erroring.
- **Dry-run on an existing-but-drifted resource now reports `WOULD_SYNC`** where it previously said `SYNCED` — expected, and the whole point.
- Rebased onto the `Resources/`/`Steps/` reorg + `sync:platform` → `sync:environment` rename. 373 Pest / PHPStan / Pint green.

🤖 Generated with [Claude Code](https://claude.ai/code)