### PR TITLE
LPX-643: Fix cross-origin asset 503s — static CORS, drop Origin cache key, Cache-Control, error-caching 0

### DIFF
--- a/src/Aws/CloudFront.php
+++ b/src/Aws/CloudFront.php
@@ -33,26 +33,26 @@ class CloudFront
         throw new ResourceDoesNotExistException("Could not find CloudFront distribution with comment $comment");
     }
 
-    public static function cachePolicyByName(string $name): array
+    public static function responseHeadersPolicyByName(string $name): array
     {
         $marker = null;
 
         do {
-            $list = Aws::cloudFront()->listCachePolicies([
+            $list = Aws::cloudFront()->listResponseHeadersPolicies([
                 'Type' => 'custom',
                 ...$marker ? ['Marker' => $marker] : [],
-            ])['CachePolicyList'];
+            ])['ResponseHeadersPolicyList'];
 
             foreach ($list['Items'] ?? [] as $item) {
-                if (($item['CachePolicy']['CachePolicyConfig']['Name'] ?? null) === $name) {
-                    return $item['CachePolicy'];
+                if (($item['ResponseHeadersPolicy']['ResponseHeadersPolicyConfig']['Name'] ?? null) === $name) {
+                    return $item['ResponseHeadersPolicy'];
                 }
             }
 
             $marker = ($list['IsTruncated'] ?? false) ? $list['NextMarker'] : null;
         } while ($marker);
 
-        throw new ResourceDoesNotExistException("Could not find cache policy with name $name");
+        throw new ResourceDoesNotExistException("Could not find response headers policy with name $name");
     }
 
     public static function originAccessControlByName(string $name): array

--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -25,6 +25,14 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * `builds/*` -> S3 and everything-else -> ALB would hijack any app that has its
  * own `/builds` route. The keyed name is stamped into the distribution's
  * Comment (and the OAC's Name) for lookup, and surfaced as the `Name` tag.
+ *
+ * CORS for cross-origin module imports (the app is on the ALB domain, assets on
+ * this distribution) is owned entirely by a response-headers policy that stamps
+ * a static `Access-Control-Allow-Origin: *` on every response. The cache key
+ * carries no request headers, so there is one cache entry per object for every
+ * viewer — no Vary: Origin split, and a transient origin 5xx is never cached
+ * (ErrorCachingMinTTL 0) against the immutable, content-hashed paths it would
+ * otherwise poison until the next deploy. See the constants below.
  */
 class AssetDistribution implements Resource, SynchronisesConfiguration
 {
@@ -32,26 +40,37 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
 
     protected const ORIGIN_ID = 'asset-bucket';
 
-    // Custom cache policy: like CachingOptimized but with `Origin` in the cache
-    // key. S3 only returns Access-Control-Allow-Origin when a request carries
-    // Origin, so a no-Origin request (CloudFront's own compression fetch, a
-    // preload, a bot) would otherwise cache a header-less copy that Origin-
-    // bearing browser requests then hit. Keying on Origin caches the with-CORS
-    // and without-CORS variants separately, so browsers can't be served a
-    // poisoned entry. No managed cache policy includes Origin, hence a custom.
-    protected const CACHE_POLICY_NAME = 'yolo-asset-cors';
+    // AWS managed "CachingOptimized". No request headers in the cache key (gzip
+    // /brotli only), so there is a single cache entry per object regardless of
+    // the viewer's Origin. The previous custom "Origin in the key" policy split
+    // the cache into with-CORS / without-CORS variants; the browser-only variant
+    // was sparsely warmed and a transient origin 503 cached against it broke
+    // every cross-origin import() until the next deploy. One entry can't drift
+    // apart like that. Same TTLs as the old custom policy (1 / 86400 / 31536000).
+    protected const CACHE_POLICY_ID = '658327ea-f89d-4fab-a63d-7e88639e58f6';
 
-    // AWS managed "CORS-S3Origin" origin-request policy. Forwards the viewer
-    // Origin header (+ Access-Control-Request-*) to S3 so the bucket's own CORS
-    // config returns Access-Control-Allow-Origin. CloudFront then caches and
-    // serves that as a normal origin header on every path — unlike a
-    // response-headers-policy CORS header, which CloudFront silently omits on
-    // the revalidation it forces for `Cache-Control: no-cache` / `max-age=0`
-    // (reloads, DevTools "Disable cache"). Empty ResponseHeadersPolicyId: the
-    // origin now owns CORS, and a second source would emit a duplicate header.
-    protected const ORIGIN_REQUEST_POLICY_ID = '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf';
+    // No origin-request policy: the viewer Origin header is no longer forwarded
+    // to S3, so S3 never runs its bucket CORS and never emits its own
+    // Access-Control-Allow-Origin. CORS is owned solely by the response-headers
+    // policy below — one unconditional header, no second source to double up,
+    // and nothing Origin-dependent reaching the origin to force a Vary.
+    protected const ORIGIN_REQUEST_POLICY_ID = '';
 
-    protected const RESPONSE_HEADERS_POLICY_ID = '';
+    // Custom response-headers policy that stamps a static
+    // `Access-Control-Allow-Origin: *` on EVERY response via a custom header —
+    // not a managed CORS policy. A managed CORS policy only adds the header when
+    // the request carries Origin, and CloudFront drops it on the revalidation it
+    // forces for `Cache-Control: no-cache` / `max-age=0` (reloads, DevTools
+    // "Disable cache"); a custom header is unconditional and survives that.
+    // Account-scoped and generic, so every YOLO asset distribution shares the one
+    // policy — looked up by name like the OAC.
+    protected const RESPONSE_HEADERS_POLICY_NAME = 'yolo-asset-headers';
+
+    // Build assets live under a per-deploy `builds/{version}/` prefix (ASSET_URL
+    // carries the version), so every object is immutable — a new deploy is a new
+    // URL, never an overwrite. A transient origin 5xx must therefore never be
+    // cached against these paths: the poisoned entry would never self-bust.
+    protected const ERROR_CODES_NOT_CACHED = [500, 502, 503, 504];
 
     public function name(): string
     {
@@ -88,10 +107,11 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
     {
         $bucket = new AssetBucket();
         $oacId = $this->ensureOriginAccessControl();
+        $responseHeadersPolicyId = $this->ensureResponseHeadersPolicy();
 
         $distribution = Aws::cloudFront()->createDistributionWithTags([
             'DistributionConfigWithTags' => [
-                'DistributionConfig' => $this->distributionConfig($bucket, $oacId),
+                'DistributionConfig' => $this->distributionConfig($bucket, $oacId, $responseHeadersPolicyId),
                 'Tags' => [
                     'Items' => collect(Aws::expectedTags($this->tags()))
                         ->map(fn ($value, $key) => ['Key' => $key, 'Value' => $value])
@@ -119,14 +139,15 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
     }
 
     /**
-     * Push managed cache-behaviour config onto an existing distribution. Tags
-     * alone don't cover config changes (e.g. swapping a distribution to the
-     * CORS-S3Origin origin-request policy after it was created), so sync
-     * reconciles the behaviour fields we own. CloudFront updates trigger a full
-     * edge redeploy (~15 min), so we only call updateDistribution when a managed
-     * field has drifted, and we return the drifted fields so sync can report each
-     * current → desired comparison. A dry-run ($apply false) never creates the
-     * cache policy and never calls updateDistribution.
+     * Push managed config onto an existing distribution. Tags alone don't cover
+     * config changes, so sync reconciles the fields we own: the cache-behaviour
+     * policy IDs (swapping a distribution off the old Origin-keyed cache policy
+     * onto CachingOptimized + the static-CORS response-headers policy) and the
+     * 5xx error-caching rules. CloudFront updates trigger a full edge redeploy
+     * (~15 min), so updateDistribution only fires when a field has drifted, and
+     * the drifted fields are returned so sync can report each current → desired
+     * comparison. A dry-run ($apply false) never creates the response-headers
+     * policy and never calls updateDistribution.
      */
     public function synchroniseConfiguration(bool $apply = true): array
     {
@@ -136,7 +157,7 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
         $config = (array) $response['DistributionConfig'];
         $behaviour = (array) $config['DefaultCacheBehavior'];
 
-        $desired = static::reconcilableBehaviour($this->resolveCachePolicyId($apply));
+        $desired = static::reconcilableBehaviour($this->resolveResponseHeadersPolicyId($apply));
 
         $changes = collect($desired)
             ->filter(fn (mixed $value, string $key) => ($behaviour[$key] ?? null) !== $value)
@@ -144,11 +165,16 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
             ->values()
             ->all();
 
+        if ($errorChange = static::errorCachingDrift((array) ($config['CustomErrorResponses'] ?? []))) {
+            $changes[] = $errorChange;
+        }
+
         if ($changes === [] || ! $apply) {
             return $changes;
         }
 
         $config['DefaultCacheBehavior'] = array_merge($behaviour, $desired);
+        $config['CustomErrorResponses'] = static::customErrorResponses();
 
         Aws::cloudFront()->updateDistribution([
             'Id' => $id,
@@ -160,21 +186,6 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
     }
 
     /**
-     * The cache policy id for diffing. An existing distribution was created with
-     * the policy already in place, so the lookup all but always resolves; the
-     * dry-run fallback ('(pending …)') only shows if it were somehow missing, and
-     * never creates the policy as a side effect of a read-only --dry-run.
-     */
-    protected function resolveCachePolicyId(bool $apply): string
-    {
-        try {
-            return CloudFront::cachePolicyByName(static::CACHE_POLICY_NAME)['Id'];
-        } catch (ResourceDoesNotExistException) {
-            return $apply ? $this->ensureCachePolicy() : sprintf('(pending: %s)', static::CACHE_POLICY_NAME);
-        }
-    }
-
-    /**
      * The cache-behaviour fields sync keeps current on an existing distribution.
      * Scalars only — the policy IDs are the realistic drift surface; nested
      * blocks like AllowedMethods are set once at create and comparing them risks
@@ -182,46 +193,103 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
      *
      * @return array<string, mixed>
      */
-    public static function reconcilableBehaviour(string $cachePolicyId): array
+    public static function reconcilableBehaviour(string $responseHeadersPolicyId): array
     {
         return [
             'ViewerProtocolPolicy' => 'redirect-to-https',
             'Compress' => true,
-            'CachePolicyId' => $cachePolicyId,
+            'CachePolicyId' => static::CACHE_POLICY_ID,
             'OriginRequestPolicyId' => static::ORIGIN_REQUEST_POLICY_ID,
-            'ResponseHeadersPolicyId' => static::RESPONSE_HEADERS_POLICY_ID,
+            'ResponseHeadersPolicyId' => $responseHeadersPolicyId,
         ];
     }
 
     /**
-     * Resolve the custom cache policy (Origin in the cache key), creating it
-     * once if absent. Account-scoped and generic, so every YOLO asset
-     * distribution shares the one policy — looked up by name like the OAC.
+     * The 5xx error-caching rules. ErrorCachingMinTTL 0 means a transient origin
+     * blip is never cached, so the next request retries the origin and self-heals
+     * rather than pinning a broken entry against an immutable asset path.
+     *
+     * @return array{Quantity: int, Items: array<int, array{ErrorCode: int, ErrorCachingMinTTL: int}>}
      */
-    protected function ensureCachePolicy(): string
+    public static function customErrorResponses(): array
+    {
+        return [
+            'Quantity' => count(static::ERROR_CODES_NOT_CACHED),
+            'Items' => array_map(fn (int $code) => [
+                'ErrorCode' => $code,
+                'ErrorCachingMinTTL' => 0,
+            ], static::ERROR_CODES_NOT_CACHED),
+        ];
+    }
+
+    /**
+     * Whether the live CustomErrorResponses already pin every tracked 5xx to a
+     * 0s cache TTL. Compared by code → TTL only (not the whole block) so AWS's
+     * default ResponseCode/ResponsePagePath fields and item ordering can't read
+     * as false drift and force a needless redeploy. Returns null when already in
+     * sync, otherwise a Change with a semantic label rather than a JSON dump.
+     */
+    public static function errorCachingDrift(array $live): ?Change
+    {
+        $cached = collect($live['Items'] ?? [])
+            ->mapWithKeys(fn (array $item) => [(int) $item['ErrorCode'] => (int) $item['ErrorCachingMinTTL']]);
+
+        $pinned = collect(static::ERROR_CODES_NOT_CACHED)
+            ->every(fn (int $code) => $cached->get($code) === 0);
+
+        if ($pinned) {
+            return null;
+        }
+
+        return new Change(
+            'CustomErrorResponses',
+            $cached->isEmpty() ? 'unset (CloudFront default ~10s)' : 'caches some 5xx',
+            sprintf('TTL 0 for %s', collect(static::ERROR_CODES_NOT_CACHED)->implode('/')),
+        );
+    }
+
+    /**
+     * The response-headers policy id for diffing. An existing distribution was
+     * created with the policy already in place, so the lookup all but always
+     * resolves; the dry-run fallback ('(pending …)') only shows if it were
+     * somehow missing, and never creates the policy as a side effect of a
+     * read-only --dry-run.
+     */
+    protected function resolveResponseHeadersPolicyId(bool $apply): string
     {
         try {
-            return CloudFront::cachePolicyByName(static::CACHE_POLICY_NAME)['Id'];
+            return CloudFront::responseHeadersPolicyByName(static::RESPONSE_HEADERS_POLICY_NAME)['Id'];
         } catch (ResourceDoesNotExistException) {
-            return Aws::cloudFront()->createCachePolicy([
-                'CachePolicyConfig' => [
-                    'Name' => static::CACHE_POLICY_NAME,
-                    'Comment' => 'YOLO build assets — Origin in cache key for CORS',
-                    'MinTTL' => 1,
-                    'DefaultTTL' => 86400,
-                    'MaxTTL' => 31536000,
-                    'ParametersInCacheKeyAndForwardedToOrigin' => [
-                        'EnableAcceptEncodingGzip' => true,
-                        'EnableAcceptEncodingBrotli' => true,
-                        'HeadersConfig' => [
-                            'HeaderBehavior' => 'whitelist',
-                            'Headers' => ['Quantity' => 1, 'Items' => ['Origin']],
+            return $apply ? $this->ensureResponseHeadersPolicy() : sprintf('(pending: %s)', static::RESPONSE_HEADERS_POLICY_NAME);
+        }
+    }
+
+    /**
+     * Resolve the custom response-headers policy (static ACAO), creating it once
+     * if absent. Account-scoped and generic, so every YOLO asset distribution
+     * shares the one policy — looked up by name like the OAC.
+     */
+    protected function ensureResponseHeadersPolicy(): string
+    {
+        try {
+            return CloudFront::responseHeadersPolicyByName(static::RESPONSE_HEADERS_POLICY_NAME)['Id'];
+        } catch (ResourceDoesNotExistException) {
+            return Aws::cloudFront()->createResponseHeadersPolicy([
+                'ResponseHeadersPolicyConfig' => [
+                    'Name' => static::RESPONSE_HEADERS_POLICY_NAME,
+                    'Comment' => 'YOLO build assets — static Access-Control-Allow-Origin: * on every response',
+                    'CustomHeadersConfig' => [
+                        'Quantity' => 1,
+                        'Items' => [
+                            [
+                                'Header' => 'Access-Control-Allow-Origin',
+                                'Value' => '*',
+                                'Override' => true,
+                            ],
                         ],
-                        'CookiesConfig' => ['CookieBehavior' => 'none'],
-                        'QueryStringsConfig' => ['QueryStringBehavior' => 'none'],
                     ],
                 ],
-            ])['CachePolicy']['Id'];
+            ])['ResponseHeadersPolicy']['Id'];
         }
     }
 
@@ -241,7 +309,7 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
         }
     }
 
-    protected function distributionConfig(AssetBucket $bucket, string $originAccessControlId): array
+    protected function distributionConfig(AssetBucket $bucket, string $originAccessControlId, string $responseHeadersPolicyId): array
     {
         return [
             'CallerReference' => (string) Str::uuid(),
@@ -262,7 +330,7 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
             ],
             'DefaultCacheBehavior' => [
                 'TargetOriginId' => static::ORIGIN_ID,
-                ...static::reconcilableBehaviour($this->ensureCachePolicy()),
+                ...static::reconcilableBehaviour($responseHeadersPolicyId),
                 'AllowedMethods' => [
                     'Quantity' => 2,
                     'Items' => ['GET', 'HEAD'],
@@ -272,6 +340,7 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
                     ],
                 ],
             ],
+            'CustomErrorResponses' => static::customErrorResponses(),
         ];
     }
 

--- a/src/Resources/S3/AssetBucket.php
+++ b/src/Resources/S3/AssetBucket.php
@@ -5,7 +5,6 @@ namespace Codinglabs\Yolo\Resources\S3;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\S3;
 use Codinglabs\Yolo\Change;
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
@@ -18,13 +17,14 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * Access Control, never directly from the internet. Kept separate from the app
  * data bucket so there is never private data to accidentally expose.
  *
- * The bucket carries its own CORS configuration so it returns
- * Access-Control-Allow-Origin itself. CloudFront forwards the viewer Origin
- * header (the CORS-S3Origin origin-request policy) and serves S3's CORS header
- * as a normal cached response header — present on every request path, including
- * the revalidation CloudFront forces on `Cache-Control: no-cache` / `max-age=0`
- * (reloads, DevTools "Disable cache"), where a response-headers-policy CORS
- * header is silently dropped.
+ * The bucket deliberately carries NO CORS configuration. CORS for the
+ * cross-origin module imports is owned entirely by the distribution's
+ * response-headers policy (a static Access-Control-Allow-Origin: * on every
+ * response); the viewer Origin header is not forwarded to S3, so the bucket
+ * never needs its own rules. A CORS config here would be dead weight and a live
+ * foot-gun — if Origin forwarding were ever reintroduced, S3 would emit a second
+ * Access-Control-Allow-Origin and browsers reject duplicate headers. Sync
+ * enforces the absence: any CORS config found on the bucket is removed.
  */
 class AssetBucket implements Resource, SynchronisesConfiguration
 {
@@ -74,7 +74,6 @@ class AssetBucket implements Resource, SynchronisesConfiguration
         ]);
 
         $this->synchroniseTags();
-        $this->synchroniseConfiguration();
     }
 
     public function synchroniseTags(): void
@@ -86,42 +85,21 @@ class AssetBucket implements Resource, SynchronisesConfiguration
     }
 
     /**
-     * Allow any origin to read the assets (GET/HEAD). They're public,
-     * content-hashed build files behind CloudFront — `*` is correct and keeps
-     * the cached response origin-agnostic. Diffs the live CORS rules against the
-     * desired set first, so a clean sync makes no write and a dry-run reports the
-     * change; returns the drift as Change[].
+     * Enforce that the bucket carries no CORS configuration — CORS is owned by
+     * the distribution's response-headers policy. Checks the live config first so
+     * a clean sync writes nothing and a dry-run reports the removal; returns the
+     * drift as Change[].
      */
     public function synchroniseConfiguration(bool $apply = true): array
     {
-        $current = S3::bucketCors($this->name());
-
-        if (Helpers::documentsEqual($current, $this->corsRules())) {
+        if (S3::bucketCors($this->name()) === null) {
             return [];
         }
 
         if ($apply) {
-            Aws::s3()->putBucketCors([
-                'Bucket' => $this->name(),
-                'CORSConfiguration' => ['CORSRules' => $this->corsRules()],
-            ]);
+            Aws::s3()->deleteBucketCors(['Bucket' => $this->name()]);
         }
 
-        return [Change::make('cors', $current === null ? null : 'present', 'GET,HEAD from *')];
-    }
-
-    /**
-     * @return array<int, array<string, mixed>>
-     */
-    protected function corsRules(): array
-    {
-        return [
-            [
-                'AllowedMethods' => ['GET', 'HEAD'],
-                'AllowedOrigins' => ['*'],
-                'AllowedHeaders' => ['*'],
-                'MaxAgeSeconds' => 86400,
-            ],
-        ];
+        return [Change::make('cors', 'present', 'removed (owned by the distribution)')];
     }
 }

--- a/src/Steps/Deploy/PushAssetsToS3Step.php
+++ b/src/Steps/Deploy/PushAssetsToS3Step.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Steps\Deploy;
 
 use Aws\S3\Transfer;
 use Codinglabs\Yolo\Aws;
+use Aws\CommandInterface;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -19,10 +20,16 @@ use Codinglabs\Yolo\Resources\S3\AssetBucket;
  * icons. Uploading only `public/build` left those 403ing (ORB-blocked in the
  * browser). No public-read ACLs — the bucket is reachable only via the
  * distribution (OAC); the Transfer manager sets per-file Content-Type from the
- * extension.
+ * extension, and `applyCacheControl` stamps the immutable Cache-Control.
  */
 class PushAssetsToS3Step implements Step
 {
+    // Objects live under a per-deploy `builds/{version}/` prefix (ASSET_URL
+    // carries the version), so every upload is a brand-new immutable URL — a
+    // year-long immutable cache-control is always safe and keeps the CDN + the
+    // browser hot, shrinking the cold-miss window the distribution has to ride.
+    public const CACHE_CONTROL = 'public, max-age=31536000, immutable';
+
     public function __construct(
         protected string $environment,
         protected $filesystem = new Filesystem()
@@ -37,10 +44,22 @@ class PushAssetsToS3Step implements Step
             client: Aws::s3(),
             source: static::uploadableFiles($public),
             dest: sprintf('s3://%s/builds/%s', (new AssetBucket())->name(), $appVersion),
-            options: ['base_dir' => $public],
+            options: ['base_dir' => $public, 'before' => static::applyCacheControl(...)],
         ))->transfer();
 
         return StepResult::SUCCESS;
+    }
+
+    /**
+     * Transfer `before` hook: stamp the immutable Cache-Control onto each object
+     * as it's uploaded. Guarded to the upload commands so it's a no-op if the
+     * Transfer manager ever issues anything else.
+     */
+    public static function applyCacheControl(CommandInterface $command): void
+    {
+        if (in_array($command->getName(), ['PutObject', 'CreateMultipartUpload'], true)) {
+            $command['CacheControl'] = static::CACHE_CONTROL;
+        }
     }
 
     /**

--- a/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
+++ b/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
@@ -37,14 +37,15 @@ it('reports not-exists when no distribution matches its comment', function () {
 });
 
 it('reconciles the managed cache-behaviour policy fields', function () {
-    $behaviour = AssetDistribution::reconcilableBehaviour('cp-resolved-id');
+    $behaviour = AssetDistribution::reconcilableBehaviour('rhp-resolved-id');
 
-    // CORS is served by the S3 origin (CORS-S3Origin origin-request policy
-    // forwards Origin); no response-headers policy, so ACAO can't double up.
-    expect($behaviour['OriginRequestPolicyId'])->toBe('88a5eaf4-2fd4-4709-b370-b4c650ea3fcf');
-    expect($behaviour['ResponseHeadersPolicyId'])->toBe('');
-    // The custom Origin-in-key cache policy, resolved at sync time.
-    expect($behaviour['CachePolicyId'])->toBe('cp-resolved-id');
+    // CORS is served by a static Access-Control-Allow-Origin: * on the
+    // response-headers policy, so no Origin reaches the origin and no Origin is
+    // in the cache key — managed CachingOptimized, no origin-request policy.
+    expect($behaviour['CachePolicyId'])->toBe('658327ea-f89d-4fab-a63d-7e88639e58f6');
+    expect($behaviour['OriginRequestPolicyId'])->toBe('');
+    // The custom static-CORS response-headers policy, resolved at sync time.
+    expect($behaviour['ResponseHeadersPolicyId'])->toBe('rhp-resolved-id');
     expect($behaviour['ViewerProtocolPolicy'])->toBe('redirect-to-https');
     expect($behaviour['Compress'])->toBeTrue();
 });
@@ -54,27 +55,57 @@ it('sees no drift when the live behaviour already carries the managed fields', f
         'TargetOriginId' => 'asset-bucket',
         'ViewerProtocolPolicy' => 'redirect-to-https',
         'Compress' => true,
-        'CachePolicyId' => 'cp-resolved-id',
+        'CachePolicyId' => '658327ea-f89d-4fab-a63d-7e88639e58f6',
+        'OriginRequestPolicyId' => '',
+        'ResponseHeadersPolicyId' => 'rhp-resolved-id',
+        'MinTTL' => 0,
+    ];
+
+    // No update should fire — merging the managed fields leaves the block unchanged.
+    expect(array_merge($live, AssetDistribution::reconcilableBehaviour('rhp-resolved-id')) == $live)->toBeTrue();
+});
+
+it('sees drift on a distribution still using the Origin-keyed cache policy', function () {
+    // Shape of the live CL distribution before the fix: custom Origin-in-key
+    // cache policy, CORS-S3Origin origin-request policy forwarding Origin, no
+    // response-headers policy. Reconciling must flip all three.
+    $preFix = [
+        'TargetOriginId' => 'asset-bucket',
+        'ViewerProtocolPolicy' => 'redirect-to-https',
+        'Compress' => true,
+        'CachePolicyId' => 'custom-origin-keyed-id',
         'OriginRequestPolicyId' => '88a5eaf4-2fd4-4709-b370-b4c650ea3fcf',
         'ResponseHeadersPolicyId' => '',
         'MinTTL' => 0,
     ];
 
-    // No update should fire — merging the managed fields leaves the block unchanged.
-    expect(array_merge($live, AssetDistribution::reconcilableBehaviour('cp-resolved-id')) == $live)->toBeTrue();
+    expect(array_merge($preFix, AssetDistribution::reconcilableBehaviour('rhp-resolved-id')) == $preFix)->toBeFalse();
 });
 
-it('sees drift on a distribution still using the response-headers CORS policy', function () {
-    // Shape of the live CL distribution before the fix: SimpleCORS policy, no
-    // origin-request policy, managed CachingOptimized. Reconciling must flip all.
-    $preFix = [
-        'TargetOriginId' => 'asset-bucket',
-        'ViewerProtocolPolicy' => 'redirect-to-https',
-        'Compress' => true,
-        'CachePolicyId' => '658327ea-f89d-4fab-a63d-7e88639e58f6',
-        'ResponseHeadersPolicyId' => '60669652-455b-4ae9-85a4-c4c02393f86c',
-        'MinTTL' => 0,
-    ];
+it('pins every tracked 5xx to a zero error-caching TTL', function () {
+    $errors = AssetDistribution::customErrorResponses();
 
-    expect(array_merge($preFix, AssetDistribution::reconcilableBehaviour('cp-resolved-id')) == $preFix)->toBeFalse();
+    expect($errors['Quantity'])->toBe(4);
+    expect(collect($errors['Items'])->pluck('ErrorCachingMinTTL')->unique()->all())->toBe([0]);
+    expect(collect($errors['Items'])->pluck('ErrorCode')->all())->toBe([500, 502, 503, 504]);
+});
+
+it('detects error-caching drift', function () {
+    // Unset → CloudFront's ~10s default caches a transient 5xx → drift.
+    expect(AssetDistribution::errorCachingDrift([]))->not->toBeNull();
+
+    // A partial / non-zero TTL config still drifts.
+    expect(AssetDistribution::errorCachingDrift([
+        'Items' => [['ErrorCode' => 503, 'ErrorCachingMinTTL' => 10]],
+    ]))->not->toBeNull();
+
+    // All four codes pinned to 0 (extra default fields and ordering ignored) → in sync.
+    expect(AssetDistribution::errorCachingDrift([
+        'Items' => [
+            ['ErrorCode' => 504, 'ErrorCachingMinTTL' => 0, 'ResponsePagePath' => '', 'ResponseCode' => ''],
+            ['ErrorCode' => 500, 'ErrorCachingMinTTL' => 0, 'ResponsePagePath' => '', 'ResponseCode' => ''],
+            ['ErrorCode' => 502, 'ErrorCachingMinTTL' => 0, 'ResponsePagePath' => '', 'ResponseCode' => ''],
+            ['ErrorCode' => 503, 'ErrorCachingMinTTL' => 0, 'ResponsePagePath' => '', 'ResponseCode' => ''],
+        ],
+    ]))->toBeNull();
 });

--- a/tests/Unit/Resources/Storage/AssetBucketTest.php
+++ b/tests/Unit/Resources/Storage/AssetBucketTest.php
@@ -42,16 +42,6 @@ function bindRecordingAssetS3Client(array $byCommand): object
     return $recorder;
 }
 
-function matchingCorsRules(): array
-{
-    return [[
-        'AllowedMethods' => ['GET', 'HEAD'],
-        'AllowedOrigins' => ['*'],
-        'AllowedHeaders' => ['*'],
-        'MaxAgeSeconds' => 86400,
-    ]];
-}
-
 beforeEach(function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
@@ -70,34 +60,35 @@ it('tags the bucket with its name and app owner', function () {
     expect((new AssetBucket())->tags())->toBe(['Name' => 'yolo-testing-my-app-assets', 'yolo:app' => 'my-app']);
 });
 
-it('reconciles a CORS configuration so the origin serves Access-Control-Allow-Origin', function () {
+it('enforces the bucket CORS configuration through sync', function () {
     expect(new AssetBucket())->toBeInstanceOf(SynchronisesConfiguration::class);
 });
 
-it('returns no change and writes nothing when the CORS rules already match', function () {
-    $recorder = bindRecordingAssetS3Client(['GetBucketCors' => new Result(['CORSRules' => matchingCorsRules()])]);
+it('returns no change and writes nothing when the bucket already has no CORS', function () {
+    $recorder = bindRecordingAssetS3Client(['GetBucketCors' => new Result([])]);
 
     expect((new AssetBucket())->synchroniseConfiguration())->toBe([]);
-    expect($recorder->calls)->not->toContain('PutBucketCors');
+    expect($recorder->calls)->not->toContain('DeleteBucketCors');
 });
 
-it('returns a cors change and puts the rules when they drift', function () {
+it('returns a cors change and deletes the config when one is present', function () {
     $recorder = bindRecordingAssetS3Client([
-        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET'], 'AllowedOrigins' => ['https://example.com']]]]),
+        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET'], 'AllowedOrigins' => ['*']]]]),
     ]);
 
     $changes = (new AssetBucket())->synchroniseConfiguration();
 
     expect($changes)->toHaveCount(1);
     expect($changes[0]->attribute)->toBe('cors');
-    expect($recorder->calls)->toContain('PutBucketCors');
+    expect($changes[0]->to)->toBe('removed (owned by the distribution)');
+    expect($recorder->calls)->toContain('DeleteBucketCors');
 });
 
-it('computes the cors diff without writing under apply:false', function () {
+it('reports the cors removal without writing under apply:false', function () {
     $recorder = bindRecordingAssetS3Client([
-        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET']]]]),
+        'GetBucketCors' => new Result(['CORSRules' => [['AllowedMethods' => ['GET'], 'AllowedOrigins' => ['*']]]]),
     ]);
 
     expect((new AssetBucket())->synchroniseConfiguration(apply: false))->toHaveCount(1);
-    expect($recorder->calls)->not->toContain('PutBucketCors');
+    expect($recorder->calls)->not->toContain('DeleteBucketCors');
 });

--- a/tests/Unit/Steps/Deploy/PushAssetsToS3StepTest.php
+++ b/tests/Unit/Steps/Deploy/PushAssetsToS3StepTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Aws\Command;
 use Symfony\Component\Filesystem\Filesystem;
 use Codinglabs\Yolo\Steps\Deploy\PushAssetsToS3Step;
 
@@ -67,4 +68,23 @@ it('never ships dotfiles, dot-directories or source maps to the public CDN', fun
         'build/assets/app-abc123.js',
         'uploads/photo.jpg',
     ]);
+});
+
+it('stamps the immutable cache-control onto uploaded objects', function () {
+    $put = new Command('PutObject');
+    PushAssetsToS3Step::applyCacheControl($put);
+
+    expect($put['CacheControl'])->toBe('public, max-age=31536000, immutable');
+
+    $multipart = new Command('CreateMultipartUpload');
+    PushAssetsToS3Step::applyCacheControl($multipart);
+
+    expect($multipart['CacheControl'])->toBe('public, max-age=31536000, immutable');
+});
+
+it('leaves non-upload commands untouched', function () {
+    $get = new Command('GetObject');
+    PushAssetsToS3Step::applyCacheControl($get);
+
+    expect(isset($get['CacheControl']))->toBeFalse();
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

Production HQ navigation broke intermittently — clicking between Inertia route sections (e.g. **People**) failed with `Failed to fetch dynamically imported module`. Root cause: the asset CloudFront distribution caches transient origin **503s** on the **Origin-keyed** cache variant that browsers use, on immutable content-hashed paths that never self-bust, so the poisoned entry breaks every cross-origin `import()` until the next deploy. The *same* CloudFront+S3 config exists on LP (`df2sm3urulav` — verified byte-for-byte: conditional ACAO, `Vary: Origin`, no `Cache-Control`); only **Bunny in front** masks it there. CL has no shield, so browsers hit the raw misconfigured origin.

This makes `AssetDistribution` self-sufficient (a Bunny-equivalent at the CloudFront layer):

- **Static `Access-Control-Allow-Origin: *`** via a custom response-headers policy (`yolo-asset-headers`) — a *custom header*, so it's unconditional and survives the revalidation CloudFront forces for `no-cache`/`max-age=0` (the exact failure that pushed the earlier code off the managed CORS policy). Origin is no longer forwarded to S3, so there's no second ACAO source to double up.
- **Managed CachingOptimized cache policy** — no request headers in the key → one cache entry per object for every viewer, no `Vary: Origin` split. Replaces the custom `yolo-asset-cors` Origin-in-key policy (same TTLs).
- **`ErrorCachingMinTTL: 0`** for 500/502/503/504 → a transient origin 5xx is never pinned; the next request retries the origin and self-heals.
- **Immutable `Cache-Control`** (`public, max-age=31536000, immutable`) on every uploaded object — assets live under a per-deploy `builds/{version}/` prefix, so always safe.
- **Asset bucket now carries no CORS config, enforced by sync.** With CORS owned by the response-headers policy and Origin no longer forwarded, the bucket's own CORS rules are dead — and a foot-gun (re-introducing Origin forwarding would emit a duplicate ACAO). Sync deletes any CORS config it finds rather than leaving a manual one-off.

**Is there anything the reviewer needs to know to deploy this?**

- **Existing distributions self-heal on the next `yolo sync`**: `synchroniseConfiguration` reconciles the cache-behaviour policy IDs *and* (newly) the 5xx error-caching rules; the AssetBucket step removes the now-dead bucket CORS. All of this will drift off CL's live (Origin-keyed) distribution and be corrected. A CloudFront config update triggers a ~15-min edge redeploy.
- **Changing the cache policy changes the cache key** (Origin drops out), so the currently-poisoned Origin-keyed edge entries become unreachable and clear naturally — no manual invalidation needed. Run the sync at a quiet moment: cold-misses during the redeploy window can't pin now (error-caching 0), but it's still a brief cold-cache event.
- **Watch the first dry-run for idempotency**: it should report exactly the cache-policy / origin-request / response-headers / error-caching / bucket-CORS drift, then a second dry-run must come back clean (no perpetual `OriginRequestPolicyId: ''` drift).
- The orphaned `yolo-asset-cors` **cache** policy is left behind (unreferenced, harmless — distinct resource type from the new `yolo-asset-headers` RHP). Deletable manually whenever.
- `Cache-Control` only applies to objects uploaded from the next deploy onward — fine, since paths are version-prefixed and immutable.
- Full diagnosis + evidence (Chrome repro, header A/Bs, the LP-vs-CL comparison): [LPX-643](https://linear.app/codinglabsau/issue/LPX-643).

Closes LPX-643

🤖 Generated with [Claude Code](https://claude.ai/code)
