### PR TITLE
LPX-645: approve-before-apply for sync (plan → diff → confirm → apply) + unified Skipping

### DIFF
--- a/src/Concerns/RecordsChanges.php
+++ b/src/Concerns/RecordsChanges.php
@@ -38,4 +38,14 @@ trait RecordsChanges
             $this->recordedChanges[] = $change;
         }
     }
+
+    /**
+     * Drop everything recorded so the next invocation starts clean. Used by
+     * `runScopes` between the plan and apply passes so the apply pass doesn't
+     * carry forward the plan pass's changes on the same step instance.
+     */
+    public function resetChanges(): void
+    {
+        $this->recordedChanges = [];
+    }
 }

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -31,7 +31,15 @@ trait RunsSteppedCommands
     use ChecksIfCommandsShouldBeRunning;
 
     /**
-     * Collate, plan, confirm and execute a set of scope-grouped steps as a single flow.
+     * Collate, plan, confirm and apply a set of scope-grouped steps as a single flow.
+     *
+     * The flow is **approve-before-apply**: every step is invoked twice. A plan
+     * pass with `dry-run` injected runs each reconciler in compute-only mode and
+     * collects its status + attribute-level changes; the runner renders the full
+     * "Pending changes" diff and the "Skipping" summary against that, *then*
+     * gates the confirm, *then* runs the apply pass with the original options.
+     * The plan pass repeats read-only `Get*`/`List*` calls (one extra read per
+     * step) — fine at sync scale; the alternative is approving blind.
      *
      * @param  array<string, array<int, class-string>>  $scopes  ordered label => step class names
      */
@@ -39,15 +47,27 @@ trait RunsSteppedCommands
     {
         Prompt::interactive($this->input->isInteractive());
 
-        [$plan, $skipped] = $this->collateSteps($scopes, $environment);
+        [$planned, $skipped] = $this->collateSteps($scopes, $environment);
 
-        if ($plan->isEmpty() && $skipped->isEmpty()) {
+        if ($planned->isEmpty() && $skipped->isEmpty()) {
             warning('No steps detected.');
 
             return SymfonyCommand::SUCCESS;
         }
 
-        $this->printDeterminations($environment, $plan, $skipped);
+        intro(sprintf('Planning %s for %s', $this->getName(), $environment));
+
+        // PLAN PASS — compute-only. dry-run injection means SynchronisesResource
+        // and any bespoke reconcilers diff against live state without writing.
+        $plan = $this->executePlan($planned, time(), apply: false);
+
+        $this->printPlan($plan, $skipped);
+
+        if ($this->option('dry-run')) {
+            info(sprintf('Dry run — no changes applied to %s.', $environment));
+
+            return SymfonyCommand::SUCCESS;
+        }
 
         if (! $this->confirmGate($environment)) {
             warning('Aborted — no changes made.');
@@ -55,11 +75,15 @@ trait RunsSteppedCommands
             return SymfonyCommand::SUCCESS;
         }
 
+        // Step instances are reused across passes; clear the changes the plan
+        // pass recorded so RecordsChanges starts fresh under apply.
+        $this->resetRecordedChanges($planned);
+
         $now = time();
 
-        $ran = $this->executePlan($plan, $now);
+        $applied = $this->executePlan($planned, $now, apply: true);
 
-        $this->renderResults($environment, $ran, $skipped, time() - $now);
+        $this->renderResults($environment, $applied, time() - $now);
 
         return SymfonyCommand::SUCCESS;
     }
@@ -92,40 +116,33 @@ trait RunsSteppedCommands
         return [$plan, $skipped];
     }
 
-    protected function printDeterminations(string $environment, Collection $plan, Collection $skipped): void
+    /**
+     * Render the plan: scope counts, the full attribute-level Pending changes
+     * diff (when there's drift), and a single Skipping section grouped by
+     * scope + reason. With `-v`, the skipped section expands to list every
+     * resource under each concept group.
+     *
+     * @param  Collection<int, array{index: int, scope: string, step: Step, status: StepResult|string, elapsed: int, changes: array<int, Change>}>  $plan
+     * @param  Collection<int, array{scope: string, step: Step, reason: string}>  $skipped
+     */
+    protected function printPlan(Collection $plan, Collection $skipped): void
     {
-        intro(sprintf('Planning %s for %s', $this->getName(), $environment));
-
         $this->output->writeln('  <options=bold>Will sync</>');
 
         $plan->groupBy('scope')->each(function (Collection $entries, string $scope) {
             $this->output->writeln(sprintf('  <fg=green>✔</> %s <fg=gray>(%d)</>', $scope, $entries->count()));
         });
 
-        if ($skipped->isNotEmpty()) {
-            $this->output->writeln('');
-            $this->output->writeln('  <options=bold>Skipping</>');
+        $this->renderPendingChanges($plan);
 
-            $skipped
-                ->groupBy(fn (array $entry) => $entry['scope'] . '|' . $entry['reason'])
-                ->each(function (Collection $group) {
-                    $first = $group->first();
-
-                    $this->output->writeln(sprintf(
-                        '  <fg=yellow>•</> %s <fg=gray>(%d)</> — %s',
-                        $first['scope'],
-                        $group->count(),
-                        $first['reason'],
-                    ));
-                });
-        }
+        $this->renderSkipping($skipped);
 
         $this->output->writeln('');
     }
 
     protected function confirmGate(string $environment): bool
     {
-        if ($this->option('force') || $this->option('dry-run') || ! $this->input->isInteractive()) {
+        if ($this->option('force') || ! $this->input->isInteractive()) {
             return true;
         }
 
@@ -136,10 +153,15 @@ trait RunsSteppedCommands
     }
 
     /**
+     * Invoke every planned step once. Under `apply: false` (the plan pass)
+     * `dry-run` is injected into the options so reconcilers compute their diff
+     * without writing; under `apply: true` the original input options flow
+     * through unchanged.
+     *
      * @param  Collection<int, array{scope: string, step: Step}>  $plan
-     * @return Collection<int, array{index: int, scope: string, step: Step, status: StepResult|string, elapsed: int}>
+     * @return Collection<int, array{index: int, scope: string, step: Step, status: StepResult|string, elapsed: int, changes: array<int, Change>}>
      */
-    protected function executePlan(Collection $plan, int $now): Collection
+    protected function executePlan(Collection $plan, int $now, bool $apply): Collection
     {
         $multiScope = $plan->pluck('scope')->unique()->count() > 1;
 
@@ -149,7 +171,11 @@ trait RunsSteppedCommands
 
         $progress?->start();
 
-        $ran = $plan->values()->map(function (array $entry, int $i) use ($progress, $now, $multiScope) {
+        $options = $apply
+            ? $this->input->getOptions()
+            : [...$this->input->getOptions(), 'dry-run' => true];
+
+        $ran = $plan->values()->map(function (array $entry, int $i) use ($progress, $now, $multiScope, $options) {
             $step = $entry['step'];
 
             $label = $multiScope
@@ -160,7 +186,7 @@ trait RunsSteppedCommands
                 'index' => $i + 1,
                 'scope' => $entry['scope'],
                 'step' => $step,
-                ...$this->invokeStep($step, $progress, $label, $now),
+                ...$this->invokeStep($step, $progress, $label, $now, $options),
             ];
         });
 
@@ -170,11 +196,26 @@ trait RunsSteppedCommands
     }
 
     /**
+     * Clear changes recorded by a previous pass so the next pass starts clean.
+     *
+     * @param  Collection<int, array{scope: string, step: Step}>  $planned
+     */
+    protected function resetRecordedChanges(Collection $planned): void
+    {
+        $planned->each(function (array $entry) {
+            if (method_exists($entry['step'], 'resetChanges')) {
+                $entry['step']->resetChanges();
+            }
+        });
+    }
+
+    /**
      * Render the progress frame for a step, invoke it, and time it.
      *
+     * @param  array<string, mixed>  $options
      * @return array{status: StepResult|string, elapsed: int, changes: array<int, Change>}
      */
-    protected function invokeStep(Step $step, ?Progress $progress, string $label, int $now): array
+    protected function invokeStep(Step $step, ?Progress $progress, string $label, int $now, array $options): array
     {
         $progress?->label($label)
             ->hint(sprintf('%d seconds elapsed', time() - $now))
@@ -182,7 +223,7 @@ trait RunsSteppedCommands
 
         $started = time();
 
-        $status = $step->__invoke($this->input->getOptions(), $this);
+        $status = $step->__invoke($options, $this);
 
         // Build steps return void, and HasSubSteps steps return their sub-step
         // array (load-bearing for expandStep) — neither is a StepResult. Steps
@@ -205,10 +246,14 @@ trait RunsSteppedCommands
     }
 
     /**
+     * Render the post-apply results: per-step table + completion line. The
+     * attribute diffs were already shown pre-confirm in the plan's "Pending
+     * changes" section, and the skip ledger was rendered there too — neither
+     * is repeated here.
+     *
      * @param  Collection<int, array{index: int, scope: string, step: Step, status: StepResult|string, elapsed: int}>  $ran
-     * @param  Collection<int, array{scope: string, step: Step, reason: string}>  $skipped
      */
-    protected function renderResults(string $environment, Collection $ran, Collection $skipped, int $elapsed): void
+    protected function renderResults(string $environment, Collection $ran, int $elapsed): void
     {
         $multiScope = $ran->pluck('scope')->unique()->count() > 1;
 
@@ -238,60 +283,38 @@ trait RunsSteppedCommands
             );
         }
 
-        $this->renderChanges($ran, $multiScope);
-
-        if ($skipped->isNotEmpty()) {
-            if ($this->output->isVerbose()) {
-                table(
-                    ['Scope', 'Step', 'Reason'],
-                    $skipped->map(fn (array $entry) => [
-                        $entry['scope'],
-                        static::normaliseStep($entry['step']),
-                        $entry['reason'],
-                    ])->all()
-                );
-            } else {
-                info(sprintf(
-                    '%d step%s skipped (run with -v to show).',
-                    $skipped->count(),
-                    $skipped->count() === 1 ? '' : 's',
-                ));
-            }
-        }
-
         info(sprintf('Synced %s in %ds.', $environment, $elapsed));
     }
 
     /**
-     * Print the per-attribute detail behind the status column: which attributes
-     * each step reconciled (or, under --dry-run, would reconcile), as a
-     * current → desired comparison. Steps that changed nothing are omitted, so a
-     * clean sync stays quiet and drift stands out.
+     * Print the per-attribute Pending changes section: which attributes each
+     * step would reconcile, as a current → desired comparison. Steps that
+     * recorded nothing are omitted, so a clean plan stays quiet and drift
+     * stands out.
      *
-     * @param  Collection<int, array{scope: string, step: Step, status: StepResult|string, changes: array<int, Change>}>  $ran
+     * @param  Collection<int, array{scope: string, step: Step, changes: array<int, Change>}>  $plan
      */
-    protected function renderChanges(Collection $ran, bool $multiScope): void
+    protected function renderPendingChanges(Collection $plan): void
     {
-        $withChanges = $ran->filter(fn (array $result) => $result['changes'] !== []);
+        $withChanges = $plan->filter(fn (array $entry) => $entry['changes'] !== []);
 
         if ($withChanges->isEmpty()) {
             return;
         }
 
-        $this->output->writeln('');
-        $this->output->writeln(sprintf(
-            '  <options=bold>%s</>',
-            $this->option('dry-run') ? 'Pending changes' : 'Changes applied',
-        ));
+        $multiScope = $plan->pluck('scope')->unique()->count() > 1;
 
-        $withChanges->each(function (array $result) use ($multiScope) {
+        $this->output->writeln('');
+        $this->output->writeln('  <options=bold>Pending changes</>');
+
+        $withChanges->each(function (array $entry) use ($multiScope) {
             $label = $multiScope
-                ? sprintf('%s · %s', $result['scope'], static::normaliseStep($result['step']))
-                : static::normaliseStep($result['step']);
+                ? sprintf('%s · %s', $entry['scope'], static::normaliseStep($entry['step']))
+                : static::normaliseStep($entry['step']);
 
             $this->output->writeln(sprintf('  <fg=cyan>%s</>', $label));
 
-            foreach ($result['changes'] as $change) {
+            foreach ($entry['changes'] as $change) {
                 $this->output->writeln(sprintf(
                     '    %s: <fg=red>%s</> <fg=gray>→</> <fg=green>%s</>',
                     $change->attribute,
@@ -300,6 +323,47 @@ trait RunsSteppedCommands
                 ));
             }
         });
+    }
+
+    /**
+     * Print the Skipping section: one concept summary per scope + reason
+     * (always, regardless of verbosity), with the individual resource names
+     * listed under each summary when `-v` is set.
+     *
+     * @param  Collection<int, array{scope: string, step: Step, reason: string}>  $skipped
+     */
+    protected function renderSkipping(Collection $skipped): void
+    {
+        if ($skipped->isEmpty()) {
+            return;
+        }
+
+        $verbose = $this->output->isVerbose();
+
+        $this->output->writeln('');
+        $this->output->writeln('  <options=bold>Skipping</>');
+
+        $skipped
+            ->groupBy(fn (array $entry) => $entry['scope'] . '|' . $entry['reason'])
+            ->each(function (Collection $group) use ($verbose) {
+                $first = $group->first();
+
+                $this->output->writeln(sprintf(
+                    '  <fg=yellow>•</> %s <fg=gray>(%d)</> — %s',
+                    $first['scope'],
+                    $group->count(),
+                    $first['reason'],
+                ));
+
+                if ($verbose) {
+                    foreach ($group as $entry) {
+                        $this->output->writeln(sprintf(
+                            '      <fg=gray>· %s</>',
+                            static::normaliseStep($entry['step']),
+                        ));
+                    }
+                }
+            });
     }
 
     protected function handleSteps(string $environment): int
@@ -323,8 +387,10 @@ trait RunsSteppedCommands
 
         $progress?->start();
 
-        $output = $steps->map(function (Step $step, int $i) use ($progress, $now) {
-            ['status' => $status, 'elapsed' => $elapsed] = $this->invokeStep($step, $progress, static::normaliseStep($step), $now);
+        $options = $this->input->getOptions();
+
+        $output = $steps->map(function (Step $step, int $i) use ($progress, $now, $options) {
+            ['status' => $status, 'elapsed' => $elapsed] = $this->invokeStep($step, $progress, static::normaliseStep($step), $now, $options);
 
             return [
                 $i + 1,

--- a/tests/Unit/Concerns/InvokeStepCoercionTest.php
+++ b/tests/Unit/Concerns/InvokeStepCoercionTest.php
@@ -17,7 +17,7 @@ function statusFromInvoke(Step $step): StepResult|string
     $command->input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
 
     return (new ReflectionMethod($command, 'invokeStep'))
-        ->invoke($command, $step, null, 'label', time())['status'];
+        ->invoke($command, $step, null, 'label', time(), [])['status'];
 }
 
 it('coerces a void step return to SUCCESS', function () {

--- a/tests/Unit/Concerns/RunScopesRenderTest.php
+++ b/tests/Unit/Concerns/RunScopesRenderTest.php
@@ -34,13 +34,17 @@ class RunScopesChangeStep implements Step
 }
 
 /**
- * Drive the full collate → determinations → confirm → execute → results pipeline
- * against a non-interactive command and return everything written to the terminal.
+ * Drive the full collate → plan → confirm → apply → results pipeline against a
+ * non-interactive command and return everything written to the terminal.
+ *
+ * Non-interactive auto-approves the confirm gate, so both the plan output (Will
+ * sync / Pending changes / Skipping) and the apply output (results table +
+ * completion line) appear in the captured stream.
  *
  * @param  array<string, array<int, class-string>>  $scopes
  * @param  array<string, mixed>  $options
  */
-function runScopesCapture(array $scopes, array $options = []): string
+function runScopesCapture(array $scopes, array $options = [], int $verbosity = BufferedOutput::VERBOSITY_NORMAL): string
 {
     $command = new SyncCommand();
 
@@ -48,6 +52,7 @@ function runScopesCapture(array $scopes, array $options = []): string
     $input->setInteractive(false);
 
     $output = new BufferedOutput();
+    $output->setVerbosity($verbosity);
 
     $command->input = $input;
     $command->output = $output;
@@ -64,7 +69,7 @@ beforeEach(function () {
     writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
 });
 
-it('prints determinations grouped by scope, runs the plan, and reports skips', function () {
+it('plans (scopes + skipping) before applying, ending with the results table', function () {
     $output = runScopesCapture([
         'environment' => [RunScopesFakeStep::class, RunScopesFakeStep::class],
         'app' => [
@@ -76,19 +81,19 @@ it('prints determinations grouped by scope, runs the plan, and reports skips', f
         ],
     ], ['--no-progress' => true]);
 
-    // up-front determinations summary, grouped by scope
+    // the plan (Will sync + Skipping) renders, then the apply pass + results
     expect($output)
         ->toContain('Will sync')
         ->toContain('environment')
         ->toContain('app')
         ->toContain('Skipping')
-        ->toContain('aws.ivs not enabled in manifest');
-
-    // executed results, skip summary, and completion line
-    expect($output)
+        ->toContain('aws.ivs not enabled in manifest')
         ->toContain('CREATED')
-        ->toContain('3 steps skipped')
         ->toContain('Synced testing');
+
+    // and the plan really is rendered BEFORE the apply pass — "Will sync"
+    // must appear ahead of the completion line, not after it.
+    expect(strpos($output, 'Will sync'))->toBeLessThan(strpos($output, 'Synced testing'));
 });
 
 it('auto-proceeds without a prompt when non-interactive', function () {
@@ -101,28 +106,22 @@ it('auto-proceeds without a prompt when non-interactive', function () {
     expect($output)->toContain('Synced testing');
 });
 
-it('reports each reconciled attribute under an applied-changes section', function () {
+it('shows every pending attribute change before the confirm gate, even on a real run', function () {
     $output = runScopesCapture(
         ['environment' => [RunScopesChangeStep::class]],
         ['--no-progress' => true],
     );
 
+    // Pending changes is rendered by the plan pass — i.e. *before* the confirm
+    // gate fires — so the operator sees what's about to apply, not after.
     expect($output)
-        ->toContain('Changes applied')
+        ->toContain('Pending changes')
         ->toContain('idle_timeout')
         ->toContain('30')
         ->toContain('60');
-});
 
-it('frames the attribute changes as pending on a dry-run', function () {
-    $output = runScopesCapture(
-        ['environment' => [RunScopesChangeStep::class]],
-        ['--no-progress' => true, '--dry-run' => true],
-    );
-
-    expect($output)
-        ->toContain('Pending changes')
-        ->toContain('idle_timeout');
+    // And it precedes the completion line.
+    expect(strpos($output, 'Pending changes'))->toBeLessThan(strpos($output, 'Synced testing'));
 });
 
 it('omits the changes section entirely when nothing drifted', function () {
@@ -132,6 +131,55 @@ it('omits the changes section entirely when nothing drifted', function () {
     );
 
     expect($output)
-        ->not->toContain('Changes applied')
-        ->not->toContain('Pending changes');
+        ->not->toContain('Pending changes')
+        ->not->toContain('Changes applied');
+});
+
+it('shows the skipped concept summary at normal verbosity but hides per-resource names', function () {
+    $output = runScopesCapture([
+        'app' => [
+            Steps\Sync\App\SyncIvsCloudWatchLogGroupStep::class,
+            Steps\Sync\App\SyncIvsEventBridgeRuleStep::class,
+            Steps\Sync\App\SyncIvsEventBridgeTargetStep::class,
+        ],
+    ], ['--no-progress' => true]);
+
+    expect($output)
+        ->toContain('Skipping')
+        ->toContain('aws.ivs not enabled in manifest')
+        ->toContain('(3)')                            // concept-summary count
+        ->not->toContain('ivs cloud watch log group') // per-resource detail hidden
+        ->not->toContain('ivs event bridge rule');
+});
+
+it('expands the skipped section to per-resource names under -v', function () {
+    $output = runScopesCapture([
+        'app' => [
+            Steps\Sync\App\SyncIvsCloudWatchLogGroupStep::class,
+            Steps\Sync\App\SyncIvsEventBridgeRuleStep::class,
+            Steps\Sync\App\SyncIvsEventBridgeTargetStep::class,
+        ],
+    ], ['--no-progress' => true], BufferedOutput::VERBOSITY_VERBOSE);
+
+    // concept summary still there, plus the per-resource expansion
+    // (normaliseStep lowercases everything past the first char)
+    expect($output)
+        ->toContain('Skipping')
+        ->toContain('aws.ivs not enabled in manifest')
+        ->toContain('ivs cloud watch log group')
+        ->toContain('ivs event bridge rule')
+        ->toContain('ivs event bridge target');
+});
+
+it('dry-run renders the plan and stops — no apply, no results table, no completion line', function () {
+    $output = runScopesCapture(
+        ['environment' => [RunScopesChangeStep::class]],
+        ['--no-progress' => true, '--dry-run' => true],
+    );
+
+    expect($output)
+        ->toContain('Pending changes')
+        ->toContain('idle_timeout')
+        ->toContain('Dry run')
+        ->not->toContain('Synced testing'); // no apply ran
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

[LPX-645](https://linear.app/codinglabsau/issue/LPX-645)

Two related UX polishes to `runScopes` (`src/Concerns/RunsSteppedCommands.php`). Builds on the verbose attribute diffs (#50) and the asset-CORS fix (#51).

### What problems are you solving?

**1. Approve before apply.** Today the flow is **confirm-blind**: counts only → "Apply these changes to {env}?" → diffs computed *and* applied → "Changes applied" shown *after* the operator already said yes. Every reconciler already supports the no-op diff pass via `apply:false` — that's exactly what `--dry-run` runs (`SynchronisesResource::syncResource` → `synchroniseConfiguration(apply: ! $dryRun)` → `RecordsChanges`).

Folded a plan pass into the flow:

```
collate → PLAN PASS (apply:false, capturing status + changes)
       → render "Pending changes" (full attribute: current → desired)
       → confirm
       → APPLY PASS (apply:true)
       → results table + completion line
```

**Semantics preserved:** `--dry-run` = plan only (no apply); `--force` = show plan, skip the prompt; non-interactive / CI = plan + apply, no prompt. A clean plan still flows through apply (idempotent no-op writes). The plan pass repeats read-only `Get*`/`List*` calls per step — fine at sync scale.

**2. Unified Skipping section.** Skipped steps (IVS without `aws.ivs`, solo/multi-tenancy mismatches, headless gates) used to render a concept summary up-front *and* a per-resource list only under `-v` after the apply pass. Both now live in ONE `Skipping` section rendered with the plan:

- Concept summary always — `app (3) — aws.ivs not enabled in manifest`, grouped by scope + reason.
- Per-resource names listed under each summary when `-v` is set.
- Duplicate post-apply section removed.

### What it looks like (after)

```
Planning sync for production

  Will sync
  ✔ account     (1)
  ✔ environment (19)
  ✔ app         (23)

  Pending changes
  app · Load balancer
    deletion_protection.enabled: false → true
    access_logs.s3.enabled: false → true
  app · S3 artefact bucket
    versioning: Suspended → Enabled

  Skipping
  • app (3) — aws.ivs not enabled in manifest

  Apply these changes to production? [y/N]
  ...
  (apply pass + results table + Synced production in 42s.)
```

`-v` adds the per-resource list under each `Skipping` row; `--dry-run` stops after the plan section.

### Is there anything the reviewer needs to know to deploy this?

- **Behavioural change for `--force` and non-interactive runs:** they now run two passes per step (plan + apply). The plan pass is read-only AWS calls; second-read cost is ~1 extra `Get*`/`List*` per step at sync scale. Noted in the `runScopes` docblock.
- **`invokeStep` signature changed** — now takes `array $options` as the final arg so the plan pass can inject `dry-run => true` without mutating `$this->input`. `handleSteps` (build/deploy) passes `$this->input->getOptions()` through unchanged.
- **`RecordsChanges` gained `public resetChanges()`** so `runScopes` can clear plan-pass state on each step before re-invoking under apply. Steps are re-used across passes (cheaper than re-collating; the tenant fan-out clones already happen once).
- **No reconciler change.** All resources/steps continue to work exactly as before — this is renderer-trait + test work only.
- **Tests:** `RunScopesRenderTest` asserts plan-before-apply (`strpos('Pending changes') < strpos('Synced testing')`), concept summary visible at normal verbosity, per-resource names appear under `-v`, and `--dry-run` stops after the plan with no completion line. `InvokeStepCoercionTest` updated for the new arg list. **380 Pest / PHPStan / Pint green;** `yolo list` boots.

### Files

- `src/Concerns/RunsSteppedCommands.php` — main rewrite (`runScopes`, `executePlan`, `printPlan`, `renderPendingChanges`, `renderSkipping`, `renderResults`, `confirmGate`)
- `src/Concerns/RecordsChanges.php` — added `resetChanges()`
- `tests/Unit/Concerns/RunScopesRenderTest.php` — assertions updated, two new tests
- `tests/Unit/Concerns/InvokeStepCoercionTest.php` — `invokeStep` signature

🤖 Generated with [Claude Code](https://claude.com/claude-code)