### PR TITLE
sync: env-scoped ALB log bucket — fix greenfield ModifyLoadBalancerAttributes failure

### DIFF
--- a/src/Commands/SyncEnvironmentCommand.php
+++ b/src/Commands/SyncEnvironmentCommand.php
@@ -42,6 +42,11 @@ class SyncEnvironmentCommand extends SyncSteppedCommand
                 Steps\Sync\Environment\AttachEcsTaskRolePoliciesStep::class,
                 Steps\Sync\Environment\SyncEcsExecutionRoleStep::class,
                 Steps\Sync\Environment\AttachEcsExecutionRolePoliciesStep::class,
+                // ALB log bucket — provisioned before the load balancer so the
+                // log-delivery bucket policy already grants the ELB service
+                // principal `s3:PutObject` when `SyncLoadBalancerStep` enables
+                // access logs (AWS verifies the policy at attribute-write time).
+                Steps\Sync\Environment\SyncS3LoadBalancerLogsStep::class,
                 // load balancer + :80 listener
                 Steps\Sync\Environment\SyncLoadBalancerStep::class,
                 Steps\Sync\Environment\SyncHttpListenerStep::class,

--- a/src/Paths.php
+++ b/src/Paths.php
@@ -74,6 +74,20 @@ class Paths
         return Manifest::get('aws.artefacts-bucket', Helpers::keyedResourceName('artefacts'));
     }
 
+    /**
+     * Env-scoped bucket holding the shared ALB's access logs. Separate from
+     * the per-app artefacts bucket because the ALB itself is env-shared — a
+     * per-app log destination would make multiple apps fight over a single
+     * ALB attribute (`access_logs.s3.bucket` is one value, last-writer-wins),
+     * and the ELB log-delivery bucket policy needs to live in the same scope
+     * as the ALB so sync's account → environment → app ordering can write it
+     * before the ALB attribute write that depends on it.
+     */
+    public static function s3LoadBalancerLogsBucket(): string
+    {
+        return Manifest::get('aws.alb-logs-bucket', sprintf('yolo-%s-alb-logs', Helpers::environment()));
+    }
+
     public static function s3Artefacts(string $appVersion, $path = null): string
     {
         return 'artefacts/' . $appVersion . ($path ? '/' . ltrim($path, '/') : '');

--- a/src/Resources/ElbV2/LoadBalancer.php
+++ b/src/Resources/ElbV2/LoadBalancer.php
@@ -74,8 +74,9 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
 
         // A fresh ALB starts on AWS defaults (no deletion protection, access logs
         // off, invalid headers passed through); bring our hardened attributes onto
-        // it. The artefacts bucket access-logs policy is provisioned earlier in the
-        // sync (Storage runs before Compute), so enabling access logs validates.
+        // it. The env-scoped ALB log bucket (S3LoadBalancerLogs) is provisioned
+        // earlier in the same scope, so enabling access logs validates against the
+        // log-delivery bucket policy that already exists.
         $this->reconcileAttributes($arn, current: [], apply: true);
     }
 
@@ -163,7 +164,7 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
         return [
             'deletion_protection.enabled' => 'true',
             'access_logs.s3.enabled' => 'true',
-            'access_logs.s3.bucket' => Paths::s3ArtefactsBucket(),
+            'access_logs.s3.bucket' => Paths::s3LoadBalancerLogsBucket(),
             'access_logs.s3.prefix' => $this->accessLogsPrefix(),
             'routing.http.drop_invalid_header_fields.enabled' => 'true',
             'routing.http2.enabled' => 'true',
@@ -172,12 +173,13 @@ class LoadBalancer implements Resource, SynchronisesConfiguration
     }
 
     /**
-     * Access logs land under alb-access-logs/{env}/{name}/ in the artefacts
-     * bucket, so a shared ALB's logs are grouped by its name and split from any
-     * other yolo-managed objects. AWS appends /AWSLogs/{account}/... beneath it.
+     * Access logs land under {env}/{name}/ in the env-scoped ALB log bucket,
+     * so logs from multiple ALBs (e.g. one shared, one app-specific) land in
+     * the same bucket cleanly separated by ALB name. AWS appends
+     * /AWSLogs/{account}/... beneath it.
      */
     public function accessLogsPrefix(): string
     {
-        return sprintf('alb-access-logs/%s/%s', Helpers::environment(), $this->name());
+        return sprintf('%s/%s', Helpers::environment(), $this->name());
     }
 }

--- a/src/Resources/S3/S3ArtefactBucket.php
+++ b/src/Resources/S3/S3ArtefactBucket.php
@@ -6,8 +6,6 @@ use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Aws\S3;
 use Codinglabs\Yolo\Change;
-use Codinglabs\Yolo\Helpers;
-use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
@@ -19,10 +17,6 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * its objects must be recoverable, so Block Public Access (all four settings)
  * and versioning are reconciled onto it on every sync — both declarative,
  * idempotent puts. The yolo:app owner tag lets `yolo audit` attribute it.
- *
- * It also doubles as the destination for the ALB's access logs, so sync grants
- * the ELB log-delivery service principal write access under the alb-access-logs/
- * prefix.
  */
 class S3ArtefactBucket implements Resource, SynchronisesConfiguration
 {
@@ -71,17 +65,15 @@ class S3ArtefactBucket implements Resource, SynchronisesConfiguration
     }
 
     /**
-     * Reconcile Block Public Access, versioning and the ALB log-delivery policy,
-     * each read-compared-then-written so a clean sync is a no-op and a dry-run
-     * reports exactly what would change. Returns the drifted attributes as
-     * Change[].
+     * Reconcile Block Public Access and versioning, each read-compared-then-
+     * written so a clean sync is a no-op and a dry-run reports exactly what
+     * would change. Returns the drifted attributes as Change[].
      */
     public function synchroniseConfiguration(bool $apply = true): array
     {
         return [
             ...$this->reconcilePublicAccessBlock($apply),
             ...$this->reconcileVersioning($apply),
-            ...$this->reconcileAlbAccessLogDelivery($apply),
         ];
     }
 
@@ -136,72 +128,5 @@ class S3ArtefactBucket implements Resource, SynchronisesConfiguration
         }
 
         return [Change::make('versioning', $current, 'Enabled')];
-    }
-
-    /**
-     * Grant Elastic Load Balancing permission to deliver ALB access logs into this
-     * bucket under the alb-access-logs/ prefix. Enabling access logs on the load
-     * balancer (LoadBalancer resource) fails AWS's write-test without this, so the
-     * policy must exist before sync:compute runs — Storage runs ahead of Compute,
-     * so it does.
-     *
-     * Uses the log-delivery service principal (recommended for the SSE-S3-encrypted
-     * artefacts bucket; no customer-managed KMS key in play) rather than a
-     * per-Region ELB account ID. SourceAccount + SourceArn scope the grant to this
-     * account's load balancers, so it is never public and coexists with the
-     * bucket's BlockPublicPolicy. The artefacts bucket carries no other policy, so
-     * a full-replace put is safe — but we diff against the live policy first so a
-     * clean sync makes no write and a dry-run can report the change.
-     *
-     * @return array<int, Change>
-     */
-    protected function reconcileAlbAccessLogDelivery(bool $apply): array
-    {
-        $desired = $this->albAccessLogDeliveryPolicy();
-        $current = S3::bucketPolicy($this->name());
-
-        if (Helpers::documentsEqual($current, $desired)) {
-            return [];
-        }
-
-        if ($apply) {
-            Aws::s3()->putBucketPolicy([
-                'Bucket' => $this->name(),
-                'Policy' => json_encode($desired),
-            ]);
-        }
-
-        return [Change::make('bucket-policy', $current === null ? null : 'present', 'alb-access-log-delivery')];
-    }
-
-    /**
-     * @return array<string, mixed>
-     */
-    protected function albAccessLogDeliveryPolicy(): array
-    {
-        $accountId = Aws::accountId();
-
-        return [
-            'Version' => '2012-10-17',
-            'Statement' => [
-                [
-                    'Sid' => 'AllowELBAccessLogDelivery',
-                    'Effect' => 'Allow',
-                    'Principal' => ['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'],
-                    'Action' => 's3:PutObject',
-                    'Resource' => sprintf('arn:aws:s3:::%s/alb-access-logs/*', $this->name()),
-                    'Condition' => [
-                        'StringEquals' => ['aws:SourceAccount' => $accountId],
-                        'ArnLike' => [
-                            'aws:SourceArn' => sprintf(
-                                'arn:aws:elasticloadbalancing:%s:%s:loadbalancer/*',
-                                Manifest::get('aws.region'),
-                                $accountId,
-                            ),
-                        ],
-                    ],
-                ],
-            ],
-        ];
     }
 }

--- a/src/Resources/S3/S3LoadBalancerLogs.php
+++ b/src/Resources/S3/S3LoadBalancerLogs.php
@@ -1,0 +1,216 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\S3;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+
+/**
+ * Env-scoped bucket holding the shared ALB's access logs. Owns the ELB
+ * log-delivery bucket policy that `ModifyLoadBalancerAttributes` validates
+ * when access logs are enabled on the load balancer — so the policy needs
+ * to be in place *before* `SyncLoadBalancerStep` runs.
+ *
+ * It lives in the env scope (not app) for two reasons:
+ *
+ *  1. **Ordering.** The shared `LoadBalancer` is env-scoped and writes its
+ *     `access_logs.s3.bucket` attribute during the env scope's sync; an
+ *     app-scoped log bucket can't exist yet (account → environment → app),
+ *     so a greenfield sync's first ALB attribute write fails. Pulling the
+ *     bucket up to env makes the policy precondition satisfiable.
+ *  2. **Single-writer.** An env-shared ALB can only point at *one* bucket
+ *     (`access_logs.s3.bucket` is a single value). A per-app log destination
+ *     would mean apps fight over the attribute on a shared ALB —
+ *     last-writer-wins. An env-scoped bucket aligns the destination's scope
+ *     with the consumer's scope.
+ *
+ * Public-access-block (all four settings) and versioning are reconciled
+ * declaratively; the bucket policy grants the `logdelivery.elasticloadbalancing.amazonaws.com`
+ * service principal `s3:PutObject` over the whole bucket, scoped to this
+ * account's load balancers via `aws:SourceAccount` and `aws:SourceArn`.
+ * No `yolo:app` tag — env-scoped (ResolvesTags handles that automatically).
+ */
+class S3LoadBalancerLogs implements Resource, SynchronisesConfiguration
+{
+    use ResolvesTags;
+
+    public function name(): string
+    {
+        return Paths::s3LoadBalancerLogsBucket();
+    }
+
+    public function scope(): Scope
+    {
+        return Scope::Env;
+    }
+
+    public function exists(): bool
+    {
+        return S3::bucketExists($this->name());
+    }
+
+    public function arn(): string
+    {
+        return 'arn:aws:s3:::' . $this->name();
+    }
+
+    public function create(): void
+    {
+        Aws::s3()->createBucket([
+            'Bucket' => $this->name(),
+        ]);
+
+        Aws::s3()->waitUntil('BucketExists', [
+            'Bucket' => $this->name(),
+        ]);
+
+        $this->synchroniseTags();
+        $this->synchroniseConfiguration();
+    }
+
+    public function synchroniseTags(): void
+    {
+        Aws::s3()->putBucketTagging([
+            'Bucket' => $this->name(),
+            'Tagging' => Aws::tags($this->tags(), wrap: 'TagSet'),
+        ]);
+    }
+
+    /**
+     * Reconcile Block Public Access, versioning and the ELB log-delivery policy,
+     * each read-compared-then-written so a clean sync is a no-op and a dry-run
+     * reports exactly what would change. Returns the drifted attributes as
+     * Change[].
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        return [
+            ...$this->reconcilePublicAccessBlock($apply),
+            ...$this->reconcileVersioning($apply),
+            ...$this->reconcileAccessLogDeliveryPolicy($apply),
+        ];
+    }
+
+    /**
+     * @return array<int, Change>
+     */
+    protected function reconcilePublicAccessBlock(bool $apply): array
+    {
+        $desired = [
+            'BlockPublicAcls' => true,
+            'IgnorePublicAcls' => true,
+            'BlockPublicPolicy' => true,
+            'RestrictPublicBuckets' => true,
+        ];
+
+        $current = S3::publicAccessBlock($this->name());
+
+        $changes = collect($desired)
+            ->filter(fn (bool $value, string $key) => ($current[$key] ?? null) !== $value)
+            ->map(fn (bool $value, string $key) => Change::make("block-public-access.$key", $current[$key] ?? null, $value))
+            ->values()
+            ->all();
+
+        if ($changes === [] || ! $apply) {
+            return $changes;
+        }
+
+        Aws::s3()->putPublicAccessBlock([
+            'Bucket' => $this->name(),
+            'PublicAccessBlockConfiguration' => $desired,
+        ]);
+
+        return $changes;
+    }
+
+    /**
+     * @return array<int, Change>
+     */
+    protected function reconcileVersioning(bool $apply): array
+    {
+        $current = S3::bucketVersioning($this->name());
+
+        if ($current === 'Enabled') {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketVersioning([
+                'Bucket' => $this->name(),
+                'VersioningConfiguration' => ['Status' => 'Enabled'],
+            ]);
+        }
+
+        return [Change::make('versioning', $current, 'Enabled')];
+    }
+
+    /**
+     * Grant Elastic Load Balancing permission to deliver ALB access logs into
+     * the bucket. Uses the log-delivery service principal (correct for the
+     * SSE-S3-encrypted bucket; no customer-managed KMS key in play) rather
+     * than a per-Region ELB account ID. `aws:SourceAccount` + `aws:SourceArn`
+     * scope the grant to this account's load balancers, so the policy is
+     * never public and coexists with `BlockPublicPolicy`. The bucket is
+     * dedicated to ALB logs, so `Resource: arn:aws:s3:::{bucket}/*` is
+     * the full grant — no prefix scoping needed.
+     *
+     * @return array<int, Change>
+     */
+    protected function reconcileAccessLogDeliveryPolicy(bool $apply): array
+    {
+        $desired = $this->accessLogDeliveryPolicy();
+        $current = S3::bucketPolicy($this->name());
+
+        if (Helpers::documentsEqual($current, $desired)) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketPolicy([
+                'Bucket' => $this->name(),
+                'Policy' => json_encode($desired),
+            ]);
+        }
+
+        return [Change::make('bucket-policy', $current === null ? null : 'present', 'alb-access-log-delivery')];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function accessLogDeliveryPolicy(): array
+    {
+        $accountId = Aws::accountId();
+
+        return [
+            'Version' => '2012-10-17',
+            'Statement' => [
+                [
+                    'Sid' => 'AllowELBAccessLogDelivery',
+                    'Effect' => 'Allow',
+                    'Principal' => ['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'],
+                    'Action' => 's3:PutObject',
+                    'Resource' => sprintf('arn:aws:s3:::%s/*', $this->name()),
+                    'Condition' => [
+                        'StringEquals' => ['aws:SourceAccount' => $accountId],
+                        'ArnLike' => [
+                            'aws:SourceArn' => sprintf(
+                                'arn:aws:elasticloadbalancing:%s:%s:loadbalancer/*',
+                                Manifest::get('aws.region'),
+                                $accountId,
+                            ),
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+}

--- a/src/Steps/Sync/Environment/SyncS3LoadBalancerLogsStep.php
+++ b/src/Steps/Sync/Environment/SyncS3LoadBalancerLogsStep.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Sync\Environment;
+
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Resources\S3\S3LoadBalancerLogs;
+
+class SyncS3LoadBalancerLogsStep implements Step
+{
+    use SynchronisesResource;
+
+    public function __invoke(array $options): StepResult
+    {
+        return $this->syncResource(new S3LoadBalancerLogs(), $options);
+    }
+}

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -92,6 +92,23 @@ it('swaps the Solo steps for Landlord + Tenant steps on a multi-tenant app', fun
         ->and($appSteps)->not->toContain(Steps\Sync\App\Solo\SyncHostedZoneStep::class);
 });
 
+it('provisions the ALB log bucket before the load balancer in the environment scope', function () {
+    // `SyncLoadBalancerStep` writes `access_logs.s3.bucket`, which AWS validates
+    // against the bucket's log-delivery policy at attribute-write time. The bucket
+    // (S3LoadBalancerLogs) MUST therefore be provisioned first within the same
+    // scope, or a greenfield sync fails at `ModifyLoadBalancerAttributes`.
+    writeManifest(['aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2']]);
+
+    $envSteps = (new SyncCommand())->scopes()['environment'];
+
+    $logBucket = array_search(Steps\Sync\Environment\SyncS3LoadBalancerLogsStep::class, $envSteps, true);
+    $loadBalancer = array_search(Steps\Sync\Environment\SyncLoadBalancerStep::class, $envSteps, true);
+
+    expect($logBucket)->not->toBeFalse('log-bucket step is registered')
+        ->and($loadBalancer)->not->toBeFalse('load-balancer step is registered')
+        ->and($logBucket)->toBeLessThan($loadBalancer);
+});
+
 it('keys each scope distinctly so no scope is dropped on merge', function () {
     writeManifest([
         'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],

--- a/tests/Unit/Resources/Fargate/LoadBalancerTest.php
+++ b/tests/Unit/Resources/Fargate/LoadBalancerTest.php
@@ -80,8 +80,8 @@ function syncedLoadBalancerAttributes(array $overrides = []): array
     $attributes = array_merge([
         'deletion_protection.enabled' => 'true',
         'access_logs.s3.enabled' => 'true',
-        'access_logs.s3.bucket' => 'yolo-testing-my-app-artefacts',
-        'access_logs.s3.prefix' => 'alb-access-logs/testing/yolo-testing',
+        'access_logs.s3.bucket' => 'yolo-testing-alb-logs',
+        'access_logs.s3.prefix' => 'testing/yolo-testing',
         'routing.http.drop_invalid_header_fields.enabled' => 'true',
         'routing.http2.enabled' => 'true',
         'idle_timeout.timeout_seconds' => '60',
@@ -105,8 +105,8 @@ it('pins the full hardened attribute shape', function () {
     expect((new LoadBalancer())->desiredAttributes())->toBe([
         'deletion_protection.enabled' => 'true',
         'access_logs.s3.enabled' => 'true',
-        'access_logs.s3.bucket' => 'yolo-testing-my-app-artefacts',
-        'access_logs.s3.prefix' => 'alb-access-logs/testing/yolo-testing',
+        'access_logs.s3.bucket' => 'yolo-testing-alb-logs',
+        'access_logs.s3.prefix' => 'testing/yolo-testing',
         'routing.http.drop_invalid_header_fields.enabled' => 'true',
         'routing.http2.enabled' => 'true',
         'idle_timeout.timeout_seconds' => '60',

--- a/tests/Unit/Resources/S3/S3LoadBalancerLogsTest.php
+++ b/tests/Unit/Resources/S3/S3LoadBalancerLogsTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\S3\S3Client;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Resources\S3\S3LoadBalancerLogs;
+
+/**
+ * Bind an S3 client that records every command and returns the given responses
+ * (looked up by command name; missing entries default to an empty Result).
+ * Returns a recorder with a `calls` array of `['name', 'args']` entries.
+ *
+ * @param  array<string, Result>  $byCommand
+ */
+function bindRecordingS3Client(array $byCommand = []): object
+{
+    $recorder = new class($byCommand) extends MockHandler
+    {
+        /** @var array<int, array{name: string, args: array<string, mixed>}> */
+        public array $calls = [];
+
+        public function __construct(public array $byCommand) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            return Create::promiseFor($this->byCommand[$cmd->getName()] ?? new Result());
+        }
+    };
+
+    Helpers::app()->instance('s3', new S3Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+beforeEach(function () {
+    writeManifest([
+        'aws' => ['account-id' => '111111111111', 'region' => 'ap-southeast-2'],
+    ]);
+});
+
+it('is env-scoped and named yolo-{env}-alb-logs', function () {
+    $bucket = new S3LoadBalancerLogs();
+
+    expect($bucket->name())->toBe('yolo-testing-alb-logs')
+        ->and($bucket->scope())->toBe(Scope::Env)
+        // env-scoped → no yolo:app owner tag (only Name)
+        ->and($bucket->tags())->toBe(['Name' => 'yolo-testing-alb-logs']);
+});
+
+it('reconciles BPA + versioning + the log-delivery policy when none of them match', function () {
+    $recorder = bindRecordingS3Client();
+
+    $changes = (new S3LoadBalancerLogs())->synchroniseConfiguration();
+
+    $writes = collect($recorder->calls)->pluck('name')->all();
+
+    expect($writes)->toContain('PutPublicAccessBlock')
+        ->toContain('PutBucketVersioning')
+        ->toContain('PutBucketPolicy');
+
+    // every drifted attribute surfaces as a Change
+    $attributes = collect($changes)->pluck('attribute')->all();
+    expect($attributes)->toContain('block-public-access.BlockPublicAcls')
+        ->toContain('versioning')
+        ->toContain('bucket-policy');
+});
+
+it('grants ELB access-log delivery to the log-delivery service principal over the whole bucket', function () {
+    $recorder = bindRecordingS3Client();
+
+    (new S3LoadBalancerLogs())->synchroniseConfiguration();
+
+    $put = collect($recorder->calls)->firstWhere('name', 'PutBucketPolicy');
+
+    $statement = json_decode($put['args']['Policy'], true)['Statement'][0];
+
+    expect($statement['Effect'])->toBe('Allow')
+        ->and($statement['Principal'])->toBe(['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'])
+        ->and($statement['Action'])->toBe('s3:PutObject')
+        // dedicated bucket → /* is the full grant, no prefix scoping needed
+        ->and($statement['Resource'])->toBe('arn:aws:s3:::yolo-testing-alb-logs/*')
+        ->and($statement['Condition']['StringEquals']['aws:SourceAccount'])->toBe('111111111111')
+        ->and($statement['Condition']['ArnLike']['aws:SourceArn'])
+        ->toBe('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/*');
+});
+
+it('computes the diff without writing under apply:false', function () {
+    $recorder = bindRecordingS3Client();
+
+    $changes = (new S3LoadBalancerLogs())->synchroniseConfiguration(apply: false);
+
+    // changes are recorded
+    expect($changes)->not->toBeEmpty();
+
+    // but nothing was written
+    $writes = collect($recorder->calls)->pluck('name')->all();
+    expect($writes)->not->toContain('PutPublicAccessBlock')
+        ->not->toContain('PutBucketVersioning')
+        ->not->toContain('PutBucketPolicy');
+});
+
+it('does not rewrite a policy that already matches', function () {
+    // Bind a recorder whose GetBucketPolicy returns the exact desired document,
+    // so the diff sees no drift and the apply pass skips the write.
+    $resource = new S3LoadBalancerLogs();
+    $desired = (new ReflectionMethod($resource, 'accessLogDeliveryPolicy'))->invoke($resource);
+
+    $recorder = bindRecordingS3Client([
+        'GetBucketPolicy' => new Result(['Policy' => json_encode($desired)]),
+        // also report PBA + versioning already in the desired state so the whole
+        // sync is a no-op rather than just the policy
+        'GetPublicAccessBlock' => new Result(['PublicAccessBlockConfiguration' => [
+            'BlockPublicAcls' => true,
+            'IgnorePublicAcls' => true,
+            'BlockPublicPolicy' => true,
+            'RestrictPublicBuckets' => true,
+        ]]),
+        'GetBucketVersioning' => new Result(['Status' => 'Enabled']),
+    ]);
+
+    expect($resource->synchroniseConfiguration())->toBe([]);
+
+    expect(collect($recorder->calls)->pluck('name'))
+        ->not->toContain('PutBucketPolicy')
+        ->not->toContain('PutPublicAccessBlock')
+        ->not->toContain('PutBucketVersioning');
+});

--- a/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
+++ b/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
@@ -181,7 +181,13 @@ it('does not flip public access on an existing app bucket', function () {
     expect(array_column($captured, 'name'))->not->toContain('PutPublicAccessBlock');
 });
 
-it('grants ELB access-log delivery to the log-delivery service principal on a new artefact bucket', function () {
+it('never puts a bucket policy on the artefact bucket (log-delivery moved to S3LoadBalancerLogs)', function () {
+    // The artefacts bucket previously doubled as the ALB access-log destination,
+    // which forced its policy to grant logdelivery.elasticloadbalancing.amazonaws.com
+    // — but that put env-scoped policy logic on an app-scoped bucket and
+    // collided with the account → environment → app sync order. The log
+    // bucket now lives in env scope (S3LoadBalancerLogs), so a synced artefacts
+    // bucket must NEVER call PutBucketPolicy.
     $captured = [];
 
     bindMockS3Client([
@@ -190,49 +196,8 @@ it('grants ELB access-log delivery to the log-delivery service principal on a ne
         'PutBucketTagging' => new Result(),
         'PutPublicAccessBlock' => new Result(),
         'PutBucketVersioning' => new Result(),
-        'PutBucketPolicy' => new Result(),
     ], $captured);
 
     expect((new SyncS3ArtefactBucketStep())([]))->toBe(StepResult::CREATED);
-
-    $policy = collect($captured)->firstWhere('name', 'PutBucketPolicy');
-    expect($policy)->not->toBeNull();
-
-    $statement = json_decode($policy['args']['Policy'], true)['Statement'][0];
-
-    expect($statement['Effect'])->toBe('Allow')
-        ->and($statement['Principal'])->toBe(['Service' => 'logdelivery.elasticloadbalancing.amazonaws.com'])
-        ->and($statement['Action'])->toBe('s3:PutObject')
-        ->and($statement['Resource'])->toBe('arn:aws:s3:::yolo-testing-my-app-artefacts/alb-access-logs/*')
-        ->and($statement['Condition']['StringEquals']['aws:SourceAccount'])->toBe('111111111111')
-        ->and($statement['Condition']['ArnLike']['aws:SourceArn'])
-        ->toBe('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/*');
-});
-
-it('backfills the ELB access-log delivery policy onto an existing artefact bucket', function () {
-    $captured = [];
-
-    bindMockS3Client([
-        'HeadBucket' => new Result(),   // exists
-        'PutPublicAccessBlock' => new Result(),
-        'PutBucketVersioning' => new Result(),
-        'PutBucketPolicy' => new Result(),
-        'PutBucketTagging' => new Result(),
-    ], $captured);
-
-    expect((new SyncS3ArtefactBucketStep())([]))->toBe(StepResult::SYNCED);
-
-    expect(array_column($captured, 'name'))->toContain('PutBucketPolicy');
-});
-
-it('does not write the log-delivery policy during a dry-run', function () {
-    $captured = [];
-
-    bindMockS3Client([
-        'HeadBucket' => new Result(),   // exists
-    ], $captured);
-
-    expect((new SyncS3ArtefactBucketStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
-
     expect(array_column($captured, 'name'))->not->toContain('PutBucketPolicy');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Reproduced live on the codinglabs account — the first `yolo sync production` after the scope reorg fails at the env scope's **Sync load balancer** step:

```
InvalidConfigurationRequest: Access Denied for bucket: yolo-production-codinglabs-artefacts.
Please check S3bucket permission
```

### What problems are you solving?

**1. Structural ordering bug on greenfield.** `LoadBalancer` (Scope::Env) enables access logs against `yolo-{env}-{app}-artefacts`, but the log-delivery bucket policy lives on `S3ArtefactBucket` (Scope::App). account → environment → app ordering means the ALB attribute write fires *before* the policy is in place; AWS validates the policy at attribute-write time → fails on every greenfield (bucket-not-found on a clean account, access-denied on CL where the bucket exists from a prior sync). One-time `aws s3api put-bucket-policy` would patch CL but every new env hits the same wall — it's structural, not site-specific.

**2. Shared-ALB last-writer-wins.** Same underlying mismatch. A shared (env-scoped) ALB can only point at one bucket (`access_logs.s3.bucket` is a single value), so a per-app log destination made multi-app envs fight over the attribute. Long-flagged design issue, dissolved by the same move.

### The fix

Move the ALB access-log destination to a **new env-scoped bucket** that owns the log-delivery policy. Strip the log-delivery responsibility from `S3ArtefactBucket` entirely.

| File | Change |
|---|---|
| `src/Resources/S3/S3LoadBalancerLogs.php` | **new** — Scope::Env, `yolo-{env}-alb-logs` (override `aws.alb-logs-bucket`). Reconciles BPA + versioning + log-delivery policy. No `yolo:app` tag (ResolvesTags handles it from `scope()`). |
| `src/Steps/Sync/Environment/SyncS3LoadBalancerLogsStep.php` | **new** — thin step wrapper. |
| `src/Commands/SyncEnvironmentCommand.php` | Registers the new step **before** `SyncLoadBalancerStep` so the policy precondition holds. |
| `src/Paths.php` | `s3LoadBalancerLogsBucket()`. |
| `src/Resources/ElbV2/LoadBalancer.php` | Points at the new bucket; prefix becomes `{env}/{name}` (bucket is already env-scoped); stale "Storage runs before Compute" comment updated. |
| `src/Resources/S3/S3ArtefactBucket.php` | Drops the log-delivery responsibility entirely. |

### Is there anything the reviewer needs to know to deploy this?

- **Known cosmetic leftover.** Existing per-app artefacts buckets still carry the `AllowELBAccessLogDelivery` statement from the previous sync. The ALB now points at the new env-scoped bucket so it's unused permission — harmless. No migration logic; if you want to clean it up, one `aws s3api delete-bucket-policy --bucket yolo-{env}-{app}-artefacts` per existing bucket does it (entirely optional).
- **Existing ALB logs.** On envs that had access logs going to the artefacts bucket (CL), the old logs remain there. New logs land in `yolo-{env}-alb-logs/{env}/{name}/AWSLogs/...`. Operator can move/expire the old objects manually if desired.
- **Manifest:** one optional override added, `aws.alb-logs-bucket`, mirroring `aws.artefacts-bucket`. No other knobs (per the "no speculative configurability" rule).
- **`yolo-asset-cors` orphan policy** (the `CachePolicyInUse` error you hit at the bottom of the failed sync output): not addressed here — it's CL-specific cleanup, not a yolo bug. Once this PR lets sync reach `SyncAssetDistributionStep`, the distribution repoints onto the managed `CachingOptimized` policy and `yolo-asset-cors` becomes deletable on retry.

### Linear

No existing Backlog issue specifically about the env-scoped ALB log bucket. Closest neighbours are [LPX-275](https://linear.app/codinglabsau/issue/LPX-275) (S3 bucket + policy + lifecycle rules, generic) and [LPX-264](https://linear.app/codinglabsau/issue/LPX-264) (CloudFront distro for app-uploads bucket) — both adjacent but different concerns. This change stands on its own; filing a tracking issue is optional.

### Tests

- `tests/Unit/Resources/S3/S3LoadBalancerLogsTest.php` **new** — env-scope + no `yolo:app` tag invariant, policy shape (service principal + SourceAccount/SourceArn scoping + dedicated-bucket `/*` resource), create + reconcile, dry-run no-write, no-op when already in sync.
- `tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php` — three log-delivery-specific tests removed; one regression guard added that the artefact bucket NEVER calls `PutBucketPolicy` now.
- `tests/Unit/Resources/Fargate/LoadBalancerTest.php` — `access_logs.s3.bucket` + prefix shape updated.
- `tests/Unit/Commands/SyncCommandCollationTest.php` — new ordering assertion: `SyncS3LoadBalancerLogsStep` < `SyncLoadBalancerStep` in env scope (`array_search` indices).

**384 Pest / PHPStan / Pint green;** `yolo list` boots.

### After this lands

Bump `codinglabs/composer.lock` to the new SHA, run `yolo sync production`. The env scope provisions the new log bucket → ALB attribute write validates → sync reaches app scope → `SyncAssetDistributionStep` rewrites the distribution onto `CachingOptimized` → the orphan `yolo-asset-cors` cache policy becomes deletable on retry of your manual `delete-cache-policy` command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)