### PR TITLE
fix(asset-distribution): move ACAO into CorsConfig — AWS rejects it as a custom header

### DIFF
--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -57,13 +57,16 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
     protected const ORIGIN_REQUEST_POLICY_ID = '';
 
     // Custom response-headers policy that stamps a static
-    // `Access-Control-Allow-Origin: *` on EVERY response via a custom header —
-    // not a managed CORS policy. A managed CORS policy only adds the header when
-    // the request carries Origin, and CloudFront drops it on the revalidation it
-    // forces for `Cache-Control: no-cache` / `max-age=0` (reloads, DevTools
-    // "Disable cache"); a custom header is unconditional and survives that.
-    // Account-scoped and generic, so every YOLO asset distribution shares the one
-    // policy — looked up by name like the OAC.
+    // `Access-Control-Allow-Origin: *` on every response, via the policy's
+    // dedicated CorsConfig with OriginOverride: true. AWS rejects ACAO/ACAM/etc.
+    // as CustomHeadersConfig entries ("cannot be set as custom header") — those
+    // headers belong in CorsConfig, where CloudFront documents the policy's
+    // headers as "added to every response that CloudFront sends" for the
+    // matched cache behaviour. OriginOverride: true means the policy values
+    // win even when the origin's response includes its own CORS headers, so
+    // there's no Origin-dependent variance reaching the cached object.
+    // Account-scoped and generic, so every YOLO asset distribution shares the
+    // one policy — looked up by name like the OAC.
     protected const RESPONSE_HEADERS_POLICY_NAME = 'yolo-asset-headers';
 
     // Build assets live under a per-deploy `builds/{version}/` prefix (ASSET_URL
@@ -278,15 +281,33 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
                 'ResponseHeadersPolicyConfig' => [
                     'Name' => static::RESPONSE_HEADERS_POLICY_NAME,
                     'Comment' => 'YOLO build assets — static Access-Control-Allow-Origin: * on every response',
-                    'CustomHeadersConfig' => [
-                        'Quantity' => 1,
-                        'Items' => [
-                            [
-                                'Header' => 'Access-Control-Allow-Origin',
-                                'Value' => '*',
-                                'Override' => true,
-                            ],
+                    'CorsConfig' => [
+                        // `*` matches every cross-origin caller — the asset bucket
+                        // is public-by-design (immutable, content-hashed build
+                        // artefacts) so there's no caller to discriminate against.
+                        'AccessControlAllowOrigins' => [
+                            'Quantity' => 1,
+                            'Items' => ['*'],
                         ],
+                        // Browsers only fetch static assets with GET/HEAD plus the
+                        // OPTIONS preflight; anything else against the asset
+                        // distribution would already be wrong.
+                        'AccessControlAllowMethods' => [
+                            'Quantity' => 3,
+                            'Items' => ['GET', 'HEAD', 'OPTIONS'],
+                        ],
+                        'AccessControlAllowHeaders' => [
+                            'Quantity' => 1,
+                            'Items' => ['*'],
+                        ],
+                        // ACAO: * is incompatible with credentials, so this MUST
+                        // be false — AWS would reject the combination otherwise.
+                        'AccessControlAllowCredentials' => false,
+                        // The asset bucket no longer sees Origin (no origin-request
+                        // policy), so it never sends its own CORS headers — but
+                        // setting OriginOverride: true makes the policy's values
+                        // win regardless, even if S3 ever surfaces one.
+                        'OriginOverride' => true,
                     ],
                 ],
             ])['ResponseHeadersPolicy']['Id'];

--- a/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
+++ b/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
@@ -1,6 +1,46 @@
 <?php
 
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Aws\CloudFront\CloudFrontClient;
 use Codinglabs\Yolo\Resources\CloudFront\AssetDistribution;
+
+/**
+ * Bind a CloudFront client that records every call and returns the response
+ * mapped to its command name (missing entries default to a benign empty
+ * Result). Returns a recorder whose `$calls` is `[['name', 'args'], ...]`.
+ *
+ * @param  array<string, Result>  $byCommand
+ */
+function bindRecordingCloudFrontClient(array $byCommand): object
+{
+    $recorder = new class($byCommand) extends MockHandler
+    {
+        /** @var array<int, array{name: string, args: array<string, mixed>}> */
+        public array $calls = [];
+
+        public function __construct(public array $byCommand) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->calls[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            return Create::promiseFor($this->byCommand[$cmd->getName()] ?? new Result());
+        }
+    };
+
+    Helpers::app()->instance('cloudFront', new CloudFrontClient([
+        'region' => 'us-east-1',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
 
 beforeEach(function () {
     writeManifest([
@@ -88,6 +128,60 @@ it('pins every tracked 5xx to a zero error-caching TTL', function () {
     expect($errors['Quantity'])->toBe(4);
     expect(collect($errors['Items'])->pluck('ErrorCachingMinTTL')->unique()->all())->toBe([0]);
     expect(collect($errors['Items'])->pluck('ErrorCode')->all())->toBe([500, 502, 503, 504]);
+});
+
+it('creates the response-headers policy with CorsConfig (not CustomHeadersConfig — AWS rejects ACAO there)', function () {
+    // No existing policy by name → fall through to CreateResponseHeadersPolicy.
+    $recorder = bindRecordingCloudFrontClient([
+        'ListResponseHeadersPolicies' => new Result(['ResponseHeadersPolicyList' => ['Items' => []]]),
+        'CreateResponseHeadersPolicy' => new Result(['ResponseHeadersPolicy' => ['Id' => 'rhp-new-id']]),
+    ]);
+
+    $resource = new AssetDistribution();
+    $id = (new ReflectionMethod($resource, 'ensureResponseHeadersPolicy'))->invoke($resource);
+
+    expect($id)->toBe('rhp-new-id');
+
+    $create = collect($recorder->calls)->firstWhere('name', 'CreateResponseHeadersPolicy');
+    expect($create)->not->toBeNull();
+
+    $config = $create['args']['ResponseHeadersPolicyConfig'];
+
+    // The bug we're guarding: putting ACAO in CustomHeadersConfig is rejected
+    // by AWS ("Access-Control-Allow-Origin is a CORS header and cannot be set
+    // as custom header"). CorsConfig is the right home for it.
+    expect($config)->not->toHaveKey('CustomHeadersConfig');
+
+    expect($config['CorsConfig']['AccessControlAllowOrigins'])->toBe([
+        'Quantity' => 1,
+        'Items' => ['*'],
+    ]);
+    expect($config['CorsConfig']['AccessControlAllowMethods']['Items'])->toBe(['GET', 'HEAD', 'OPTIONS']);
+    expect($config['CorsConfig']['AccessControlAllowHeaders']['Items'])->toBe(['*']);
+    // `*` is incompatible with credentials — must be false.
+    expect($config['CorsConfig']['AccessControlAllowCredentials'])->toBeFalse();
+    // Override origin's CORS headers if it ever sends any (it shouldn't —
+    // the Origin header isn't forwarded to S3).
+    expect($config['CorsConfig']['OriginOverride'])->toBeTrue();
+});
+
+it('reuses an existing response-headers policy by name (no Create call)', function () {
+    $recorder = bindRecordingCloudFrontClient([
+        'ListResponseHeadersPolicies' => new Result(['ResponseHeadersPolicyList' => [
+            'Items' => [
+                ['ResponseHeadersPolicy' => [
+                    'Id' => 'rhp-existing-id',
+                    'ResponseHeadersPolicyConfig' => ['Name' => 'yolo-asset-headers'],
+                ]],
+            ],
+        ]]),
+    ]);
+
+    $resource = new AssetDistribution();
+    $id = (new ReflectionMethod($resource, 'ensureResponseHeadersPolicy'))->invoke($resource);
+
+    expect($id)->toBe('rhp-existing-id');
+    expect(collect($recorder->calls)->pluck('name'))->not->toContain('CreateResponseHeadersPolicy');
 });
 
 it('detects error-caching drift', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Reproduced live on the codinglabs sync — after #53 unblocked the env scope, the app scope now reaches `SyncAssetDistributionStep` at step 43/44 and fails:

```
Error executing "CreateResponseHeadersPolicy" on "https://cloudfront.amazonaws.com/2020-05-31/response-headers-policy"; AWS HTTP error:
InvalidArgument (client): The parameter CustomHeaders contains Access-Control-Allow-Origin that is a CORS header and cannot be set as custom header.
```

### What problems are you solving?

PR #51 ([LPX-643](https://linear.app/codinglabsau/issue/LPX-643)) built the `yolo-asset-headers` response-headers policy with `CustomHeadersConfig` to stamp a static `Access-Control-Allow-Origin: *` on every response, dodging the "managed CORS policy only emits ACAO when Origin is present" issue observed at the time. AWS **reserves ACAO/ACAM/ACAH/etc. for the policy's dedicated `CorsConfig` section** and rejects them as custom headers — so every first sync since #51 fails on `CreateResponseHeadersPolicy`.

This is structural, like #53 — every new account hits it; CL hit it because the policy didn't exist there yet either.

### The fix

Use `CorsConfig` with `OriginOverride: true`. CloudFront documents the headers in a response-headers policy as **"added to every response that CloudFront sends"** for the matched cache behaviour, and `OriginOverride: true` makes the policy's CORS values win even if the origin ever surfaces its own (S3 won't — there's no origin-request policy, so it never sees `Origin` and never emits CORS headers). Same unconditional-ACAO behaviour, through the field AWS actually accepts.

```php
'CorsConfig' => [
    'AccessControlAllowOrigins'  => ['Quantity' => 1, 'Items' => ['*']],
    'AccessControlAllowMethods'  => ['Quantity' => 3, 'Items' => ['GET', 'HEAD', 'OPTIONS']],
    'AccessControlAllowHeaders'  => ['Quantity' => 1, 'Items' => ['*']],
    'AccessControlAllowCredentials' => false,  // mandatory with `*` origin
    'OriginOverride' => true,
],
```

Class docblock + the `RESPONSE_HEADERS_POLICY_NAME` const comment updated to capture the new design.

### Is there anything the reviewer needs to know to deploy this?

- **The `yolo-asset-headers` policy doesn't exist anywhere yet** (every sync that tried to create it failed), so this isn't a migration — first successful sync after merge creates the policy fresh with the correct CorsConfig shape. No orphan to clean up.
- **CL-specific follow-on:** once this lands and you bump `codinglabs/composer.lock` and re-sync, sync should finish all 44 steps. The `yolo-asset-cors` orphan cache policy then becomes deletable (`SyncAssetDistributionStep` rewrites the distribution onto managed `CachingOptimized`, detaching it).
- **Linear:** no separate issue — this is a direct fix for the AWS-API mismatch introduced by #51 (LPX-643).

### Tests

- **New:** `AssetDistributionTest` gains two cases —
  - asserts the `CreateResponseHeadersPolicy` payload has `CorsConfig` with the expected shape (origins / methods / headers / credentials false / OriginOverride true) AND **explicitly asserts no `CustomHeadersConfig`** — regression guard against the AWS rejection.
  - asserts an existing policy by name short-circuits (no Create call).
- **386 Pest / PHPStan / Pint green;** `yolo list` boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)