### PR TITLE
audit: split into scope-grouped audit / audit:environment / audit:app verbs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,8 +55,8 @@ All commands extend `Command` (base) or, for multi-step work, `SteppedCommand` /
 - **`SyncSteppedCommand`** — a `SteppedCommand` whose steps are declared as scope-labelled `domains()`. Adds the
   `--dry-run`, `--force`, `--no-progress`, and `--tenant=<id>` options and an `environment` argument.
 
-The full command set: `init`, `env:pull`, `env:push`, `build`, `deploy`, `run`, `audit`, and the scope-grouped sync
-commands below.
+The full command set: `init`, `env:pull`, `env:push`, `build`, `deploy`, `run`, and the scope-grouped `sync` / `audit`
+verbs below.
 
 ### Sync is scope-first (`sync` / `sync:account` / `sync:environment` / `sync:app`)
 
@@ -74,6 +74,14 @@ allowed to write it:
 attaches to* shared infra (a listener rule, an SNI cert) — it never mutates it, so the shared tier keeps a single
 writer. Two env-named resources (the HTTPS `:443` listener and the RDS security group) are provisioned by `sync:app`
 by exception, because their creation has a per-app dependency; both are created-if-missing and never mutated.
+
+### Audit is scope-first too (`audit` / `audit:environment` / `audit:app`)
+
+Read-only counterpart to `sync` with the same scope split. `audit <env>` queries every resource tagged
+`yolo:environment=<env>` via the Resource Groups Tagging API, classifies each as `ok` / `drift` / `unattributed`
+(drift = `yolo:app` pointing at an app with no live Fargate cluster), and renders them grouped by scope.
+`audit:environment <env>` narrows to env-tier rows; `audit:app <env> <app>` narrows to one app. `--drift` is a
+universal flag — a no-op on `audit:environment` since env-scope resources never carry `yolo:app`.
 
 ### Steps (`src/Steps/`)
 

--- a/src/Commands/AbstractAuditCommand.php
+++ b/src/Commands/AbstractAuditCommand.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Aws\Ecs;
+use Codinglabs\Yolo\Audit\Arn;
+use Codinglabs\Yolo\Audit\Audit;
+use Illuminate\Support\Collection;
+use Codinglabs\Yolo\Audit\ConsoleUrl;
+use Symfony\Component\Console\Input\InputOption;
+use Codinglabs\Yolo\Aws\ResourceGroupsTaggingApi;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\warning;
+
+/**
+ * Shared scaffolding for the `audit`, `audit:environment` and `audit:app`
+ * commands. The audit verbs are scope-grouped to mirror sync — bare `audit`
+ * orchestrates everything, the scope-specific verbs narrow to one tier — so
+ * the query (tag-key filter on `yolo:environment`), classification and table
+ * render are identical across all three; only the row filter and the
+ * empty-state message change.
+ */
+abstract class AbstractAuditCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('drift', null, InputOption::VALUE_NONE, 'Only show drift (resources tagged for an app that is no longer live)');
+    }
+
+    public function handle(): int
+    {
+        $environment = $this->argument('environment');
+
+        $tagged = ResourceGroupsTaggingApi::getResources([
+            ['Key' => 'yolo:environment', 'Values' => [$environment]],
+        ]);
+
+        $report = Audit::classify($tagged, $this->liveApps($environment));
+
+        return $this->render($report, $environment);
+    }
+
+    /**
+     * Per-subcommand row filter. Return true to include the row in the table.
+     * Applied before the universal `--drift` filter, so subclasses don't need
+     * to know about `--drift` at all.
+     *
+     * @param  array<string, mixed>  $resource
+     */
+    abstract protected function includes(array $resource): bool;
+
+    /**
+     * Shown when the post-filter list is empty. Subclasses tailor the wording
+     * to their scope so `--drift` on a scope that can't carry drift reads
+     * clearly rather than as a non sequitur.
+     */
+    abstract protected function emptyFilterMessage(string $environment): string;
+
+    /**
+     * Apps with at least one running Fargate task — the authoritative "what's
+     * actually deployed" signal. We only probe clusters in this environment's
+     * namespace so the audit doesn't list tasks across unrelated clusters.
+     *
+     * @return array<int, string>
+     */
+    protected function liveApps(string $environment): array
+    {
+        $prefix = "yolo-$environment-";
+
+        $liveClusters = collect(Ecs::clusterArns())
+            ->filter(fn (string $arn) => str_starts_with(Arn::parse($arn)?->resourceId ?? '', $prefix))
+            ->filter(fn (string $arn) => Ecs::clusterRunningTasks($arn) !== [])
+            ->all();
+
+        return Audit::appsFromClusters($liveClusters, $environment);
+    }
+
+    /**
+     * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, driftCount: int, unattributedCount: int}  $report
+     */
+    protected function render(array $report, string $environment): int
+    {
+        if (empty($report['resources'])) {
+            info(sprintf("Nothing tagged for '%s'. 🐥", $environment));
+
+            return self::SUCCESS;
+        }
+
+        note(sprintf('Live apps: %s', $report['liveApps'] ? implode(', ', $report['liveApps']) : 'none'));
+
+        $rows = $this->filtered($report['resources']);
+
+        if ($rows->isEmpty()) {
+            info($this->emptyFilterMessage($environment));
+
+            return self::SUCCESS;
+        }
+
+        if (! $this->option('drift') && $report['driftCount'] > 0) {
+            warning(sprintf('%d resource(s) are drift — tagged for an app that is no longer live.', $report['driftCount']));
+        }
+
+        table(
+            ['Scope', 'Status', 'Type', 'Name', 'App'],
+            $rows->map(fn (array $resource) => [
+                static::scopeLabel($resource['scope']),
+                static::statusLabel($resource['status']),
+                $resource['type'],
+                static::nameCell($resource),
+                $resource['app'] ?? '—',
+            ])->all(),
+        );
+
+        note(sprintf(
+            "%d tagged for '%s' · %d drift · %d unattributed · %d ok",
+            count($report['resources']),
+            $environment,
+            $report['driftCount'],
+            $report['unattributedCount'],
+            $report['okCount'],
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Apply the subcommand's scope filter and the universal `--drift` flag,
+     * then order by scope (account → env → app, top to bottom), drift first
+     * within a scope, then app and name. Drift is still surfaced regardless
+     * of position — via the warning line, the red label and `--drift`.
+     *
+     * @param  array<int, array<string, mixed>>  $resources
+     * @return Collection<int, array<string, mixed>>
+     */
+    protected function filtered(array $resources)
+    {
+        return collect($resources)
+            ->filter(fn (array $resource) => $this->includes($resource))
+            ->when($this->option('drift'), fn ($rows) => $rows->where('status', Audit::STATUS_DRIFT))
+            ->sortBy(fn (array $resource) => Audit::orderKey($resource))
+            ->values();
+    }
+
+    protected static function statusLabel(string $status): string
+    {
+        return match ($status) {
+            Audit::STATUS_DRIFT => '<fg=red;options=bold>DRIFT</>',
+            Audit::STATUS_OK => '<fg=green>ok</>',
+            default => '<fg=yellow>unattributed</>',
+        };
+    }
+
+    protected static function scopeLabel(string $scope): string
+    {
+        return match ($scope) {
+            Audit::SCOPE_ACCOUNT => '<fg=magenta>account</>',
+            Audit::SCOPE_ENV => '<fg=cyan>environment</>',
+            default => '<fg=blue>app</>',
+        };
+    }
+
+    /**
+     * The resource name, wrapped in an OSC 8 hyperlink to its AWS Console page
+     * when we can build one. Terminals that support hyperlinks (Ghostty, Warp,
+     * iTerm2) make the name clickable; the rest just show the text.
+     *
+     * @param  array<string, mixed>  $resource
+     */
+    protected static function nameCell(array $resource): string
+    {
+        $url = ConsoleUrl::for(Arn::parse($resource['arn']));
+
+        return $url === null
+            ? $resource['name']
+            : sprintf('<href=%s>%s</>', $url, $resource['name']);
+    }
+}

--- a/src/Commands/AuditAppCommand.php
+++ b/src/Commands/AuditAppCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Symfony\Component\Console\Input\InputArgument;
+
+/**
+ * Audit one app's resources in an environment. Filters the env-wide audit
+ * report to rows whose `yolo:app` tag matches the given app — so an
+ * unaccounted-for (`unattributed`) row never shows up here, only `ok` and
+ * `drift` against that app.
+ */
+class AuditAppCommand extends AbstractAuditCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('audit:app')
+            ->addArgument('app', InputArgument::REQUIRED, 'The app name (matches the resource\'s yolo:app tag)')
+            ->setDescription("Audit a single app's resources for the given environment");
+    }
+
+    protected function includes(array $resource): bool
+    {
+        return $resource['app'] === $this->argument('app');
+    }
+
+    protected function emptyFilterMessage(string $environment): string
+    {
+        $app = $this->argument('app');
+
+        if ($this->option('drift')) {
+            return sprintf("No drift for app '%s' in '%s'. 🐥", $app, $environment);
+        }
+
+        return sprintf("No resources tagged for app '%s' in '%s'.", $app, $environment);
+    }
+}

--- a/src/Commands/AuditCommand.php
+++ b/src/Commands/AuditCommand.php
@@ -2,135 +2,26 @@
 
 namespace Codinglabs\Yolo\Commands;
 
-use Codinglabs\Yolo\Aws\Ecs;
-use Codinglabs\Yolo\Audit\Arn;
-use Codinglabs\Yolo\Audit\Audit;
-use Illuminate\Support\Collection;
-use Codinglabs\Yolo\Audit\ConsoleUrl;
-use Symfony\Component\Console\Input\InputOption;
-use Codinglabs\Yolo\Aws\ResourceGroupsTaggingApi;
-use Symfony\Component\Console\Input\InputArgument;
-
-use function Laravel\Prompts\info;
-use function Laravel\Prompts\note;
-use function Laravel\Prompts\table;
-use function Laravel\Prompts\warning;
-
 /**
- * Read-only audit of the YOLO-tagged resources in an environment. Surfaces
- * "drift" — resources tagged for an app that no longer has a live Fargate
- * cluster — alongside the ok (owned by a live app) and unattributed (shared /
- * not-yet-stamped) resources, grouped by ownership scope (account → env → app),
- * so a cutover can confirm nothing's been left behind.
+ * Top-level audit verb — shows every YOLO-tagged resource in an environment,
+ * grouped by ownership scope (account → env → app). Mirrors how bare `sync`
+ * orchestrates all three tiers; use `audit:environment` / `audit:app` to
+ * narrow to one tier.
  */
-class AuditCommand extends Command
+class AuditCommand extends AbstractAuditCommand
 {
     protected function configure(): void
     {
+        parent::configure();
+
         $this
             ->setName('audit')
-            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('app', null, InputOption::VALUE_REQUIRED, 'Only show resources attributed to this app')
-            ->addOption('drift', null, InputOption::VALUE_NONE, 'Only show drift (resources tagged for an app that is no longer live)')
-            ->setDescription('Audit YOLO-tagged resources for an environment and flag unexplained drift');
+            ->setDescription('Audit YOLO-tagged resources for an environment (account → environment → app) and flag unexplained drift');
     }
 
-    public function handle(): int
+    protected function includes(array $resource): bool
     {
-        $environment = $this->argument('environment');
-
-        $tagged = ResourceGroupsTaggingApi::getResources([
-            ['Key' => 'yolo:environment', 'Values' => [$environment]],
-        ]);
-
-        $report = Audit::classify($tagged, $this->liveApps($environment));
-
-        return $this->render($report, $environment);
-    }
-
-    /**
-     * Apps with at least one running Fargate task — the authoritative "what's
-     * actually deployed" signal. We only probe clusters in this environment's
-     * namespace so the audit doesn't list tasks across unrelated clusters.
-     *
-     * @return array<int, string>
-     */
-    protected function liveApps(string $environment): array
-    {
-        $prefix = "yolo-$environment-";
-
-        $liveClusters = collect(Ecs::clusterArns())
-            ->filter(fn (string $arn) => str_starts_with(Arn::parse($arn)?->resourceId ?? '', $prefix))
-            ->filter(fn (string $arn) => Ecs::clusterRunningTasks($arn) !== [])
-            ->all();
-
-        return Audit::appsFromClusters($liveClusters, $environment);
-    }
-
-    /**
-     * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, driftCount: int, unattributedCount: int}  $report
-     */
-    protected function render(array $report, string $environment): int
-    {
-        if (empty($report['resources'])) {
-            info(sprintf("Nothing tagged for '%s'. 🐥", $environment));
-
-            return self::SUCCESS;
-        }
-
-        note(sprintf('Live apps: %s', $report['liveApps'] ? implode(', ', $report['liveApps']) : 'none'));
-
-        $rows = $this->filtered($report['resources']);
-
-        if ($rows->isEmpty()) {
-            info($this->emptyFilterMessage($environment));
-
-            return self::SUCCESS;
-        }
-
-        if (! $this->option('drift') && $report['driftCount'] > 0) {
-            warning(sprintf('%d resource(s) are drift — tagged for an app that is no longer live.', $report['driftCount']));
-        }
-
-        table(
-            ['Scope', 'Status', 'Type', 'Name', 'App'],
-            $rows->map(fn (array $resource) => [
-                static::scopeLabel($resource['scope']),
-                static::statusLabel($resource['status']),
-                $resource['type'],
-                static::nameCell($resource),
-                $resource['app'] ?? '—',
-            ])->all(),
-        );
-
-        note(sprintf(
-            "%d tagged for '%s' · %d drift · %d unattributed · %d ok",
-            count($report['resources']),
-            $environment,
-            $report['driftCount'],
-            $report['unattributedCount'],
-            $report['okCount'],
-        ));
-
-        return self::SUCCESS;
-    }
-
-    /**
-     * Apply the --app and --drift filters, then order by scope (account → env →
-     * app, top to bottom), drift first within a scope, then app and name. Drift is
-     * still surfaced regardless of position — via the warning line, the red label
-     * and --drift.
-     *
-     * @param  array<int, array<string, mixed>>  $resources
-     * @return Collection<int, array<string, mixed>>
-     */
-    protected function filtered(array $resources)
-    {
-        return collect($resources)
-            ->when($this->option('app'), fn ($rows, $app) => $rows->where('app', $app))
-            ->when($this->option('drift'), fn ($rows) => $rows->where('status', Audit::STATUS_DRIFT))
-            ->sortBy(fn (array $resource) => Audit::orderKey($resource))
-            ->values();
+        return true;
     }
 
     protected function emptyFilterMessage(string $environment): string
@@ -139,40 +30,6 @@ class AuditCommand extends Command
             return sprintf("No drift in '%s' — every tagged resource maps to a live app. 🐥", $environment);
         }
 
-        return sprintf("No resources tagged for app '%s' in '%s'.", $this->option('app'), $environment);
-    }
-
-    protected static function statusLabel(string $status): string
-    {
-        return match ($status) {
-            Audit::STATUS_DRIFT => '<fg=red;options=bold>DRIFT</>',
-            Audit::STATUS_OK => '<fg=green>ok</>',
-            default => '<fg=yellow>unattributed</>',
-        };
-    }
-
-    protected static function scopeLabel(string $scope): string
-    {
-        return match ($scope) {
-            Audit::SCOPE_ACCOUNT => '<fg=magenta>account</>',
-            Audit::SCOPE_ENV => '<fg=cyan>environment</>',
-            default => '<fg=blue>app</>',
-        };
-    }
-
-    /**
-     * The resource name, wrapped in an OSC 8 hyperlink to its AWS Console page
-     * when we can build one. Terminals that support hyperlinks (Ghostty, Warp,
-     * iTerm2) make the name clickable; the rest just show the text.
-     *
-     * @param  array<string, mixed>  $resource
-     */
-    protected static function nameCell(array $resource): string
-    {
-        $url = ConsoleUrl::for(Arn::parse($resource['arn']));
-
-        return $url === null
-            ? $resource['name']
-            : sprintf('<href=%s>%s</>', $url, $resource['name']);
+        return sprintf("Nothing tagged for '%s'. 🐥", $environment);
     }
 }

--- a/src/Commands/AuditEnvironmentCommand.php
+++ b/src/Commands/AuditEnvironmentCommand.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Audit\Audit;
+
+/**
+ * Audit the env-shared (environment-tier) resources for one environment —
+ * VPC, ALB, subnets, RDS SG, SNS topic and the like. Env-scope resources
+ * never carry `yolo:app` by design, so `--drift` is a no-op here: drift is
+ * an app-scope concept.
+ */
+class AuditEnvironmentCommand extends AbstractAuditCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('audit:environment')
+            ->setDescription('Audit the env-shared (environment-tier) resources for the given environment');
+    }
+
+    protected function includes(array $resource): bool
+    {
+        return $resource['scope'] === Audit::SCOPE_ENV;
+    }
+
+    protected function emptyFilterMessage(string $environment): string
+    {
+        if ($this->option('drift')) {
+            return sprintf("No drift at the environment tier in '%s' — drift only applies to app-scope resources. 🐥", $environment);
+        }
+
+        return sprintf("No environment-tier resources tagged for '%s'.", $environment);
+    }
+}

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -31,8 +31,10 @@ class Yolo
         Commands\SyncEnvironmentCommand::class,
         Commands\SyncAppCommand::class,
 
-        // Audit
+        // Audit (scope-grouped: account → environment → app, orchestrated by `audit`)
         Commands\AuditCommand::class,
+        Commands\AuditEnvironmentCommand::class,
+        Commands\AuditAppCommand::class,
     ];
 
     public function __construct()

--- a/tests/Unit/Commands/AuditCommandsTest.php
+++ b/tests/Unit/Commands/AuditCommandsTest.php
@@ -1,0 +1,35 @@
+<?php
+
+use Codinglabs\Yolo\Commands\AuditCommand;
+use Codinglabs\Yolo\Commands\AuditAppCommand;
+use Codinglabs\Yolo\Commands\AuditEnvironmentCommand;
+
+it('registers the audit verbs under scope-grouped names', function () {
+    expect((new AuditCommand())->getName())->toBe('audit')
+        ->and((new AuditEnvironmentCommand())->getName())->toBe('audit:environment')
+        ->and((new AuditAppCommand())->getName())->toBe('audit:app');
+});
+
+it('drops the legacy --app option from the audit command', function () {
+    $definition = (new AuditCommand())->getDefinition();
+
+    expect($definition->hasOption('app'))->toBeFalse()
+        ->and($definition->hasOption('drift'))->toBeTrue()
+        ->and($definition->hasArgument('environment'))->toBeTrue();
+});
+
+it('takes app as a required positional argument on audit:app', function () {
+    $definition = (new AuditAppCommand())->getDefinition();
+
+    expect($definition->hasArgument('environment'))->toBeTrue()
+        ->and($definition->hasArgument('app'))->toBeTrue()
+        ->and($definition->getArgument('app')->isRequired())->toBeTrue()
+        ->and($definition->hasOption('app'))->toBeFalse()
+        ->and($definition->hasOption('drift'))->toBeTrue();
+});
+
+it('exposes --drift consistently across all three audit verbs', function () {
+    expect((new AuditCommand())->getDefinition()->hasOption('drift'))->toBeTrue()
+        ->and((new AuditEnvironmentCommand())->getDefinition()->hasOption('drift'))->toBeTrue()
+        ->and((new AuditAppCommand())->getDefinition()->hasOption('drift'))->toBeTrue();
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- `yolo audit <env>` had a single `--app` option, inconsistent with the sync verb's scope-grouped subcommand shape (`sync:account` / `sync:environment` / `sync:app`).
- This PR mirrors that pattern for audit: bare `audit <env>` keeps the orchestrator role (everything, scope-grouped account → env → app), `audit:environment <env>` narrows to env-tier rows, `audit:app <env> <app>` narrows to one app via a positional argument (replacing `--app=`).
- `--drift` stays universal across all three verbs. It's a no-op on `audit:environment` by design (env-scope resources never carry `yolo:app`, so they can't drift); the empty-state message there reads as deliberate rather than confusing.
- Shared query/classify/render lifted into `AbstractAuditCommand`; the three concrete commands each declare their per-scope row filter and empty-state wording. The pure `Audit\Audit` classification class is unchanged.

**Is there anything the reviewer needs to know to deploy this?**
- **CLI-surface change, breaking for anyone scripting `yolo audit --app=…`** — that flag is gone; the call site becomes `yolo audit:app <env> <app>`. There are no consumers of `--app` in CI/scripts that I'm aware of.
- No runtime/AWS-API behaviour change: same RGT API query (`yolo:environment` tag filter), same classification rules, same `--drift` semantics on the orchestrator and `audit:app`.
- 384 pest passed (+4 new command tests guarding CLI surface) · pint · phpstan all green.
- CLAUDE.md updated with an "Audit is scope-first too" section mirroring the sync block.

🤖 Generated with [Claude Code](https://claude.ai/code)