### PR TITLE
fix(asset-distribution): send ResponsePagePath + ResponseCode as empty strings on CustomErrorResponses

### DIFF
--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -212,7 +212,13 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
      * blip is never cached, so the next request retries the origin and self-heals
      * rather than pinning a broken entry against an immutable asset path.
      *
-     * @return array{Quantity: int, Items: array<int, array{ErrorCode: int, ErrorCachingMinTTL: int}>}
+     * `ResponsePagePath` and `ResponseCode` must be sent as empty strings even
+     * when we don't want a custom error page — AWS rejects UpdateDistribution
+     * with "The specified list of custom error responses does not exist or is
+     * not valid" if they're omitted. CloudFront stores them as `''` in the
+     * default-no-custom-page case, matching what DescribeDistribution returns.
+     *
+     * @return array{Quantity: int, Items: array<int, array{ErrorCode: int, ResponsePagePath: string, ResponseCode: string, ErrorCachingMinTTL: int}>}
      */
     public static function customErrorResponses(): array
     {
@@ -220,6 +226,8 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
             'Quantity' => count(static::ERROR_CODES_NOT_CACHED),
             'Items' => array_map(fn (int $code) => [
                 'ErrorCode' => $code,
+                'ResponsePagePath' => '',
+                'ResponseCode' => '',
                 'ErrorCachingMinTTL' => 0,
             ], static::ERROR_CODES_NOT_CACHED),
         ];

--- a/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
+++ b/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
@@ -128,6 +128,12 @@ it('pins every tracked 5xx to a zero error-caching TTL', function () {
     expect($errors['Quantity'])->toBe(4);
     expect(collect($errors['Items'])->pluck('ErrorCachingMinTTL')->unique()->all())->toBe([0]);
     expect(collect($errors['Items'])->pluck('ErrorCode')->all())->toBe([500, 502, 503, 504]);
+
+    // AWS rejects UpdateDistribution with "The specified list of custom error
+    // responses does not exist or is not valid" when ResponsePagePath /
+    // ResponseCode are omitted. Pin them as empty strings on every item.
+    expect(collect($errors['Items'])->pluck('ResponsePagePath')->unique()->all())->toBe(['']);
+    expect(collect($errors['Items'])->pluck('ResponseCode')->unique()->all())->toBe(['']);
 });
 
 it('creates the response-headers policy with CorsConfig (not CustomHeadersConfig — AWS rejects ACAO there)', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Reproduced live on codinglabs sync after #53 + #54 unblocked the env scope and the response-headers policy — now failing one step further on, at `UpdateDistribution`:

\`\`\`
Error executing \"UpdateDistribution\" on \"https://cloudfront.amazonaws.com/2020-05-31/distribution/E32CLVIHOLVT83/config\";
IllegalUpdate (client): The specified list of custom error responses does not exist or is not valid.
\`\`\`

### What problems are you solving?

\`customErrorResponses()\` emitted each item as \`{ErrorCode, ErrorCachingMinTTL}\` only. AWS treats \`ResponsePagePath\` and \`ResponseCode\` as **required strings** on the API — DescribeDistribution returns them populated as \`''\` for the \"no custom error page\" default (the existing \`errorCachingDrift\` test even asserts that live shape), and UpdateDistribution rejects payloads that omit them.

Same structural pattern as #53 and #54 — a missing-field rejection any greenfield sync hits the first time it reaches this step; not CL-specific.

### The fix

Send both as empty strings on every item:

\`\`\`php
'Items' => array_map(fn (int \$code) => [
    'ErrorCode' => \$code,
    'ResponsePagePath' => '',
    'ResponseCode' => '',
    'ErrorCachingMinTTL' => 0,
], self::ERROR_CODES_NOT_CACHED),
\`\`\`

Matches the live shape DescribeDistribution returns, satisfies the API.

### Is there anything the reviewer needs to know to deploy this?

- **No migration / no orphan.** The distribution currently has no \`CustomErrorResponses\` set at all (default CloudFront behaviour — \~10s caching of 5xx), so this is the first time the field gets populated. First successful sync after merge writes the four \`{500, 502, 503, 504} → TTL 0\` entries.
- **Same one-shot follow-on as before**: after this lands and CL re-syncs, the \`yolo-asset-cors\` orphan cache policy will be detachable via the manual \`aws cloudfront delete-cache-policy\` command.

### Tests

The existing \"pins every tracked 5xx to a zero error-caching TTL\" assertion now also pins \`ResponsePagePath\` and \`ResponseCode\` to \`''\` across every Item — a regression guard so we can't drop them again.

**386 Pest / PHPStan / Pint green;** \`yolo list\` boots.

🤖 Generated with [Claude Code](https://claude.com/claude-code)