### PR TITLE
sync: apply only the steps the plan flagged as pending

### DIFF
--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -33,13 +33,15 @@ trait RunsSteppedCommands
     /**
      * Collate, plan, confirm and apply a set of scope-grouped steps as a single flow.
      *
-     * The flow is **approve-before-apply**: every step is invoked twice. A plan
-     * pass with `dry-run` injected runs each reconciler in compute-only mode and
-     * collects its status + attribute-level changes; the runner renders the full
-     * "Pending changes" diff and the "Skipping" summary against that, *then*
-     * gates the confirm, *then* runs the apply pass with the original options.
-     * The plan pass repeats read-only `Get*`/`List*` calls (one extra read per
-     * step) — fine at sync scale; the alternative is approving blind.
+     * The flow is **approve-before-apply**. A plan pass with `dry-run` injected runs
+     * each reconciler in compute-only mode and collects its status + attribute-level
+     * changes; the runner renders the full "Pending changes" diff and the "Skipping"
+     * summary, gates the confirm, *then* runs the apply pass with the original
+     * options — but only over the steps the plan flagged as pending (WOULD_CREATE /
+     * WOULD_SYNC, or anything that recorded a change). Clean steps — already-synced
+     * resources with no drift — are dropped after plan, so apply doesn't repeat
+     * their `exists()` / Describe* round-trips or re-tag them, and the post-apply
+     * results table only lists what actually changed.
      *
      * @param  array<string, array<int, class-string>>  $scopes  ordered label => step class names
      */
@@ -69,23 +71,54 @@ trait RunsSteppedCommands
             return SymfonyCommand::SUCCESS;
         }
 
+        $pending = $plan->filter(fn (array $entry) => static::planEntryHasWork($entry))->values();
+
+        if ($pending->isEmpty()) {
+            info(sprintf('Already in sync — %s has no pending changes.', $environment));
+
+            return SymfonyCommand::SUCCESS;
+        }
+
         if (! $this->confirmGate($environment)) {
             warning('Aborted — no changes made.');
 
             return SymfonyCommand::SUCCESS;
         }
 
+        // Apply pass only over the pending entries — the plan-clean steps are
+        // already verified in sync and don't need a second Describe* + tag re-put.
+        $applyPlan = $pending->map(fn (array $entry) => [
+            'scope' => $entry['scope'],
+            'step' => $entry['step'],
+        ])->values();
+
         // Step instances are reused across passes; clear the changes the plan
         // pass recorded so RecordsChanges starts fresh under apply.
-        $this->resetRecordedChanges($planned);
+        $this->resetRecordedChanges($applyPlan);
 
         $now = time();
 
-        $applied = $this->executePlan($planned, $now, apply: true);
+        $applied = $this->executePlan($applyPlan, $now, apply: true);
 
         $this->renderResults($environment, $applied, time() - $now);
 
         return SymfonyCommand::SUCCESS;
+    }
+
+    /**
+     * Did the plan pass flag this step as having work for apply to do?
+     *
+     * A step has pending work when it would create or sync a resource, or when it
+     * recorded an attribute-level Change. Everything else — clean SYNCED, SKIPPED,
+     * CUSTOM_MANAGED — is dropped before apply.
+     *
+     * @param  array{status: StepResult|string, changes: array<int, Change>}  $entry
+     */
+    protected static function planEntryHasWork(array $entry): bool
+    {
+        return $entry['status'] === StepResult::WOULD_CREATE
+            || $entry['status'] === StepResult::WOULD_SYNC
+            || $entry['changes'] !== [];
     }
 
     /**

--- a/tests/Unit/Concerns/RunScopesRenderTest.php
+++ b/tests/Unit/Concerns/RunScopesRenderTest.php
@@ -16,7 +16,18 @@ class RunScopesFakeStep implements Step
 {
     public function __invoke(array $options): StepResult
     {
-        return StepResult::CREATED;
+        // Honour dry-run so the plan pass surfaces this step as pending work; apply
+        // would otherwise drop it (status CREATED counts as already-done).
+        return Arr::get($options, 'dry-run') ? StepResult::WOULD_CREATE : StepResult::CREATED;
+    }
+}
+
+/** A step that's already in sync — clean SYNCED on both passes, never any drift. */
+class RunScopesCleanStep implements Step
+{
+    public function __invoke(array $options): StepResult
+    {
+        return StepResult::SYNCED;
     }
 }
 
@@ -182,4 +193,38 @@ it('dry-run renders the plan and stops — no apply, no results table, no comple
         ->toContain('idle_timeout')
         ->toContain('Dry run')
         ->not->toContain('Synced testing'); // no apply ran
+});
+
+it('skips the apply pass when nothing drifted — no confirm, no results table', function () {
+    $output = runScopesCapture(
+        ['environment' => [RunScopesCleanStep::class, RunScopesCleanStep::class]],
+        ['--no-progress' => true],
+    );
+
+    expect($output)
+        ->toContain('Already in sync')
+        ->not->toContain('Pending changes')
+        ->not->toContain('Synced testing'); // apply never ran
+});
+
+it('apply pass runs only the pending steps — clean steps are dropped from the results table', function () {
+    $output = runScopesCapture(
+        ['environment' => [RunScopesCleanStep::class, RunScopesChangeStep::class, RunScopesCleanStep::class]],
+        ['--no-progress' => true],
+    );
+
+    // The drifted step appears in the apply table (renders as SYNCED post-apply
+    // because RunScopesChangeStep returns SYNCED when dry-run is off), and the
+    // clean RunScopesCleanSteps never re-ran — only one step is in the table.
+    expect($output)
+        ->toContain('Pending changes')
+        ->toContain('idle_timeout')
+        ->toContain('Synced testing')
+        ->toContain('Run scopes change');
+
+    // Only one row in the table — the table border ─ rules sit immediately above
+    // and below the row, so a single `Run scopes change` between them confirms
+    // the clean steps were dropped from apply.
+    expect(substr_count($output, 'Run scopes change'))->toBe(2); // pending + apply row
+    expect($output)->not->toContain('Run scopes clean');
 });


### PR DESCRIPTION
## Summary
- Plan → apply used to invoke every step twice. Steps the plan returned as clean `SYNCED` still re-ran their `exists()` / `Describe*` round-trip and re-put their tags on apply before reporting "no change". A 40-step sync with 2 drifted resources still fired ~38 redundant `Describe*` + `TagResource` calls on apply.
- Filter the apply collection to entries whose plan status was `WOULD_CREATE` / `WOULD_SYNC`, or that recorded an attribute-level `Change`. Clean `SYNCED` / `SKIPPED` / `CUSTOM_MANAGED` are dropped before apply, so the **post-apply results table only lists what actually changed**.
- When the plan is entirely clean, skip the confirm gate and exit with "Already in sync" — no apply, no second pass, no empty results table.

## Before / after on a clean env
**Before:** plan shows "no pending changes" → confirm fires → apply iterates every step (Describe* + TagResource per resource) → results table prints every step as `SYNCED`.

**After:** plan shows "no pending changes" → "Already in sync — env has no pending changes." → exit.

## Before / after on a drifted env (2 of 40 steps drifted)
**Before:** apply re-runs all 40 steps; results table has 40 rows; ~38 redundant API reads.

**After:** apply re-runs only the 2 drifted steps; results table has 2 rows; zero redundant reads.

## Test plan
- [x] `./vendor/bin/pest` — 392 passed
- [x] `./vendor/bin/phpstan analyse` — no errors
- [x] `./vendor/bin/pint --test` — passed
- [x] New tests: (a) clean plan → no apply, no results table; (b) mixed plan → only the drifted step in the apply results table, clean steps dropped
- [ ] Real `yolo sync production` against an already-synced env — should report `Already in sync` and exit without iterating resources
- [ ] Real `yolo sync production` with one drifted attribute — should plan / confirm / apply only the drifted step

🤖 Generated with [Claude Code](https://claude.com/claude-code)