### PR TITLE
fix(asset-distribution): treat absent OriginRequestPolicyId as '' to stop phantom drift loop

### DIFF
--- a/src/Resources/CloudFront/AssetDistribution.php
+++ b/src/Resources/CloudFront/AssetDistribution.php
@@ -162,11 +162,7 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
 
         $desired = static::reconcilableBehaviour($this->resolveResponseHeadersPolicyId($apply));
 
-        $changes = collect($desired)
-            ->filter(fn (mixed $value, string $key) => ($behaviour[$key] ?? null) !== $value)
-            ->map(fn (mixed $value, string $key) => Change::make($key, $behaviour[$key] ?? null, $value))
-            ->values()
-            ->all();
+        $changes = static::behaviourDrift($behaviour, $desired);
 
         if ($errorChange = static::errorCachingDrift((array) ($config['CustomErrorResponses'] ?? []))) {
             $changes[] = $errorChange;
@@ -231,6 +227,26 @@ class AssetDistribution implements Resource, SynchronisesConfiguration
                 'ErrorCachingMinTTL' => 0,
             ], static::ERROR_CODES_NOT_CACHED),
         ];
+    }
+
+    /**
+     * Drifted reconcilable-behaviour fields between live and desired. Treats an
+     * absent live value as equivalent to a desired empty string — CloudFront
+     * returns an unset OriginRequestPolicyId as absent on read but accepts ''
+     * on UpdateDistribution write, so the value `'' → absent` round-trips and
+     * would otherwise read as permanent drift on every plan after apply.
+     *
+     * @param  array<string, mixed>  $behaviour
+     * @param  array<string, mixed>  $desired
+     * @return array<int, Change>
+     */
+    public static function behaviourDrift(array $behaviour, array $desired): array
+    {
+        return collect($desired)
+            ->filter(fn (mixed $value, string $key) => ($behaviour[$key] ?? '') !== $value)
+            ->map(fn (mixed $value, string $key) => Change::make($key, $behaviour[$key] ?? null, $value))
+            ->values()
+            ->all();
     }
 
     /**

--- a/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
+++ b/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
@@ -91,18 +91,21 @@ it('reconciles the managed cache-behaviour policy fields', function () {
 });
 
 it('sees no drift when the live behaviour already carries the managed fields', function () {
+    // Realistic post-sync shape: CloudFront's GetDistributionConfig omits
+    // OriginRequestPolicyId from the response when no policy is attached, even
+    // though UpdateDistribution wrote it as ''. Filter must treat absent ↔ ''
+    // as equivalent or every plan reports phantom `OriginRequestPolicyId:
+    // absent → ` drift forever.
     $live = [
         'TargetOriginId' => 'asset-bucket',
         'ViewerProtocolPolicy' => 'redirect-to-https',
         'Compress' => true,
         'CachePolicyId' => '658327ea-f89d-4fab-a63d-7e88639e58f6',
-        'OriginRequestPolicyId' => '',
         'ResponseHeadersPolicyId' => 'rhp-resolved-id',
         'MinTTL' => 0,
     ];
 
-    // No update should fire — merging the managed fields leaves the block unchanged.
-    expect(array_merge($live, AssetDistribution::reconcilableBehaviour('rhp-resolved-id')) == $live)->toBeTrue();
+    expect(AssetDistribution::behaviourDrift($live, AssetDistribution::reconcilableBehaviour('rhp-resolved-id')))->toBe([]);
 });
 
 it('sees drift on a distribution still using the Origin-keyed cache policy', function () {
@@ -119,7 +122,10 @@ it('sees drift on a distribution still using the Origin-keyed cache policy', fun
         'MinTTL' => 0,
     ];
 
-    expect(array_merge($preFix, AssetDistribution::reconcilableBehaviour('rhp-resolved-id')) == $preFix)->toBeFalse();
+    $changes = AssetDistribution::behaviourDrift($preFix, AssetDistribution::reconcilableBehaviour('rhp-resolved-id'));
+
+    expect(collect($changes)->pluck('attribute')->all())
+        ->toEqualCanonicalizing(['CachePolicyId', 'OriginRequestPolicyId', 'ResponseHeadersPolicyId']);
 });
 
 it('pins every tracked 5xx to a zero error-caching TTL', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- `yolo sync <env>` reported `OriginRequestPolicyId: absent → ` as a pending change to the asset distribution on every plan, even immediately after a successful apply. Accepting the prompt wrote the value, CloudFront stored it as "no policy", the next plan re-read absent, and the same diff resurfaced — phantom drift forever.
- The two existing unit tests for `reconcilableBehaviour` used `array_merge ... ==` and never exercised the buggy comparator in `synchroniseConfiguration`, which is why the regression shipped through #54/#56.

**Is there anything the reviewer needs to know to deploy this?**
- Root cause: `synchroniseConfiguration` compared `$behaviour[$key] ?? null` strict-not-equal to desired. The asset distribution deliberately desires `OriginRequestPolicyId => ''` (no origin-request policy), but CloudFront's `GetDistributionConfig` omits the field from the response once it's unset. `null !== ''` → false drift.
- Fix: normalise absent ↔ `''` in the drift comparator. `Change::make` still receives the live value as null so the UI continues to render `absent → ` for genuine drift (e.g. a distribution still carrying the old custom Origin-keyed `OriginRequestPolicyId`).
- Drift detection extracted to a public static `AssetDistribution::behaviourDrift($behaviour, $desired)` so the regression is unit-testable. The two tests at lines 93/108 rewritten to call it directly; the no-drift test now models the realistic CloudFront response shape (no `OriginRequestPolicyId` key in `$live`).
- No behaviour change for resources that actually have drifted: the apply path still writes `OriginRequestPolicyId => ''` and the Change UI still surfaces real `id → id` swaps.
- 392 tests green, pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)