### PR TITLE
docs: render one consolidated sidebar across guide and reference

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -18,43 +18,42 @@ export default defineConfig({
       { text: 'Reference', link: '/reference/commands' },
     ],
 
-    sidebar: {
-      '/guide/': [
-        {
-          text: 'Introduction',
-          items: [
-            { text: 'What is YOLO?', link: '/guide/what-is-yolo' },
-            { text: 'Getting Started', link: '/guide/getting-started' },
-          ],
-        },
-        {
-          text: 'Essentials',
-          items: [
-            { text: 'The Container Image', link: '/guide/images' },
-            { text: 'Environment Files', link: '/guide/environment-files' },
-            { text: 'Provisioning', link: '/guide/provisioning' },
-            { text: 'Building & Deploying', link: '/guide/building-and-deploying' },
-          ],
-        },
-        {
-          text: 'Features',
-          items: [
-            { text: 'Domains', link: '/guide/domains' },
-            { text: 'Multi-Tenancy', link: '/guide/multi-tenancy' },
-            { text: 'CI/CD', link: '/guide/ci-cd' },
-          ],
-        },
-      ],
-      '/reference/': [
-        {
-          text: 'Reference',
-          items: [
-            { text: 'Commands', link: '/reference/commands' },
-            { text: 'Manifest', link: '/reference/manifest' },
-          ],
-        },
-      ],
-    },
+    // One consolidated sidebar shown on every page, so the Guide and the
+    // Reference are always reachable from each other (VitePress otherwise scopes
+    // a path-keyed sidebar to its own section).
+    sidebar: [
+      {
+        text: 'Introduction',
+        items: [
+          { text: 'What is YOLO?', link: '/guide/what-is-yolo' },
+          { text: 'Getting Started', link: '/guide/getting-started' },
+        ],
+      },
+      {
+        text: 'Essentials',
+        items: [
+          { text: 'The Container Image', link: '/guide/images' },
+          { text: 'Environment Files', link: '/guide/environment-files' },
+          { text: 'Provisioning', link: '/guide/provisioning' },
+          { text: 'Building & Deploying', link: '/guide/building-and-deploying' },
+        ],
+      },
+      {
+        text: 'Features',
+        items: [
+          { text: 'Domains', link: '/guide/domains' },
+          { text: 'Multi-Tenancy', link: '/guide/multi-tenancy' },
+          { text: 'CI/CD', link: '/guide/ci-cd' },
+        ],
+      },
+      {
+        text: 'Reference',
+        items: [
+          { text: 'Commands', link: '/reference/commands' },
+          { text: 'Manifest', link: '/reference/manifest' },
+        ],
+      },
+    ],
 
     socialLinks: [
       { icon: 'github', link: 'https://github.com/codinglabsau/yolo' },


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- The docs sidebar was path-keyed (`/guide/` vs `/reference/`), so VitePress scoped each sidebar to its own section. From any guide page the **Manifest** and **Commands** references were unreachable, and from the reference pages the guides were unreachable.
- Collapsed the two scoped sidebars into a single array, which VitePress renders on **every** page — the full tree (Introduction, Essentials, Features, Reference) is now always present, so Guide ↔ Reference are always one click apart.

**Is there anything the reviewer needs to know to deploy this?**
- Docs-only change to `docs/.vitepress/config.ts` (sidebar config). No app/runtime code touched.
- `vitepress build` passes clean — no dead links, config valid. Publishes to `codinglabsau.github.io/yolo/` via the existing `docs.yml` workflow on merge.

🤖 Generated with [Claude Code](https://claude.ai/code)