### PR TITLE
feat(sync): per-app CloudWatch dashboard in sync:app

### DIFF
--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -14,7 +14,7 @@ YOLO groups every resource by **ownership scope** — the blast radius if it cha
 |---|---|---|---|
 | `yolo sync:account <env>` | **Account** | the whole AWS account | GitHub OIDC provider |
 | `yolo sync:environment <env>` | **Environment** | every app in the environment | VPC, subnets, internet gateway & routes, RDS security group, SNS alarm topic, shared ECS task & execution IAM roles, the ALB and its `:80`/`:443` listeners |
-| `yolo sync:app <env>` | **App** | one app | S3 buckets, app IAM (deployer role/policy), ECS cluster/service/task definition, target group + listener rule, CloudFront distribution, hosted zone & ACM certificate, SQS queues |
+| `yolo sync:app <env>` | **App** | one app | S3 buckets, app IAM (deployer role/policy), ECS cluster/service/task definition, target group + listener rule, CloudFront distribution, hosted zone & ACM certificate, SQS queues, CloudWatch dashboard |
 
 The bare `yolo sync` runs all three **in dependency order** — account, then environment, then app:
 
@@ -77,6 +77,10 @@ yolo audit production
 | `ok` | Accounted for — `yolo:app` points at a live app, or it carries a `yolo:scope=env`/`=account` marker (declared shared infra). |
 | `drift` | `yolo:app` points at an app whose ECS cluster is gone — leftover resources from a removed app. |
 | `rogue` | Tagged for the environment but with **no** YOLO ownership marker — hand-rolled infrastructure or alpha-era debris in the environment's namespace. |
+
+::: tip The per-app dashboard isn't audited
+`sync:app` also generates a CloudWatch dashboard (`yolo-<env>-<app>-dashboard`) panelling the app's ECS service, ALB, SQS queues, CloudFront, S3 and logs, plus an RDS panel derived from `DB_HOST`. CloudWatch dashboards can't carry tags, so it's a read-only convenience that **won't** show up in `yolo audit`.
+:::
 
 Like sync, audit is scope-grouped — narrow it with `audit:environment <env>` or `audit:app <env> <app>`, and add `--drift` to show only the drifted rows:
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -215,7 +215,7 @@ Arguments and options as [`sync`](#sync-options). Scope: **environment**. These 
 
 ## `yolo sync:app`
 
-Sync a single application's resources for the given environment — S3 buckets, app IAM (deployer role/policy, MediaConvert role for IVS), ECS cluster/service/task definition, target group + listener rule, CloudFront distribution, SQS queues, and — for a solo app — its hosted zone and ACM certificate.
+Sync a single application's resources for the given environment — S3 buckets, app IAM (deployer role/policy, MediaConvert role for IVS), ECS cluster/service/task definition, target group + listener rule, CloudFront distribution, SQS queues, a CloudWatch dashboard, and — for a solo app — its hosted zone and ACM certificate.
 
 ```bash
 yolo sync:app <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
@@ -226,6 +226,8 @@ Arguments and options as [`sync`](#sync-options). Scope: **app**.
 The step set is mode-aware: a multi-tenant app fans out landlord + per-tenant queues (and skips the solo hosted zone/cert); a solo app gets the apex zone + certificate. Web/CDN steps only run when `tasks.web` is declared. Use `--tenant=<id>` to narrow per-tenant steps to one tenant.
 
 Two environment-tier resources are bootstrapped here by exception — the RDS security group (because its real purpose is this app's task-SG ingress) and the HTTPS `:443` listener (because its creation needs this app's certificate). Both are created-if-missing and never mutated, so the environment tier remains their single writer.
+
+A per-app **CloudWatch dashboard** (`yolo-<env>-<app>-dashboard`) is generated last, so every resource it charts already exists. It panels the ECS service (CPU/memory/tasks), the ALB (requests, latency, errors), SQS depth/throughput, the asset CloudFront distribution, the S3 buckets and the app's logs — plus an RDS panel derived from `DB_HOST` in the app's env file. It's a read-only convenience: CloudWatch dashboards can't carry tags, so it doesn't appear in `yolo audit`.
 
 ---
 

--- a/src/Aws/CloudWatch.php
+++ b/src/Aws/CloudWatch.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Aws;
 
 use Codinglabs\Yolo\Aws;
+use Aws\Exception\AwsException;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 class CloudWatch
@@ -16,5 +17,23 @@ class CloudWatch
         }
 
         throw new ResourceDoesNotExistException("Could not find CloudWatch alarm $name");
+    }
+
+    /**
+     * The decoded body of a dashboard, addressed by name. Returns the parsed
+     * `{ "widgets": [...] }` document so callers diff an array, not a JSON string.
+     * Translates the SDK's not-found error to the project's standard signal.
+     *
+     * @return array<string, mixed>
+     */
+    public static function dashboard(string $name): array
+    {
+        try {
+            $body = Aws::cloudWatch()->getDashboard(['DashboardName' => $name])['DashboardBody'];
+        } catch (AwsException) {
+            throw new ResourceDoesNotExistException("Could not find CloudWatch dashboard $name");
+        }
+
+        return json_decode($body, true);
     }
 }

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -76,6 +76,8 @@ class SyncAppCommand extends SyncSteppedCommand
                 Steps\Sync\App\SyncIvsCloudWatchLogGroupStep::class,
                 Steps\Sync\App\SyncIvsEventBridgeRuleStep::class,
                 Steps\Sync\App\SyncIvsEventBridgeTargetStep::class,
+                // observability — runs last so every resource it charts already exists
+                Steps\Sync\App\SyncCloudWatchDashboardStep::class,
             ],
         ];
     }

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -1,0 +1,741 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\CloudWatch;
+
+use Dotenv\Dotenv;
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Change;
+use Illuminate\Support\Str;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Aws\CloudFront;
+use Codinglabs\Yolo\Aws\CloudWatch;
+use Codinglabs\Yolo\Resources\Ecs\EcsCluster;
+use Codinglabs\Yolo\Resources\Ecs\EcsService;
+use Codinglabs\Yolo\Resources\S3\AssetBucket;
+use Codinglabs\Yolo\Resources\ElbV2\TargetGroup;
+use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
+use Codinglabs\Yolo\Resources\CloudWatchLogs\IvsLogGroup;
+use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
+use Codinglabs\Yolo\Resources\CloudFront\AssetDistribution;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * A per-app CloudWatch dashboard giving at-a-glance visibility across every
+ * service YOLO provisions for the app — the ECS service (web + in-task queue &
+ * scheduler), the ALB it sits behind, its SQS queues, the asset CloudFront
+ * distribution, its S3 buckets and its log groups — plus the RDS database it
+ * connects to (derived deterministically from DB_HOST in the app's env file).
+ *
+ * Like QueueAlarm this is a standalone reconciler, NOT a Resource: a dashboard
+ * carries no meaningful tags (CloudWatch only tags alarms / Contributor Insights
+ * rules) and PutDashboard is a pure upsert with no create/update split. Unlike
+ * the blind QueueAlarm step it is dry-run honest — it reads the live body, diffs
+ * it against the desired body (key-order-independent) and only writes on drift,
+ * so `sync --dry-run` reports exactly when the dashboard would change.
+ *
+ * The widget body is built from a resolved context: names are derived (ECS, SQS,
+ * S3, log groups), the RDS identifier comes from the env file, and the three
+ * AWS-assigned identifiers (the ALB and target-group ARN suffixes and the
+ * CloudFront distribution id) are looked up live and their widget groups omitted
+ * if the backing resource doesn't exist yet — so on a greenfield first sync those
+ * panels land on the next sync once their resources are provisioned.
+ */
+class Dashboard
+{
+    // Sensible default annotation thresholds. The queue-depth line instead
+    // reuses aws.sqs.depth-alarm-threshold so the graph and the existing
+    // QueueAlarm agree. CPU bands stay hardcoded until the web-scaling config
+    // lands with autoscaling, at which point the scale line reads from it.
+    protected const CPU_SCALE_THRESHOLD = 60;
+
+    protected const CPU_CRITICAL_THRESHOLD = 80;
+
+    protected const RESPONSE_TIME_TARGET = 0.25;
+
+    protected const RESPONSE_TIME_ALARM = 1.5;
+
+    protected const BLUE = '#1f77b4';
+
+    protected const GREEN = '#2ca02c';
+
+    protected const ORANGE = '#ff7f0e';
+
+    protected const RED = '#d62728';
+
+    protected const PURPLE = '#9467bd';
+
+    public function name(): string
+    {
+        return Helpers::keyedResourceName('dashboard');
+    }
+
+    public function exists(): bool
+    {
+        try {
+            CloudWatch::dashboard($this->name());
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    /**
+     * Build the desired body, diff it against the live dashboard, and (only when
+     * $apply and something drifted) push it. Returns the drift as Change[] so the
+     * step reports WOULD_SYNC / SYNCED and the apply pass survives the
+     * only-pending-steps filter.
+     *
+     * @return array<int, Change>
+     */
+    public function synchronise(bool $apply): array
+    {
+        $desired = static::body($this->resolveContext());
+        $live = $this->liveBody();
+
+        if (Helpers::documentsEqual($live, $desired)) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::cloudWatch()->putDashboard([
+                'DashboardName' => $this->name(),
+                'DashboardBody' => json_encode($desired),
+            ]);
+        }
+
+        return [Change::make(
+            'dashboard',
+            $live === null ? 'absent' : 'drifted',
+            sprintf('%d widgets', count($desired['widgets'])),
+        )];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    protected function liveBody(): ?array
+    {
+        try {
+            return CloudWatch::dashboard($this->name());
+        } catch (ResourceDoesNotExistException) {
+            return null;
+        }
+    }
+
+    /**
+     * Resolve every value the body needs. Names are derived; the RDS identifier
+     * comes from the env; the three AWS-assigned identifiers are looked up live
+     * and left null (→ widget omitted) when their resource doesn't exist yet.
+     *
+     * @return array<string, mixed>
+     */
+    public function resolveContext(): array
+    {
+        $web = Manifest::has('tasks.web');
+
+        return [
+            'region' => Manifest::get('aws.region'),
+            'web' => $web,
+            'clusterName' => $web ? (new EcsCluster())->name() : null,
+            'serviceName' => $web ? (new EcsService())->name() : null,
+            'albSuffix' => $web ? static::tryResolve(fn () => static::loadBalancerDimension((new LoadBalancer())->arn())) : null,
+            'targetGroupSuffix' => $web ? static::tryResolve(fn () => static::targetGroupDimension((new TargetGroup())->arn())) : null,
+            'distributionId' => $web ? static::tryResolve(fn () => CloudFront::distributionByComment((new AssetDistribution())->name())['Id']) : null,
+            'queuePrefix' => Helpers::keyedResourceName() . '-',
+            'queues' => static::queueNames(),
+            'rds' => static::rdsTarget($this->databaseHost()),
+            'buckets' => static::bucketNames(),
+            'taskLogGroup' => $web ? (new TaskLogGroup())->name() : null,
+            'ivsLogGroup' => Manifest::ivsEnabled() ? (new IvsLogGroup())->name() : null,
+            'depthThreshold' => (int) Manifest::get('aws.sqs.depth-alarm-threshold', 100),
+        ];
+    }
+
+    /**
+     * @param  callable(): string  $resolve
+     */
+    protected static function tryResolve(callable $resolve): ?string
+    {
+        try {
+            return $resolve();
+        } catch (ResourceDoesNotExistException) {
+            return null;
+        }
+    }
+
+    /**
+     * The app's SQS queue names, matching the queue steps: one for a solo app, or
+     * the landlord queue plus one per tenant for a multi-tenant app.
+     *
+     * @return array<int, string>
+     */
+    protected static function queueNames(): array
+    {
+        if (Manifest::isMultitenanted()) {
+            return [
+                Helpers::keyedResourceName('landlord'),
+                ...collect(Manifest::tenants())->keys()->map(fn (string $id) => Helpers::keyedResourceName($id))->all(),
+            ];
+        }
+
+        return [Helpers::keyedResourceName()];
+    }
+
+    /**
+     * The S3 buckets YOLO owns for the app: artefacts and assets always, plus the
+     * optional application data bucket when aws.bucket is configured.
+     *
+     * @return array<int, string>
+     */
+    protected static function bucketNames(): array
+    {
+        return collect([
+            Paths::s3ArtefactsBucket(),
+            (new AssetBucket())->name(),
+            Manifest::has('aws.bucket') ? Paths::s3AppBucket() : null,
+        ])->filter()->values()->all();
+    }
+
+    /**
+     * DB_HOST from the app's env file (stored in the artefacts bucket). Returns
+     * null when the env isn't there yet (pre-env:push) — the RDS section is then
+     * simply omitted.
+     */
+    protected function databaseHost(): ?string
+    {
+        try {
+            $body = Aws::s3()->getObject([
+                'Bucket' => Paths::s3ArtefactsBucket(),
+                'Key' => sprintf('.env.%s', Helpers::environment()),
+            ])['Body'];
+
+            return Dotenv::parse((string) $body)['DB_HOST'] ?? null;
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    /**
+     * Map an RDS endpoint hostname to its CloudWatch metric target. An Aurora
+     * endpoint (`{cluster}.cluster-{hash}.{region}.rds.amazonaws.com`) keys on
+     * DBClusterIdentifier + Role=WRITER; a plain instance keys on
+     * DBInstanceIdentifier. A non-RDS host (external DB, RDS Proxy, localhost)
+     * returns null so the section is dropped rather than pointing at nothing.
+     *
+     * @return array{identifier: string, cluster: bool}|null
+     */
+    public static function rdsTarget(?string $host): ?array
+    {
+        if ($host === null || ! str_ends_with($host, '.rds.amazonaws.com')) {
+            return null;
+        }
+
+        // RDS Proxy endpoints don't map to a DB metric identifier.
+        if (str_contains($host, '.proxy-')) {
+            return null;
+        }
+
+        return [
+            'identifier' => strtok($host, '.'),
+            'cluster' => str_contains($host, '.cluster-'),
+        ];
+    }
+
+    /**
+     * The CloudWatch `LoadBalancer` dimension value (`app/{name}/{id}`) parsed
+     * out of a full ALB ARN.
+     */
+    public static function loadBalancerDimension(string $arn): string
+    {
+        $position = strpos($arn, ':loadbalancer/');
+
+        return $position === false ? $arn : substr($arn, $position + strlen(':loadbalancer/'));
+    }
+
+    /**
+     * The CloudWatch `TargetGroup` dimension value (`targetgroup/{name}/{id}`)
+     * parsed out of a full target-group ARN.
+     */
+    public static function targetGroupDimension(string $arn): string
+    {
+        $position = strpos($arn, ':targetgroup/');
+
+        return $position === false ? $arn : substr($arn, $position + 1);
+    }
+
+    /**
+     * The full dashboard document, assembled purely from a resolved context so it
+     * can be asserted in tests without touching AWS.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{widgets: array<int, array<string, mixed>>}
+     */
+    public static function body(array $context): array
+    {
+        $widgets = [];
+        $y = 0;
+
+        if ($context['web']) {
+            [$section, $y] = static::webSection($context, $y);
+            $widgets = [...$widgets, ...$section];
+        }
+
+        [$section, $y] = static::queueSection($context, $y);
+        $widgets = [...$widgets, ...$section];
+
+        if ($context['rds'] !== null) {
+            [$section, $y] = static::databaseSection($context, $y);
+            $widgets = [...$widgets, ...$section];
+        }
+
+        [$section, $y] = static::storageSection($context, $y);
+        $widgets = [...$widgets, ...$section];
+
+        [$section, $y] = static::logsSection($context, $y);
+        $widgets = [...$widgets, ...$section];
+
+        return ['widgets' => $widgets];
+    }
+
+    /**
+     * ECS compute (one service — web + in-task queue & scheduler) and, when the
+     * ALB is attached, the request / latency / error panels in front of it.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function webSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+        $cluster = $context['clusterName'];
+        $service = $context['serviceName'];
+        $alb = $context['albSuffix'];
+        $targetGroup = $context['targetGroupSuffix'];
+
+        $widgets = [static::header($y, '# Web')];
+        $y++;
+
+        if ($alb !== null) {
+            $requests = [['AWS/ApplicationELB', 'RequestCount', 'LoadBalancer', $alb, ['label' => 'Total requests', 'color' => static::BLUE]]];
+
+            if ($targetGroup !== null) {
+                $requests[] = ['AWS/ApplicationELB', 'RequestCountPerTarget', 'TargetGroup', $targetGroup, ['label' => 'Requests per task', 'color' => static::GREEN]];
+            }
+
+            $widgets[] = static::metric(0, $y, 12, 6, [
+                'title' => 'Requests',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Sum',
+                'metrics' => $requests,
+            ]);
+
+            $widgets[] = static::metric(12, $y, 12, 6, [
+                'title' => 'Response time',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'p95',
+                'yAxis' => ['left' => ['min' => 0]],
+                'metrics' => [
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => 'IQM', 'stat' => 'IQM', 'color' => static::BLUE]],
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => 'p95', 'stat' => 'p95', 'color' => static::ORANGE]],
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => 'p99', 'stat' => 'p99', 'color' => static::RED]],
+                ],
+                'annotations' => ['horizontal' => [
+                    ['color' => static::RED, 'label' => 'Alarm', 'value' => static::RESPONSE_TIME_ALARM, 'fill' => 'above'],
+                    ['color' => static::GREEN, 'label' => 'Target', 'value' => static::RESPONSE_TIME_TARGET],
+                ]],
+            ]);
+            $y += 6;
+
+            $widgets[] = static::metric(0, $y, 12, 6, [
+                'title' => 'Slow requests',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => true,
+                'period' => 60,
+                'yAxis' => ['left' => ['showUnits' => false]],
+                'metrics' => [
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => '2-5s', 'stat' => 'TS(2:5)', 'color' => '#98df8a']],
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => '5-10s', 'stat' => 'TS(5:10)', 'color' => static::ORANGE]],
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => '10-30s', 'stat' => 'TS(10:30)', 'color' => static::RED]],
+                    ['AWS/ApplicationELB', 'TargetResponseTime', 'LoadBalancer', $alb, ['label' => '> 30s', 'stat' => 'TS(30:60)', 'color' => static::PURPLE]],
+                ],
+            ]);
+
+            $widgets[] = static::metric(12, $y, 12, 6, [
+                'title' => 'HTTP errors',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Sum',
+                'metrics' => [
+                    ['AWS/ApplicationELB', 'HTTPCode_Target_4XX_Count', 'LoadBalancer', $alb, ['label' => '4xx', 'color' => static::ORANGE]],
+                    ['AWS/ApplicationELB', 'HTTPCode_Target_5XX_Count', 'LoadBalancer', $alb, ['label' => 'Target 5xx', 'color' => static::RED]],
+                    ['AWS/ApplicationELB', 'HTTPCode_ELB_5XX_Count', 'LoadBalancer', $alb, ['label' => 'ELB 5xx', 'color' => static::PURPLE]],
+                ],
+            ]);
+            $y += 6;
+        }
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'CPU utilisation',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0, 'max' => 100]],
+            'metrics' => [
+                ['AWS/ECS', 'CPUUtilization', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Average', 'color' => static::BLUE]],
+                ['AWS/ECS', 'CPUUtilization', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Max', 'stat' => 'Maximum', 'color' => static::ORANGE]],
+            ],
+            'annotations' => ['horizontal' => [
+                ['color' => static::ORANGE, 'label' => 'Scale', 'value' => static::CPU_SCALE_THRESHOLD],
+                ['color' => static::RED, 'label' => 'Critical', 'value' => static::CPU_CRITICAL_THRESHOLD, 'fill' => 'above'],
+            ]],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'Memory utilisation',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0, 'max' => 100]],
+            'metrics' => [
+                ['AWS/ECS', 'MemoryUtilization', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Average', 'color' => static::BLUE]],
+                ['AWS/ECS', 'MemoryUtilization', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Max', 'stat' => 'Maximum', 'color' => static::ORANGE]],
+            ],
+        ]);
+        $y += 6;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'Tasks (running vs desired)',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0]],
+            'metrics' => [
+                ['ECS/ContainerInsights', 'RunningTaskCount', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Running', 'color' => static::GREEN]],
+                ['ECS/ContainerInsights', 'DesiredTaskCount', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Desired', 'color' => static::BLUE]],
+            ],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'Network in/out',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'metrics' => [
+                ['ECS/ContainerInsights', 'NetworkRxBytes', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Rx', 'color' => static::BLUE]],
+                ['ECS/ContainerInsights', 'NetworkTxBytes', 'ClusterName', $cluster, 'ServiceName', $service, ['label' => 'Tx', 'color' => static::ORANGE]],
+            ],
+        ]);
+        $y += 6;
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * SQS depth, throughput and oldest-message age across the app's queues.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function queueSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+        $queues = $context['queues'];
+
+        $series = fn (string $metric) => collect($queues)
+            ->map(fn (string $queue) => ['AWS/SQS', $metric, 'QueueName', $queue, ['label' => static::queueLabel($queue, $context['queuePrefix'])]])
+            ->all();
+
+        $widgets = [static::header($y, '# Queue')];
+        $y++;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'Queue depth',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => true,
+            'period' => 60,
+            'stat' => 'Maximum',
+            'metrics' => $series('ApproximateNumberOfMessagesVisible'),
+            'annotations' => ['horizontal' => [
+                ['label' => 'Depth alarm', 'value' => $context['depthThreshold'], 'color' => static::RED],
+            ]],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'Queue throughput',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => true,
+            'period' => 60,
+            'stat' => 'Sum',
+            'metrics' => $series('NumberOfMessagesSent'),
+        ]);
+        $y += 6;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'Oldest message age',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Maximum',
+            'metrics' => $series('ApproximateAgeOfOldestMessage'),
+        ]);
+        $y += 6;
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * RDS health for the database the app connects to (Aurora cluster writer or a
+     * plain instance), derived from DB_HOST.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function databaseSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+        $rds = $context['rds'];
+
+        $metric = fn (string $name, array $options = []) => ['AWS/RDS', $name, ...static::rdsDimensions($rds), $options];
+
+        $widgets = [static::header($y, '# Database')];
+        $y++;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'RDS CPU',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0, 'max' => 100]],
+            'metrics' => [$metric('CPUUtilization')],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'RDS connections',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'metrics' => [$metric('DatabaseConnections')],
+        ]);
+        $y += 6;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'RDS freeable memory',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'metrics' => [$metric('FreeableMemory')],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'RDS throughput',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => true,
+            'period' => 60,
+            'stat' => 'Sum',
+            'metrics' => [
+                $metric('SelectThroughput', ['label' => 'SELECT', 'color' => static::BLUE]),
+                $metric('InsertThroughput', ['label' => 'INSERT', 'color' => static::GREEN]),
+                $metric('UpdateThroughput', ['label' => 'UPDATE', 'color' => static::ORANGE]),
+                $metric('DeleteThroughput', ['label' => 'DELETE', 'color' => static::RED]),
+            ],
+        ]);
+        $y += 6;
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * @param  array{identifier: string, cluster: bool}  $rds
+     * @return array<int, string>
+     */
+    protected static function rdsDimensions(array $rds): array
+    {
+        return $rds['cluster']
+            ? ['DBClusterIdentifier', $rds['identifier'], 'Role', 'WRITER']
+            : ['DBInstanceIdentifier', $rds['identifier']];
+    }
+
+    /**
+     * The asset CloudFront distribution (omitted until it exists) and the app's
+     * S3 buckets.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function storageSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+        $distributionId = $context['distributionId'];
+        $buckets = $context['buckets'];
+
+        $widgets = [static::header($y, '# CDN & storage')];
+        $y++;
+
+        if ($distributionId !== null) {
+            $widgets[] = static::metric(0, $y, 12, 6, [
+                'title' => 'Asset CDN — requests',
+                'region' => 'us-east-1',
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Sum',
+                'yAxis' => ['right' => ['showUnits' => false]],
+                'metrics' => [
+                    ['AWS/CloudFront', 'Requests', 'Region', 'Global', 'DistributionId', $distributionId, ['label' => 'Requests', 'color' => static::BLUE]],
+                    ['AWS/CloudFront', '4xxErrorRate', 'Region', 'Global', 'DistributionId', $distributionId, ['label' => '4xx %', 'stat' => 'Average', 'color' => static::ORANGE, 'yAxis' => 'right']],
+                    ['AWS/CloudFront', '5xxErrorRate', 'Region', 'Global', 'DistributionId', $distributionId, ['label' => '5xx %', 'stat' => 'Average', 'color' => static::RED, 'yAxis' => 'right']],
+                ],
+            ]);
+
+            $widgets[] = static::metric(12, $y, 12, 6, [
+                'title' => 'Asset CDN — data transfer (MB)',
+                'region' => 'us-east-1',
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Sum',
+                'metrics' => [
+                    [['expression' => 'm1/1000000', 'label' => 'Downloaded MB', 'id' => 'e1', 'region' => 'us-east-1']],
+                    ['AWS/CloudFront', 'BytesDownloaded', 'Region', 'Global', 'DistributionId', $distributionId, ['id' => 'm1', 'visible' => false]],
+                ],
+            ]);
+            $y += 6;
+        }
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'S3 storage size',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 86400,
+            'stat' => 'Average',
+            'metrics' => collect($buckets)
+                ->map(fn (string $bucket) => ['AWS/S3', 'BucketSizeBytes', 'BucketName', $bucket, 'StorageType', 'StandardStorage', ['label' => $bucket]])
+                ->all(),
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'S3 object count',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 86400,
+            'stat' => 'Average',
+            'metrics' => collect($buckets)
+                ->map(fn (string $bucket) => ['AWS/S3', 'NumberOfObjects', 'BucketName', $bucket, 'StorageType', 'AllStorageTypes', ['label' => $bucket]])
+                ->all(),
+        ]);
+        $y += 6;
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * Logs Insights panels over the app's task log group and, when IVS logging is
+     * enabled, the IVS log group.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function logsSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+
+        $logGroups = collect([
+            'Application logs' => $context['taskLogGroup'],
+            'IVS logs' => $context['ivsLogGroup'],
+        ])->filter();
+
+        if ($logGroups->isEmpty()) {
+            return [[], $y];
+        }
+
+        $widgets = [static::header($y, '# Logs')];
+        $y++;
+
+        foreach ($logGroups as $title => $logGroup) {
+            $widgets[] = [
+                'type' => 'log',
+                'x' => 0,
+                'y' => $y,
+                'width' => 24,
+                'height' => 6,
+                'properties' => [
+                    'title' => $title,
+                    'region' => $region,
+                    'view' => 'table',
+                    'query' => sprintf("SOURCE '%s' | fields @timestamp, @message\n| sort @timestamp desc\n| limit 100", $logGroup),
+                ],
+            ];
+            $y += 6;
+        }
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * @param  array<string, mixed>  $properties
+     * @return array<string, mixed>
+     */
+    protected static function metric(int $x, int $y, int $width, int $height, array $properties): array
+    {
+        return [
+            'type' => 'metric',
+            'x' => $x,
+            'y' => $y,
+            'width' => $width,
+            'height' => $height,
+            'properties' => $properties,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function header(int $y, string $markdown): array
+    {
+        return [
+            'type' => 'text',
+            'x' => 0,
+            'y' => $y,
+            'width' => 24,
+            'height' => 1,
+            'properties' => ['markdown' => $markdown, 'background' => 'transparent'],
+        ];
+    }
+
+    protected static function queueLabel(string $queue, string $prefix): string
+    {
+        return Str::startsWith($queue, $prefix) ? Str::after($queue, $prefix) : $queue;
+    }
+}

--- a/src/Steps/Sync/App/SyncCloudWatchDashboardStep.php
+++ b/src/Steps/Sync/App/SyncCloudWatchDashboardStep.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Sync\App;
+
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
+use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
+
+/**
+ * Provisions the per-app CloudWatch dashboard. Runs last in sync:app so every
+ * resource it visualises already exists on the apply pass. Dry-run honest: it
+ * diffs the desired body against the live dashboard and reports WOULD_CREATE /
+ * WOULD_SYNC / SYNCED accordingly, rather than blind-stamping like the queue
+ * alarm step.
+ */
+class SyncCloudWatchDashboardStep implements Step
+{
+    use RecordsChanges;
+
+    public function __invoke(array $options): StepResult
+    {
+        $dryRun = (bool) Arr::get($options, 'dry-run');
+        $dashboard = new Dashboard();
+
+        $existed = $dashboard->exists();
+
+        $changes = $dashboard->synchronise(apply: ! $dryRun);
+
+        $this->recordChanges($changes);
+
+        if (! $existed) {
+            return $dryRun ? StepResult::WOULD_CREATE : StepResult::CREATED;
+        }
+
+        if ($changes !== []) {
+            return $dryRun ? StepResult::WOULD_SYNC : StepResult::SYNCED;
+        }
+
+        return StepResult::SYNCED;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -9,6 +9,7 @@ use Codinglabs\Yolo\Helpers;
 use GuzzleHttp\Promise\Create;
 use Symfony\Component\Yaml\Yaml;
 use Aws\CloudFront\CloudFrontClient;
+use Aws\CloudWatch\CloudWatchClient;
 
 /*
 |--------------------------------------------------------------------------
@@ -220,6 +221,41 @@ function bindMockEc2Client(array $byCommand, array &$captured): void
     };
 
     Helpers::app()->instance('ec2', new Ec2Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
+ * Bind a mock CloudWatch client with command-routed responses, capturing every
+ * call. A command's value is a single Result (repeated for every call), or a
+ * Throwable (returned as a rejection, e.g. a GetDashboard not-found) repeated
+ * the same way. Mirrors bindMockEc2Client.
+ *
+ * @param  array<string, Result|Throwable>  $byCommand
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
+ */
+function bindMockCloudWatchClient(array $byCommand, array &$captured): void
+{
+    $mock = new class($byCommand, $captured) extends MockHandler
+    {
+        public function __construct(protected array $byCommand, protected array &$captured) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->captured[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            $entry = $this->byCommand[$cmd->getName()] ?? new Result();
+
+            return $entry instanceof Throwable
+                ? Create::rejectionFor($entry)
+                : Create::promiseFor($entry);
+        }
+    };
+
+    Helpers::app()->instance('cloudWatch', new CloudWatchClient([
         'region' => 'ap-southeast-2',
         'version' => 'latest',
         'credentials' => false,

--- a/tests/Unit/Resources/CloudWatch/DashboardTest.php
+++ b/tests/Unit/Resources/CloudWatch/DashboardTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use Aws\Result;
+use Aws\Command;
+use Aws\MockHandler;
+use Aws\S3\S3Client;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
+use Codinglabs\Yolo\Steps\Sync\App\SyncCloudWatchDashboardStep;
+
+/**
+ * A resolved dashboard context — the struct body() is a pure function of, so the
+ * whole document can be asserted without touching AWS. Defaults describe a solo
+ * web app with an Aurora cluster and an asset distribution; tests override.
+ *
+ * @param  array<string, mixed>  $overrides
+ * @return array<string, mixed>
+ */
+function dashboardContext(array $overrides = []): array
+{
+    return array_merge([
+        'region' => 'ap-southeast-2',
+        'web' => true,
+        'clusterName' => 'yolo-testing-my-app',
+        'serviceName' => 'yolo-testing-my-app-web',
+        'albSuffix' => 'app/yolo-testing/abc123def456',
+        'targetGroupSuffix' => 'targetgroup/yolo-testing-my-app/0a1b2c3d4e5f',
+        'distributionId' => 'E123ABCDEF',
+        'queuePrefix' => 'yolo-testing-my-app-',
+        'queues' => ['yolo-testing-my-app'],
+        'rds' => ['identifier' => 'my-cluster', 'cluster' => true],
+        'buckets' => ['yolo-testing-my-app-artefacts', 'yolo-testing-my-app-assets'],
+        'taskLogGroup' => '/yolo/testing-my-app',
+        'ivsLogGroup' => null,
+        'depthThreshold' => 100,
+    ], $overrides);
+}
+
+/** @param  array{widgets: array<int, array<string, mixed>>}  $body */
+function widgetTitles(array $body): array
+{
+    return collect($body['widgets'])
+        ->map(fn (array $widget) => $widget['properties']['title'] ?? $widget['properties']['markdown'] ?? null)
+        ->filter()
+        ->values()
+        ->all();
+}
+
+/** @param  array{widgets: array<int, array<string, mixed>>}  $body */
+function findWidget(array $body, string $title): ?array
+{
+    return collect($body['widgets'])->first(fn (array $widget) => ($widget['properties']['title'] ?? null) === $title);
+}
+
+/** Bind an S3 client whose GetObject always returns the given env body. */
+function bindDashboardEnv(string $body): void
+{
+    $result = new Result(['Body' => $body]);
+
+    $mock = new class($result) extends MockHandler
+    {
+        public function __construct(protected Result $result) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            return Create::promiseFor($this->result);
+        }
+    };
+
+    Helpers::app()->instance('s3', new S3Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+beforeEach(function () {
+    writeManifest(['aws' => ['region' => 'ap-southeast-2', 'account-id' => '111111111111']]);
+});
+
+it('names the dashboard per app + environment', function () {
+    expect((new Dashboard())->name())->toBe('yolo-testing-my-app-dashboard');
+});
+
+it('maps an Aurora endpoint to a cluster target, an instance endpoint to an instance target', function () {
+    expect(Dashboard::rdsTarget('my-cluster.cluster-cabc123.ap-southeast-2.rds.amazonaws.com'))
+        ->toBe(['identifier' => 'my-cluster', 'cluster' => true]);
+
+    expect(Dashboard::rdsTarget('my-db.cabc123.ap-southeast-2.rds.amazonaws.com'))
+        ->toBe(['identifier' => 'my-db', 'cluster' => false]);
+});
+
+it('returns no RDS target for a non-RDS, proxy or absent host', function () {
+    expect(Dashboard::rdsTarget(null))->toBeNull();
+    expect(Dashboard::rdsTarget('127.0.0.1'))->toBeNull();
+    expect(Dashboard::rdsTarget('db.internal.example.com'))->toBeNull();
+    expect(Dashboard::rdsTarget('my-proxy.proxy-cabc.ap-southeast-2.rds.amazonaws.com'))->toBeNull();
+});
+
+it('parses the CloudWatch dimension suffix out of ELB ARNs', function () {
+    expect(Dashboard::loadBalancerDimension('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/app/yolo-testing/abc123'))
+        ->toBe('app/yolo-testing/abc123');
+
+    expect(Dashboard::targetGroupDimension('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:targetgroup/yolo-testing-my-app/def456'))
+        ->toBe('targetgroup/yolo-testing-my-app/def456');
+});
+
+it('builds every section for a full web app', function () {
+    $body = Dashboard::body(dashboardContext());
+
+    expect(widgetTitles($body))->toContain('# Web', '# Queue', '# Database', '# CDN & storage', '# Logs');
+
+    expect(findWidget($body, 'CPU utilisation')['properties']['metrics'][0])
+        ->toContain('AWS/ECS', 'yolo-testing-my-app', 'yolo-testing-my-app-web');
+
+    expect(findWidget($body, 'Tasks (running vs desired)')['properties']['metrics'][0])
+        ->toContain('ECS/ContainerInsights', 'RunningTaskCount');
+
+    expect(findWidget($body, 'RDS CPU')['properties']['metrics'][0])
+        ->toContain('AWS/RDS', 'DBClusterIdentifier', 'my-cluster', 'Role', 'WRITER');
+});
+
+it('queries CloudFront in us-east-1 with the Global region dimension', function () {
+    $requests = findWidget(Dashboard::body(dashboardContext()), 'Asset CDN — requests');
+
+    expect($requests['properties']['region'])->toBe('us-east-1');
+    expect($requests['properties']['metrics'][0])->toContain('AWS/CloudFront', 'Global', 'E123ABCDEF');
+});
+
+it('annotates queue depth with the same threshold the alarm uses', function () {
+    $depth = findWidget(Dashboard::body(dashboardContext(['depthThreshold' => 250])), 'Queue depth');
+
+    expect($depth['properties']['annotations']['horizontal'][0]['value'])->toBe(250);
+    expect($depth['properties']['metrics'][0])->toContain('AWS/SQS', 'ApproximateNumberOfMessagesVisible');
+});
+
+it('renders one queue series per tenant plus the landlord', function () {
+    $body = Dashboard::body(dashboardContext([
+        'queues' => ['yolo-testing-my-app-landlord', 'yolo-testing-my-app-acme', 'yolo-testing-my-app-globex'],
+    ]));
+
+    $depth = findWidget($body, 'Queue depth');
+
+    expect($depth['properties']['metrics'])->toHaveCount(3);
+    expect(collect($depth['properties']['metrics'])->map(fn ($m) => end($m)['label'])->all())
+        ->toBe(['landlord', 'acme', 'globex']);
+});
+
+it('omits the CloudFront panels until the distribution exists', function () {
+    $body = Dashboard::body(dashboardContext(['distributionId' => null]));
+
+    expect(findWidget($body, 'Asset CDN — requests'))->toBeNull();
+    expect(findWidget($body, 'S3 storage size'))->not->toBeNull();
+});
+
+it('drops the web, database and log sections for a headless app with no env DB', function () {
+    $body = Dashboard::body(dashboardContext([
+        'web' => false,
+        'clusterName' => null,
+        'serviceName' => null,
+        'albSuffix' => null,
+        'targetGroupSuffix' => null,
+        'distributionId' => null,
+        'rds' => null,
+        'taskLogGroup' => null,
+    ]));
+
+    expect(widgetTitles($body))->toContain('# Queue', '# CDN & storage');
+    expect(widgetTitles($body))->not->toContain('# Web', '# Database', '# Logs');
+});
+
+it('adds an IVS logs panel when IVS logging is enabled', function () {
+    $ivs = findWidget(Dashboard::body(dashboardContext(['ivsLogGroup' => '/aws/ivs/testing-my-app'])), 'IVS logs');
+
+    expect($ivs['type'])->toBe('log');
+    expect($ivs['properties']['query'])->toContain("SOURCE '/aws/ivs/testing-my-app'");
+});
+
+it('creates the dashboard when it does not exist (apply) and reports WOULD_CREATE on a dry-run', function () {
+    bindDashboardEnv("APP_ENV=production\n");
+
+    $captured = [];
+    bindMockCloudWatchClient(['GetDashboard' => new AwsException('not found', new Command('GetDashboard'))], $captured);
+
+    expect((new SyncCloudWatchDashboardStep())(['dry-run' => true]))->toBe(StepResult::WOULD_CREATE);
+    expect(collect($captured)->pluck('name'))->not->toContain('PutDashboard');
+
+    $captured = [];
+    bindMockCloudWatchClient(['GetDashboard' => new AwsException('not found', new Command('GetDashboard'))], $captured);
+
+    expect((new SyncCloudWatchDashboardStep())(['dry-run' => false]))->toBe(StepResult::CREATED);
+    expect(collect($captured)->pluck('name'))->toContain('PutDashboard');
+});
+
+it('makes no write when the live body already matches', function () {
+    bindDashboardEnv("APP_ENV=production\n");
+
+    $desired = Dashboard::body((new Dashboard())->resolveContext());
+
+    $captured = [];
+    bindMockCloudWatchClient([
+        'GetDashboard' => new Result(['DashboardBody' => json_encode($desired)]),
+    ], $captured);
+
+    expect((new SyncCloudWatchDashboardStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+    expect(collect($captured)->pluck('name'))->not->toContain('PutDashboard');
+});
+
+it('rewrites a drifted dashboard on apply and only reports it on a dry-run', function () {
+    bindDashboardEnv("APP_ENV=production\n");
+
+    $captured = [];
+    bindMockCloudWatchClient(['GetDashboard' => new Result(['DashboardBody' => json_encode(['widgets' => []])])], $captured);
+
+    expect((new SyncCloudWatchDashboardStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect(collect($captured)->pluck('name'))->not->toContain('PutDashboard');
+
+    $captured = [];
+    bindMockCloudWatchClient(['GetDashboard' => new Result(['DashboardBody' => json_encode(['widgets' => []])])], $captured);
+
+    expect((new SyncCloudWatchDashboardStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+    expect(collect($captured)->pluck('name'))->toContain('PutDashboard');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- `sync:app` provisioned everything an app needs but gave **no observability** — there was no single place to see an app's health across the services YOLO stands up. This adds a per-app CloudWatch dashboard (`yolo-<env>-<app>-dashboard`), generated as the last `sync:app` step.

**What it panels (everything YOLO provisions):**
- **ECS service** — CPU %, memory %, running-vs-desired tasks, network (one service: web + in-task queue & scheduler)
- **ALB** — requests, response-time gauge, `TS()` slow-request buckets, 4xx/5xx
- **SQS** — depth + throughput per queue (solo, or landlord + per-tenant); depth annotation reuses `aws.sqs.depth-alarm-threshold` so the graph matches the existing alarm
- **CloudFront** (asset CDN), **S3** buckets, **Logs Insights** over the task + IVS log groups
- **RDS** — derived deterministically from `DB_HOST` in the app's env file (Aurora cluster vs plain instance); Redis/WAF dropped as not-provisioned

**Is there anything the reviewer needs to know to deploy this?**
- **No new manifest keys, command args or options** — always-on, zero config (matches the "hardcode sensible defaults" stance).
- **Standalone reconciler, not a tagged `Resource`** (like `QueueAlarm`): CloudWatch dashboards aren't reliably taggable, so the dashboard **won't appear in `yolo audit`** — by design. Dry-run honest: it diffs the live body against desired (`documentsEqual`) and only `putDashboard`s on drift.
- **Greenfield first-sync skew**: on the very first `sync`, the dry-run plan runs before ALB/TG/CF exist, so those panels land on the *next* sync. Self-heals; RDS (env-derived) is unaffected.
- **Deferred**: MediaConvert panels → [LPX-650](https://linear.app/codinglabsau/issue/LPX-650) (per-app keyed queue + Laravel job routing). Valkey/cache & autoscaling thresholds when those resources land.
- Verified: `pest` 413 passed (14 new), `pint` clean, `phpstan` no errors, VitePress docs build clean. Nothing run against AWS.

🤖 Generated with [Claude Code](https://claude.ai/code)