### PR TITLE
feat(dashboard): add long-term production-health panels

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -227,7 +227,7 @@ The step set is mode-aware: a multi-tenant app fans out landlord + per-tenant qu
 
 Two environment-tier resources are bootstrapped here by exception — the RDS security group (because its real purpose is this app's task-SG ingress) and the HTTPS `:443` listener (because its creation needs this app's certificate). Both are created-if-missing and never mutated, so the environment tier remains their single writer.
 
-A per-app **CloudWatch dashboard** (`yolo-<env>-<app>-dashboard`) is generated last, so every resource it charts already exists. It panels the ECS service (CPU/memory/tasks), the ALB (requests, latency, errors), SQS depth/throughput, the asset CloudFront distribution, the S3 buckets and the app's logs — plus an RDS panel derived from `DB_HOST` in the app's env file. It's a read-only convenience: CloudWatch dashboards can't carry tags, so it doesn't appear in `yolo audit`.
+A per-app **CloudWatch dashboard** (`yolo-<env>-<app>-dashboard`) is generated last, so every resource it charts already exists. It panels the ECS service (CPU/memory/tasks), the ALB (target health, requests, latency, slow-request bands, error counts and a 5xx error-rate SLO), SQS depth/throughput, the asset CloudFront distribution (requests, errors and cache hit rate), the S3 buckets and the app's logs — plus an RDS panel derived from `DB_HOST` in the app's env file (CPU, connections, memory, throughput and read/write latency). It's a read-only convenience: CloudWatch dashboards can't carry tags, so it doesn't appear in `yolo audit`.
 
 ---
 

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -56,6 +56,13 @@ class Dashboard
 
     protected const RESPONSE_TIME_ALARM = 1.5;
 
+    // The ALB should always have at least one task in rotation; anything below
+    // this floor means the service is degraded or fully out of rotation.
+    protected const EXPECTED_HEALTHY_HOSTS = 1;
+
+    // 5xx SLO line (% of requests). A sustained breach is a user-facing outage.
+    protected const ERROR_RATE_SLO = 1;
+
     protected const BLUE = '#1f77b4';
 
     protected const GREEN = '#2ca02c';
@@ -319,6 +326,51 @@ class Dashboard
         $y++;
 
         if ($alb !== null) {
+            // Availability & SLO headline: a task can be "running" in ECS while the
+            // ALB has pulled it out of rotation, so target health is the truest
+            // availability signal; the 5xx rate is the user-facing SLO.
+            $errorRateX = 0;
+
+            if ($targetGroup !== null) {
+                $widgets[] = static::metric(0, $y, 12, 6, [
+                    'title' => 'Target health',
+                    'region' => $region,
+                    'view' => 'timeSeries',
+                    'stacked' => false,
+                    'period' => 60,
+                    'stat' => 'Average',
+                    'yAxis' => ['left' => ['min' => 0]],
+                    'metrics' => [
+                        ['AWS/ApplicationELB', 'HealthyHostCount', 'TargetGroup', $targetGroup, 'LoadBalancer', $alb, ['label' => 'Healthy', 'stat' => 'Minimum', 'color' => static::GREEN]],
+                        ['AWS/ApplicationELB', 'UnHealthyHostCount', 'TargetGroup', $targetGroup, 'LoadBalancer', $alb, ['label' => 'Unhealthy', 'stat' => 'Maximum', 'color' => static::RED]],
+                    ],
+                    'annotations' => ['horizontal' => [
+                        ['color' => static::RED, 'label' => 'Min healthy', 'value' => static::EXPECTED_HEALTHY_HOSTS, 'fill' => 'below'],
+                    ]],
+                ]);
+                $errorRateX = 12;
+            }
+
+            $widgets[] = static::metric($errorRateX, $y, 12, 6, [
+                'title' => '5xx error rate',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Sum',
+                'yAxis' => ['left' => ['min' => 0, 'showUnits' => false]],
+                'metrics' => [
+                    [['expression' => '(m1 + m2) / m3 * 100', 'label' => '5xx %', 'id' => 'e1', 'color' => static::RED]],
+                    ['AWS/ApplicationELB', 'HTTPCode_Target_5XX_Count', 'LoadBalancer', $alb, ['id' => 'm1', 'visible' => false]],
+                    ['AWS/ApplicationELB', 'HTTPCode_ELB_5XX_Count', 'LoadBalancer', $alb, ['id' => 'm2', 'visible' => false]],
+                    ['AWS/ApplicationELB', 'RequestCount', 'LoadBalancer', $alb, ['id' => 'm3', 'visible' => false]],
+                ],
+                'annotations' => ['horizontal' => [
+                    ['color' => static::RED, 'label' => 'SLO', 'value' => static::ERROR_RATE_SLO, 'fill' => 'above'],
+                ]],
+            ]);
+            $y += 6;
+
             $requests = [['AWS/ApplicationELB', 'RequestCount', 'LoadBalancer', $alb, ['label' => 'Total requests', 'color' => static::BLUE]]];
 
             if ($targetGroup !== null) {
@@ -465,6 +517,9 @@ class Dashboard
             ->map(fn (string $queue) => ['AWS/SQS', $metric, 'QueueName', $queue, ['label' => static::queueLabel($queue, $context['queuePrefix'])]])
             ->all();
 
+        // No dedicated dead-letter-queue depth panel: the Queue resource provisions
+        // a plain SQS queue with no RedrivePolicy, so there is no DLQ to chart. If a
+        // DLQ is ever added, a ">0 = silent job failures" panel belongs right here.
         $widgets = [static::header($y, '# Queue')];
         $y++;
 
@@ -571,6 +626,25 @@ class Dashboard
         ]);
         $y += 6;
 
+        // Read/write latency is the earliest DB-degradation tell — it climbs well
+        // before CPU or connections saturate. Seconds, p90 alongside the average.
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'RDS read/write latency',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0]],
+            'metrics' => [
+                $metric('ReadLatency', ['label' => 'Read avg', 'color' => static::BLUE]),
+                $metric('ReadLatency', ['label' => 'Read p90', 'stat' => 'p90', 'color' => static::PURPLE]),
+                $metric('WriteLatency', ['label' => 'Write avg', 'color' => static::GREEN]),
+                $metric('WriteLatency', ['label' => 'Write p90', 'stat' => 'p90', 'color' => static::ORANGE]),
+            ],
+        ]);
+        $y += 6;
+
         return [$widgets, $y];
     }
 
@@ -627,6 +701,22 @@ class Dashboard
                 'metrics' => [
                     [['expression' => 'm1/1000000', 'label' => 'Downloaded MB', 'id' => 'e1', 'region' => 'us-east-1']],
                     ['AWS/CloudFront', 'BytesDownloaded', 'Region', 'Global', 'DistributionId', $distributionId, ['id' => 'm1', 'visible' => false]],
+                ],
+            ]);
+            $y += 6;
+
+            // A low cache hit rate means the CDN is passing traffic through to the
+            // origin — more origin load, higher latency and higher transfer cost.
+            $widgets[] = static::metric(0, $y, 12, 6, [
+                'title' => 'Asset CDN — cache hit rate',
+                'region' => 'us-east-1',
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Average',
+                'yAxis' => ['left' => ['min' => 0, 'max' => 100, 'showUnits' => false]],
+                'metrics' => [
+                    ['AWS/CloudFront', 'CacheHitRate', 'Region', 'Global', 'DistributionId', $distributionId, ['label' => 'Cache hit %', 'color' => static::GREEN]],
                 ],
             ]);
             $y += 6;

--- a/tests/Unit/Resources/CloudWatch/DashboardTest.php
+++ b/tests/Unit/Resources/CloudWatch/DashboardTest.php
@@ -125,6 +125,54 @@ it('builds every section for a full web app', function () {
         ->toContain('AWS/RDS', 'DBClusterIdentifier', 'my-cluster', 'Role', 'WRITER');
 });
 
+it('charts ALB target health off both the target-group and load-balancer dimensions', function () {
+    $health = findWidget(Dashboard::body(dashboardContext()), 'Target health');
+
+    expect($health['properties']['metrics'][0])
+        ->toContain('AWS/ApplicationELB', 'HealthyHostCount', 'TargetGroup', 'targetgroup/yolo-testing-my-app/0a1b2c3d4e5f', 'LoadBalancer', 'app/yolo-testing/abc123def456');
+
+    // Healthy reads the conservative floor (Minimum) over the period.
+    expect(end($health['properties']['metrics'][0])['stat'])->toBe('Minimum');
+    expect($health['properties']['annotations']['horizontal'][0]['value'])->toBe(1);
+});
+
+it('omits the target-health panel when the target group is not resolved yet', function () {
+    $body = Dashboard::body(dashboardContext(['targetGroupSuffix' => null]));
+
+    expect(findWidget($body, 'Target health'))->toBeNull();
+    // The 5xx rate only needs the ALB, so it still renders and takes the left slot.
+    expect(findWidget($body, '5xx error rate')['x'])->toBe(0);
+});
+
+it('expresses the 5xx error rate as a percentage of requests with a 1% SLO line', function () {
+    $rate = findWidget(Dashboard::body(dashboardContext()), '5xx error rate');
+
+    expect($rate['properties']['metrics'][0][0]['expression'])->toBe('(m1 + m2) / m3 * 100');
+    expect($rate['properties']['metrics'])->toHaveCount(4); // expression + target 5xx + elb 5xx + requests
+    expect($rate['properties']['annotations']['horizontal'][0]['value'])->toBe(1);
+    expect($rate['x'])->toBe(12); // sits beside target health when the target group exists
+});
+
+it('charts RDS read and write latency with p90 alongside the average', function () {
+    $latency = findWidget(Dashboard::body(dashboardContext()), 'RDS read/write latency');
+
+    $metrics = collect($latency['properties']['metrics']);
+
+    expect($metrics)->toHaveCount(4);
+    expect($metrics->map(fn ($m) => $m[1])->all())->toBe(['ReadLatency', 'ReadLatency', 'WriteLatency', 'WriteLatency']);
+    expect($metrics->filter(fn ($m) => (end($m)['stat'] ?? null) === 'p90'))->toHaveCount(2);
+    expect($latency['properties']['metrics'][0])->toContain('AWS/RDS', 'DBClusterIdentifier', 'my-cluster', 'Role', 'WRITER');
+});
+
+it('charts the CloudFront cache hit rate, and omits it with the rest of the CDN panels until the distribution exists', function () {
+    $hitRate = findWidget(Dashboard::body(dashboardContext()), 'Asset CDN — cache hit rate');
+
+    expect($hitRate['properties']['region'])->toBe('us-east-1');
+    expect($hitRate['properties']['metrics'][0])->toContain('AWS/CloudFront', 'CacheHitRate', 'Global', 'E123ABCDEF');
+
+    expect(findWidget(Dashboard::body(dashboardContext(['distributionId' => null])), 'Asset CDN — cache hit rate'))->toBeNull();
+});
+
 it('queries CloudFront in us-east-1 with the Global region dimension', function () {
     $requests = findWidget(Dashboard::body(dashboardContext()), 'Asset CDN — requests');
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

The per-app CloudWatch dashboard ([#62](https://github.com/codinglabsau/yolo/pull/62)) covered volume and resource use, but was missing the signals that actually tell you the app is healthy over the long run. This adds five durable production-health panels, each grouped into its existing section:

- **ALB target health** (`HealthyHostCount` min / `UnHealthyHostCount` max) — the availability signal the board was missing. A task can be "running" in ECS while the ALB has pulled it out of rotation; this is what catches that. Annotated with a min-healthy floor.
- **5xx error rate (%)** — metric math `(Target_5XX + ELB_5XX) / RequestCount * 100`, the user-facing SLO, with a 1% line. Complements the existing raw 5xx count panel.
- **RDS read/write latency** (Average + p90) — the earliest DB-degradation tell, climbs before CPU/connections saturate.
- **CloudFront cache hit rate** — low hit rate = origin getting hammered = latency + cost.

No new sections, no new manifest knobs — thresholds are hardcoded constants alongside the existing CPU/response-time ones.

**Is there anything the reviewer needs to know to deploy this?**

- **No DLQ panel** by design: the `Queue` resource provisions a plain SQS queue with no `RedrivePolicy`, so there is no dead-letter queue to chart. Left an inline note in `queueSection` marking where one would go if a DLQ is ever added.
- **Greenfield-safe**: target health is omitted until the target group resolves, and the cache hit rate joins the other CloudFront panels in being omitted until the distribution resolves — exactly like the existing ALB/CDN panels. Those panels self-heal onto the dashboard on the next sync.
- **Diff is stable** — built as pure context and reconciled via `documentsEqual` (key-order-independent), so `sync --dry-run` reports drift only on a real change. Verified the encode→decode round-trip and a key-order shuffle both compare equal. No phantom drift.
- Pure additive widgets — full-web-app widget count goes **25 → 29 (+4)**. 420 tests green (+5), PHPStan clean, pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)