### PR TITLE
docs: use a 🚀 emoji data-URI favicon

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -6,7 +6,9 @@ export default defineConfig({
   base: '/yolo/',
 
   head: [
-    ['link', { rel: 'icon', href: '/logo.png' }],
+    // A 🚀 emoji rendered as an inline SVG — no binary asset to ship, and a
+    // data URI sidesteps VitePress not prepending `base` to head link hrefs.
+    ['link', { rel: 'icon', href: 'data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100"><text y=".9em" font-size="90">🚀</text></svg>' }],
   ],
 
   themeConfig: {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- The docs favicon pointed at an absolute `/logo.png`, but VitePress doesn't prepend the `/yolo/` base to `head` link hrefs — so it resolved to `codinglabsau.github.io/logo.png` (404) on the deployed Pages site instead of `/yolo/logo.png`.
- Swapped it for the rocket emoji rendered as an inline SVG data URI: self-contained (no binary asset to ship) and base-path-independent, so it can't 404 again.

**Is there anything the reviewer needs to know to deploy this?**
- Docs-only, no runtime/infra impact. `vitepress build` passes clean and the `rel="icon"` 🚀 data URI is present in the rendered HTML.

🤖 Generated with [Claude Code](https://claude.ai/code)