### PR TITLE
feat(cli): reserve 🐥 for chickening out, 🚀 for the deploy payoff

### DIFF
--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -103,7 +103,7 @@ yolo deploy production
 
 `deploy` builds your container image, pushes it to ECR, registers a new task definition, runs your deploy hooks (e.g. `php artisan migrate`), rolls the ECS service over to the new version, and waits for it to go healthy before pointing DNS at it. If the new version fails its health checks, the [deployment circuit breaker](/guide/building-and-deploying#zero-downtime-rollout) rolls it back automatically.
 
-When it finishes, your app is live. 🐥
+When it finishes, your app is live. 🚀
 
 ## 7. Visit your app
 

--- a/src/Commands/AbstractAuditCommand.php
+++ b/src/Commands/AbstractAuditCommand.php
@@ -87,7 +87,7 @@ abstract class AbstractAuditCommand extends Command
     protected function render(array $report, string $environment): int
     {
         if (empty($report['resources'])) {
-            info(sprintf("Nothing tagged for '%s'. 🐥", $environment));
+            info(sprintf("Nothing tagged for '%s'.", $environment));
 
             return self::SUCCESS;
         }

--- a/src/Commands/AuditAppCommand.php
+++ b/src/Commands/AuditAppCommand.php
@@ -32,7 +32,7 @@ class AuditAppCommand extends AbstractAuditCommand
         $app = $this->argument('app');
 
         if ($this->option('drift')) {
-            return sprintf("No drift for app '%s' in '%s'. 🐥", $app, $environment);
+            return sprintf("No drift for app '%s' in '%s'.", $app, $environment);
         }
 
         return sprintf("No resources tagged for app '%s' in '%s'.", $app, $environment);

--- a/src/Commands/AuditCommand.php
+++ b/src/Commands/AuditCommand.php
@@ -27,9 +27,9 @@ class AuditCommand extends AbstractAuditCommand
     protected function emptyFilterMessage(string $environment): string
     {
         if ($this->option('drift')) {
-            return sprintf("No drift in '%s' — every tagged resource maps to a live app. 🐥", $environment);
+            return sprintf("No drift in '%s' — every tagged resource maps to a live app.", $environment);
         }
 
-        return sprintf("Nothing tagged for '%s'. 🐥", $environment);
+        return sprintf("Nothing tagged for '%s'.", $environment);
     }
 }

--- a/src/Commands/AuditEnvironmentCommand.php
+++ b/src/Commands/AuditEnvironmentCommand.php
@@ -29,7 +29,7 @@ class AuditEnvironmentCommand extends AbstractAuditCommand
     protected function emptyFilterMessage(string $environment): string
     {
         if ($this->option('drift')) {
-            return sprintf("No drift at the environment tier in '%s' — drift only applies to app-scope resources. 🐥", $environment);
+            return sprintf("No drift at the environment tier in '%s' — drift only applies to app-scope resources.", $environment);
         }
 
         return sprintf("No environment-tier resources tagged for '%s'.", $environment);

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -70,7 +70,7 @@ class EnvPushCommand extends Command
 
             if (! $confirm) {
                 unlink(Paths::base($temporaryFilename));
-                info('🐥 yolo');
+                info('🐥 Chickened out — nothing uploaded.');
 
                 return;
             }

--- a/src/Commands/EnvPushCommand.php
+++ b/src/Commands/EnvPushCommand.php
@@ -70,7 +70,7 @@ class EnvPushCommand extends Command
 
             if (! $confirm) {
                 unlink(Paths::base($temporaryFilename));
-                info('🐥 Chickened out — nothing uploaded.');
+                info('🐥 Nothing uploaded.');
 
                 return;
             }

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -80,7 +80,7 @@ trait RunsSteppedCommands
         }
 
         if (! $this->confirmGate($environment)) {
-            warning('🐥 Chickened out — no changes made.');
+            warning('🐥 No changes made.');
 
             return SymfonyCommand::SUCCESS;
         }

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -80,7 +80,7 @@ trait RunsSteppedCommands
         }
 
         if (! $this->confirmGate($environment)) {
-            warning('Aborted — no changes made.');
+            warning('🐥 Chickened out — no changes made.');
 
             return SymfonyCommand::SUCCESS;
         }


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

YOLO's emoji use had drifted. The 🐥 chick was the "all good" mascot on clean audits and the deploy-success line, *but also* on the `env:push` decline — so the success mascot was waving goodbye when you bailed, and the clean-audit chicks were only half-applied (the `audit:environment`/`audit:app` non-drift branches already had none).

This applies one convention across the CLI and docs:

- **General / status messages → no emoji**
- **Declined a confirm gate ("chickened out") → 🐥**
- **The deploy payoff → 🚀**

Changes:
- `sync*` abort message gains the chick — covers all four sync commands through the shared confirm gate (`RunsSteppedCommands::confirmGate`)
- `env:push` decline swaps `🐥 yolo` for `🐥 Nothing uploaded.`
- docs "your app is live" line: 🐥 → 🚀
- stripped the chick from the five clean-audit status lines (routine status, not an event)

**Is there anything the reviewer needs to know to deploy this?**

No production impact — output-copy only. No behaviour, control flow, or AWS calls changed; no exit codes touched. No tests asserted any of these strings (verified), so nothing breaks. The app tagline 🚀, docs feature icon, and favicon were already correct and left alone.

🤖 Generated with [Claude Code](https://claude.ai/code)