### PR TITLE
feat(sync): name brand-new resources under a "Will create" plan section

### DIFF
--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -34,7 +34,7 @@ Several apps can share one environment's VPC and load balancer. Because `sync:ap
 
 `sync` never surprises you. It runs as a three-step flow:
 
-1. **Plan** — YOLO inspects live AWS state and computes what would change, rendering it grouped by scope with per-attribute diffs (`current → desired`).
+1. **Plan** — YOLO inspects live AWS state and computes what would change, rendering it grouped by scope. Brand-new resources are listed under **Will create** (one `+` line each); drift on existing resources is shown under **Pending changes** as per-attribute diffs (`current → desired`).
 2. **Confirm** — you're shown the plan and asked to approve. If nothing has drifted, it short-circuits with **"Already in sync"** and exits without touching anything.
 3. **Apply** — only the changed steps run.
 

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -150,10 +150,10 @@ trait RunsSteppedCommands
     }
 
     /**
-     * Render the plan: scope counts, the full attribute-level Pending changes
-     * diff (when there's drift), and a single Skipping section grouped by
-     * scope + reason. With `-v`, the skipped section expands to list every
-     * resource under each concept group.
+     * Render the plan: scope counts, a Will create list of brand-new resources,
+     * the per-attribute Pending changes diff for drift on existing resources,
+     * and a single Skipping section grouped by scope + reason. With `-v`, the
+     * skipped section expands to list every resource under each concept group.
      *
      * @param  Collection<int, array{index: int, scope: string, step: Step, status: StepResult|string, elapsed: int, changes: array<int, Change>}>  $plan
      * @param  Collection<int, array{scope: string, step: Step, reason: string}>  $skipped
@@ -166,7 +166,11 @@ trait RunsSteppedCommands
             $this->output->writeln(sprintf('  <fg=green>✔</> %s <fg=gray>(%d)</>', $scope, $entries->count()));
         });
 
-        $this->renderPendingChanges($plan);
+        $multiScope = $plan->pluck('scope')->unique()->count() > 1;
+
+        $this->renderWillCreate($plan, $multiScope);
+
+        $this->renderPendingChanges($plan, $multiScope);
 
         $this->renderSkipping($skipped);
 
@@ -320,14 +324,41 @@ trait RunsSteppedCommands
     }
 
     /**
+     * Print the Will create section: every resource the plan would stand up
+     * fresh (status WOULD_CREATE). Creation records no attribute-level Change —
+     * there's no "before" to diff — so without an explicit list a new resource
+     * is folded silently into the scope tally and never named. Standing up new
+     * (billable, least-reversible) infra is the most consequential thing apply
+     * does, so the plan names it before the per-attribute drift diff.
+     *
+     * @param  Collection<int, array{scope: string, step: Step, status: StepResult|string, changes: array<int, Change>}>  $plan
+     */
+    protected function renderWillCreate(Collection $plan, bool $multiScope): void
+    {
+        $creating = $plan->filter(fn (array $entry) => $entry['status'] === StepResult::WOULD_CREATE);
+
+        if ($creating->isEmpty()) {
+            return;
+        }
+
+        $this->output->writeln('');
+        $this->output->writeln('  <options=bold>Will create</>');
+
+        $creating->each(function (array $entry) use ($multiScope) {
+            $this->output->writeln(sprintf('  <fg=green>+</> %s', static::planEntryLabel($entry, $multiScope)));
+        });
+    }
+
+    /**
      * Print the per-attribute Pending changes section: which attributes each
-     * step would reconcile, as a current → desired comparison. Steps that
-     * recorded nothing are omitted, so a clean plan stays quiet and drift
-     * stands out.
+     * step would reconcile on an *existing* resource, as a current → desired
+     * comparison. Brand-new resources are listed by renderWillCreate(), not
+     * here. Steps that recorded nothing are omitted, so a clean plan stays
+     * quiet and drift stands out.
      *
      * @param  Collection<int, array{scope: string, step: Step, changes: array<int, Change>}>  $plan
      */
-    protected function renderPendingChanges(Collection $plan): void
+    protected function renderPendingChanges(Collection $plan, bool $multiScope): void
     {
         $withChanges = $plan->filter(fn (array $entry) => $entry['changes'] !== []);
 
@@ -335,17 +366,11 @@ trait RunsSteppedCommands
             return;
         }
 
-        $multiScope = $plan->pluck('scope')->unique()->count() > 1;
-
         $this->output->writeln('');
         $this->output->writeln('  <options=bold>Pending changes</>');
 
         $withChanges->each(function (array $entry) use ($multiScope) {
-            $label = $multiScope
-                ? sprintf('%s · %s', $entry['scope'], static::normaliseStep($entry['step']))
-                : static::normaliseStep($entry['step']);
-
-            $this->output->writeln(sprintf('  <fg=cyan>%s</>', $label));
+            $this->output->writeln(sprintf('  <fg=cyan>%s</>', static::planEntryLabel($entry, $multiScope)));
 
             foreach ($entry['changes'] as $change) {
                 $this->output->writeln(sprintf(
@@ -356,6 +381,19 @@ trait RunsSteppedCommands
                 ));
             }
         });
+    }
+
+    /**
+     * The scope-qualified label for a plan entry — "app · Cache cluster" when a
+     * multi-scope sync is in play, just "Cache cluster" for a single scope.
+     *
+     * @param  array{scope: string, step: Step}  $entry
+     */
+    protected static function planEntryLabel(array $entry, bool $multiScope): string
+    {
+        return $multiScope
+            ? sprintf('%s · %s', $entry['scope'], static::normaliseStep($entry['step']))
+            : static::normaliseStep($entry['step']);
     }
 
     /**

--- a/tests/Unit/Concerns/RunScopesRenderTest.php
+++ b/tests/Unit/Concerns/RunScopesRenderTest.php
@@ -146,6 +146,40 @@ it('omits the changes section entirely when nothing drifted', function () {
         ->not->toContain('Changes applied');
 });
 
+it('names brand-new resources under Will create, before the confirm gate', function () {
+    $output = runScopesCapture(
+        ['app' => [RunScopesFakeStep::class]],
+        ['--no-progress' => true],
+    );
+
+    // A WOULD_CREATE step records no attribute Change, so without the Will create
+    // list it would be folded silently into the scope tally and never named.
+    // Creation is not an attribute diff, so it stays out of Pending changes.
+    expect($output)
+        ->toContain('Will create')
+        ->toContain('Run scopes fake')
+        ->not->toContain('Pending changes');
+
+    // It's part of the plan — rendered ahead of the apply/completion line.
+    expect(strpos($output, 'Will create'))->toBeLessThan(strpos($output, 'Synced testing'));
+});
+
+it('separates brand-new resources (Will create) from drift on existing ones (Pending changes)', function () {
+    $output = runScopesCapture(
+        ['app' => [RunScopesFakeStep::class, RunScopesChangeStep::class]],
+        ['--no-progress' => true],
+    );
+
+    // The create is named under Will create; the attribute drift is itemised
+    // under Pending changes — and Will create leads, as the more consequential.
+    expect($output)
+        ->toContain('Will create')
+        ->toContain('Pending changes')
+        ->toContain('idle_timeout');
+
+    expect(strpos($output, 'Will create'))->toBeLessThan(strpos($output, 'Pending changes'));
+});
+
 it('shows the skipped concept summary at normal verbosity but hides per-resource names', function () {
     $output = runScopesCapture([
         'app' => [


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- The sync plan itemised attribute **drift** on existing resources (`current → desired`) but never named **brand-new** resources it was about to create — a `WOULD_CREATE` step records no `Change`, so `renderPendingChanges()` skipped it and the resource was folded silently into the scope tally (`✔ app (29)`).
- Net effect: standing up new, billable, least-reversible infra (e.g. a web app's default Valkey cluster + DynamoDB sessions table on first sync) was the one thing the plan *didn't* spell out before the confirm gate — you saw a count bump, not the resources.

**What changed**
- New **Will create** plan section: every `WOULD_CREATE` entry listed as a green `+` line, above the drift diff (Terraform-style).
- `renderPendingChanges()` is now explicitly **drift-only** (existing resources, attribute diffs); shared scope-label logic extracted to `planEntryLabel()`.
- Docs (`provisioning.md`) updated to describe both sections; two new render tests.

```
  Will create
  + app · Cache subnet group
  + app · Cache parameter group
  + app · Cache security group
  + app · Cache cluster
  + app · Dynamo db sessions table
```

**Is there anything the reviewer needs to know to deploy this?**
- **Pure plan-rendering change.** The apply path, `planEntryHasWork()`, and `SynchronisesResource` are untouched — what gets provisioned is identical; only what the operator *sees* before confirming changes. No behavioural/runtime risk to a live sync.
- Verified: `pint` clean, **468 pest pass** (incl. 2 new), `phpstan` no errors. Rebased onto latest `main` (#67).

🤖 Generated with [Claude Code](https://claude.ai/code)