### PR TITLE
feat(sync): --check drift gate for CI + README tidy

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,19 +7,20 @@
 YOLO deploys Laravel applications to AWS Fargate.
 
 > [!IMPORTANT]
-> This package is in active development - contributions are welcome!
+> This package is in active development — contributions are welcome!
 
 ## Documentation
 
-Full documentation — getting started, the command reference, and the manifest reference — lives at
-**[codinglabsau.github.io/yolo](https://codinglabsau.github.io/yolo/)**. You can have a Laravel app live on Fargate in
-under an hour by following the [Getting Started guide](https://codinglabsau.github.io/yolo/guide/getting-started).
+Everything lives at **[codinglabsau.github.io/yolo](https://codinglabsau.github.io/yolo/)**:
+
+- [Getting Started](https://codinglabsau.github.io/yolo/guide/getting-started) — a Laravel app live on Fargate in under an hour
+- [Provisioning](https://codinglabsau.github.io/yolo/guide/provisioning) and [Building & Deploying](https://codinglabsau.github.io/yolo/guide/building-and-deploying)
+- [Deploying from GitHub Actions](https://codinglabsau.github.io/yolo/guide/ci-cd) — keyless OIDC, plus the `--check` drift gate for CI
+- [Command reference](https://codinglabsau.github.io/yolo/reference/commands) and [manifest reference](https://codinglabsau.github.io/yolo/reference/manifest)
 
 The docs are a VitePress site under [`docs/`](docs/) and deploy to GitHub Pages on every push to `main`.
 
-## Composer pinning
-
-For new apps and Fargate canaries:
+## Installation
 
 ```json
 {
@@ -29,83 +30,13 @@ For new apps and Fargate canaries:
 }
 ```
 
-For existing EC2/ASG consumers (frozen, maintenance-only):
-
-```json
-{
-  "require": {
-    "codinglabsau/yolo-alpha": "v1.0.0-alpha.34"
-  }
-}
-```
-
-Consumers migrating from `yolo-alpha` to `yolo` 1.0 install both packages side-by-side during the cutover window, then drop `yolo-alpha` once on Fargate.
-
-## YOLO 1.0 in one line
-
-```bash
-yolo init && yolo sync production && yolo deploy production
-```
-
-`yolo deploy` builds and pushes the image, then ships it. Pass `--app-version=<tag>` (e.g. a GitHub release name) to stamp the build with a specific tag instead of an auto-generated timestamp.
-
-## Deploying from GitHub Actions (OIDC)
-
-Deploy from CI with short-lived, keyless credentials — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` in repo secrets.
-
-Each environment declares the **ref it deploys from**. That one setting drives the CI deployer role's OIDC trust (and, later, the local deploy guard). It defaults to the `main` branch, so the common case needs no config at all:
-
-| Ref | OIDC `sub` scope | Typical use |
-|---|---|---|
-| `branch: main` (default) | `…:ref:refs/heads/main` | push to a branch — e.g. staging |
-| `tag: 'v*'` (`true` = any tag) | `…:ref:refs/tags/v*` | tag push — e.g. production |
-
-Staging-on-`develop`, production-on-tag:
-
-```yaml
-environments:
-  staging:
-    branch: develop           # deploys on push to develop
-  production:
-    tag: 'v*'                 # only a v* tag can assume the prod role
-```
-
-`repository` is inferred from your git origin (or `GITHUB_REPOSITORY` in CI) — set `repository: org/repo` per environment only to override (monorepo / fork).
-
-When a GitHub repository is detected, `yolo sync:iam` provisions (and keeps in sync with the deploy steps):
-
-- the account's GitHub Actions OIDC identity provider (`token.actions.githubusercontent.com`), an account-level singleton;
-- a deployer role `yolo-{env}-{app}-deployer` whose trust only lets the environment's repo + ref assume it; and
-- a tightly-scoped permission policy covering exactly what `yolo deploy` does (ECR push, ECS register/update, `iam:PassRole` on the task + execution roles, S3 env/asset access, Route 53 record changes).
-
-In the consumer workflow, request the OIDC token and assume the role — no stored secrets:
-
-```yaml
-permissions:
-  id-token: write
-  contents: read
-
-steps:
-  - uses: aws-actions/configure-aws-credentials@v4
-    with:
-      role-to-assume: arn:aws:iam::<account-id>:role/yolo-production-myapp-deployer
-      aws-region: <region>
-  - run: vendor/bin/yolo deploy production
-```
-
-For the strongest production gate, pair `tag: 'v*'` with a GitHub protected-tag ruleset (only maintainers may cut `v*` tags) — the AWS trust then just confirms "a tag push from this repo", and GitHub enforces who can trigger it.
-
-In CI, YOLO defers to the AWS SDK's default credential chain, so all three auth methods work out of the box with no extra config — OIDC (above), AWS IAM Identity Center (SSO), and legacy long-lived static access keys. Static keys still work but emit a warning nudging you towards OIDC.
-
-## Pre-1.0 alpha documentation
-
-The EC2/ASG `yolo-alpha` documentation lives in its own repo: [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha). Existing consumers should reference that repo.
+Existing EC2/ASG consumers stay on the frozen, maintenance-only [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha) (`v1.0.0-alpha.34`). Migrating to Fargate? Install both side-by-side during the cutover, then drop `yolo-alpha`.
 
 ## Contributing
 
-`yolo-alpha`: bug fixes only. Pull requests against [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha) are welcome for production-safe patches. No new features.
+`yolo` (this repo, `main`): in active development. Open an issue or coordinate with @stevethomas before submitting PRs.
 
-`yolo` (this repo, `main`): in active development. Open an issue on this repo or coordinate with @stevethomas before submitting PRs.
+`yolo-alpha`: bug fixes only — production-safe patches welcome on [`codinglabsau/yolo-alpha`](https://github.com/codinglabsau/yolo-alpha). No new features.
 
 ## License
 

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -58,6 +58,42 @@ In CI, YOLO defers to the AWS SDK's default credential chain, so the assumed-rol
 Pair `tag: 'v*'` with a GitHub protected-tag ruleset (only maintainers may cut `v*` tags). The AWS trust then just confirms "a tag push from this repo", and GitHub enforces who can trigger it.
 :::
 
+## Gate CI on drift with `yolo sync --check`
+
+`yolo deploy` ships your code; `yolo sync --check` guards the infrastructure behind it. Run it in CI to fail a pipeline the moment your live AWS resources drift from `yolo.yml` — someone hand-edited a resource in the console, or a manifest change merged without anyone running `yolo sync`.
+
+`--check` runs the same read-only plan pass as [`--dry-run`](/guide/provisioning) and prints the same diff, but **never applies** and exits non-zero when there are pending changes:
+
+| Exit code | Meaning |
+|---|---|
+| `0` | In sync — no pending changes. |
+| non-zero | Drift detected, **or** the check itself errored (bad credentials, an AWS API failure, an invalid manifest). |
+
+Either way, a non-zero exit means the job should fail and a human should read the printed plan.
+
+::: warning Use read-capable credentials, not the deployer role
+`--check` is a `sync` operation, not a deploy: it `Describe`s every resource across the stack to compute drift, so it needs **read access to the whole provisioned surface** — far broader than the deploy-scoped deployer role above. Run the check with a read-capable identity (your SSO role, or one granted AWS's managed `ReadOnlyAccess`), separate from the narrow deploy role. Pointed at the deployer role it would `AccessDenied` and fail for the wrong reason.
+:::
+
+```yaml
+# A scheduled (or pre-deploy) drift check — note the read-capable role
+permissions:
+  id-token: write
+  contents: read
+
+steps:
+  - uses: actions/checkout@v4
+
+  - uses: aws-actions/configure-aws-credentials@v4
+    with:
+      role-to-assume: arn:aws:iam::<account-id>:role/<read-capable-role>
+      aws-region: <region>
+
+  - run: vendor/bin/yolo sync production --check --no-progress
+```
+
+See the [`sync` reference](/reference/commands#sync-options) for the full option list.
+
 ## Other auth methods
 
 The default credential chain means all three auth methods work with no extra config:

--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -48,6 +48,16 @@ yolo sync production --dry-run
 
 This computes and prints the full diff but makes no changes. It's the safe way to see what a `sync` would do before you commit — always dry-run first against an account you care about.
 
+### Gate CI on drift with `--check`
+
+`--check` is the machine-readable counterpart to `--dry-run`. It runs the same plan pass and prints the same diff, but never applies and **exits non-zero when the environment has drifted** (and `0` when it's already in sync):
+
+```bash
+yolo sync production --check
+```
+
+Wire it into CI to fail a pipeline the moment infrastructure drifts from the manifest — someone hand-edited a resource, or a `sync` was never run after a manifest change. A non-zero exit also covers a dry-run that errored (bad credentials, an AWS API failure, an invalid manifest); in every case CI should stop and a human should look at the printed plan.
+
 ### Skip the prompt with `--force`
 
 In automation, skip the interactive confirmation:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -169,7 +169,7 @@ Today web, queue, and scheduler all run in the single `web` container, so the gr
 Sync **all** resources for the given environment, orchestrating the three scopes in dependency order: account → environment → app.
 
 ```bash
-yolo sync <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
+yolo sync <environment> [--dry-run] [--check] [--force] [--no-progress] [--tenant=<id>]
 ```
 
 | Argument | Required | Description |
@@ -181,9 +181,12 @@ yolo sync <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
 | Option | Short | Value | Description |
 |---|---|---|---|
 | `--dry-run` | | flag | Show what would change without applying it. |
+| `--check` | | flag | Plan only and exit non-zero if the environment has drifted — never applies. Intended as a CI gate. |
 | `--force` | `-f` | flag | Skip the confirmation prompt. |
 | `--no-progress` | | flag | Hide the live progress output. |
 | `--tenant` | | string | Limit per-tenant steps to a single tenant id. |
+
+`--check` is the machine-readable form of `--dry-run`: it runs the same plan pass and prints the same diff, but never applies and returns a non-zero exit code when there are pending changes (and `0` when the environment is already in sync). Run `yolo sync <env> --check` in CI to fail a pipeline on drifted or unsynced infrastructure. A non-zero exit also covers a dry-run that errored (bad credentials, AWS API failure, invalid manifest) — either way, CI should stop and a human should look.
 
 These four options are shared by every `sync` command below. See [Provisioning](/guide/provisioning) for the plan/confirm/apply flow.
 
@@ -194,7 +197,7 @@ These four options are shared by every `sync` command below. See [Provisioning](
 Sync the account-global resources (shared across every environment) — the GitHub OIDC identity provider.
 
 ```bash
-yolo sync:account <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
+yolo sync:account <environment> [--dry-run] [--check] [--force] [--no-progress] [--tenant=<id>]
 ```
 
 Arguments and options as [`sync`](#sync-options). Scope: **account**.
@@ -206,7 +209,7 @@ Arguments and options as [`sync`](#sync-options). Scope: **account**.
 Sync the environment-shared (environment-tier) resources — VPC, subnets, internet gateway and routes, the load balancer security group, the ALB and its `:80` listener, the SNS alarm topic, and the shared ECS task & execution IAM roles.
 
 ```bash
-yolo sync:environment <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
+yolo sync:environment <environment> [--dry-run] [--check] [--force] [--no-progress] [--tenant=<id>]
 ```
 
 Arguments and options as [`sync`](#sync-options). Scope: **environment**. These resources are shared by every app in the environment; apps attach to them but never mutate them.
@@ -218,7 +221,7 @@ Arguments and options as [`sync`](#sync-options). Scope: **environment**. These 
 Sync a single application's resources for the given environment — S3 buckets, app IAM (deployer role/policy, MediaConvert role for IVS), ECS cluster/service/task definition, target group + listener rule, CloudFront distribution, SQS queues, a CloudWatch dashboard, and — for a solo app — its hosted zone and ACM certificate. When opted in, it also provisions the shared [Valkey cache](/guide/provisioning#cache-and-sessions) (`cache.store`) and a per-app [DynamoDB sessions table](/guide/provisioning#cache-and-sessions) (`session.driver: dynamodb`).
 
 ```bash
-yolo sync:app <environment> [--dry-run] [--force] [--no-progress] [--tenant=<id>]
+yolo sync:app <environment> [--dry-run] [--check] [--force] [--no-progress] [--tenant=<id>]
 ```
 
 Arguments and options as [`sync`](#sync-options). Scope: **app**.

--- a/src/Commands/SyncSteppedCommand.php
+++ b/src/Commands/SyncSteppedCommand.php
@@ -25,6 +25,7 @@ abstract class SyncSteppedCommand extends SteppedCommand
     {
         $this->addArgument('environment', InputArgument::REQUIRED, 'The environment name');
         $this->addOption('dry-run', null, null, 'Show what would change without applying it');
+        $this->addOption('check', null, null, 'Plan only and exit non-zero if the environment has drifted (for CI)');
         $this->addOption('no-progress', null, null, 'Hide the progress output');
         $this->addOption('force', 'f', null, 'Skip the confirmation prompt');
         $this->addOption('tenant', null, InputOption::VALUE_REQUIRED, 'Limit per-tenant steps to a single tenant id');

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -65,13 +65,27 @@ trait RunsSteppedCommands
 
         $this->printPlan($plan, $skipped);
 
+        $pending = $plan->filter(fn (array $entry) => static::planEntryHasWork($entry))->values();
+
+        // --check is a CI gate: plan only, never apply, and exit non-zero when
+        // the environment has drifted so a pipeline can fail on unsynced infra.
+        if ($this->option('check')) {
+            if ($pending->isNotEmpty()) {
+                warning(sprintf('Drift detected — %s has %d pending change(s).', $environment, $pending->count()));
+
+                return SymfonyCommand::FAILURE;
+            }
+
+            info(sprintf('In sync — %s has no pending changes.', $environment));
+
+            return SymfonyCommand::SUCCESS;
+        }
+
         if ($this->option('dry-run')) {
             info(sprintf('Dry run — no changes applied to %s.', $environment));
 
             return SymfonyCommand::SUCCESS;
         }
-
-        $pending = $plan->filter(fn (array $entry) => static::planEntryHasWork($entry))->values();
 
         if ($pending->isEmpty()) {
             info(sprintf('Already in sync — %s has no pending changes.', $environment));

--- a/tests/Unit/Concerns/RunScopesRenderTest.php
+++ b/tests/Unit/Concerns/RunScopesRenderTest.php
@@ -11,6 +11,7 @@ use Codinglabs\Yolo\Commands\SyncCommand;
 use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Symfony\Component\Console\Input\ArrayInput;
 use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
 class RunScopesFakeStep implements Step
 {
@@ -57,6 +58,19 @@ class RunScopesChangeStep implements Step
  */
 function runScopesCapture(array $scopes, array $options = [], int $verbosity = BufferedOutput::VERBOSITY_NORMAL): string
 {
+    return runScopesResult($scopes, $options, $verbosity)[0];
+}
+
+/**
+ * As {@see runScopesCapture()}, but returns the captured output *and* the
+ * command exit code, so the `--check` non-zero-on-drift contract can be asserted.
+ *
+ * @param  array<string, array<int, class-string>>  $scopes
+ * @param  array<string, mixed>  $options
+ * @return array{0: string, 1: int}
+ */
+function runScopesResult(array $scopes, array $options = [], int $verbosity = BufferedOutput::VERBOSITY_NORMAL): array
+{
     $command = new SyncCommand();
 
     $input = new ArrayInput(['environment' => 'testing'] + $options, $command->getDefinition());
@@ -70,9 +84,9 @@ function runScopesCapture(array $scopes, array $options = [], int $verbosity = B
 
     Prompt::setOutput($output);
 
-    (new ReflectionMethod($command, 'runScopes'))->invoke($command, 'testing', $scopes);
+    $exitCode = (new ReflectionMethod($command, 'runScopes'))->invoke($command, 'testing', $scopes);
 
-    return $output->fetch();
+    return [$output->fetch(), $exitCode];
 }
 
 beforeEach(function () {
@@ -193,6 +207,33 @@ it('dry-run renders the plan and stops — no apply, no results table, no comple
         ->toContain('idle_timeout')
         ->toContain('Dry run')
         ->not->toContain('Synced testing'); // no apply ran
+});
+
+it('--check exits non-zero on drift and never applies', function () {
+    [$output, $exitCode] = runScopesResult(
+        ['environment' => [RunScopesChangeStep::class]],
+        ['--no-progress' => true, '--check' => true],
+    );
+
+    expect($exitCode)->toBe(SymfonyCommand::FAILURE);
+    expect($output)
+        ->toContain('Pending changes')
+        ->toContain('idle_timeout')
+        ->toContain('Drift detected')
+        ->not->toContain('Synced testing'); // gate only — no apply ran
+});
+
+it('--check exits zero when the environment is already in sync', function () {
+    [$output, $exitCode] = runScopesResult(
+        ['environment' => [RunScopesCleanStep::class, RunScopesCleanStep::class]],
+        ['--no-progress' => true, '--check' => true],
+    );
+
+    expect($exitCode)->toBe(SymfonyCommand::SUCCESS);
+    expect($output)
+        ->toContain('In sync')
+        ->not->toContain('Pending changes')
+        ->not->toContain('Synced testing');
 });
 
 it('skips the apply pass when nothing drifted — no confirm, no results table', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- `yolo sync --dry-run` always exits `0`, so it's useless as a CI gate — there was no way to fail a pipeline when live AWS resources drift from `yolo.yml`.
- Adds `yolo sync <env> --check`: runs the plan pass (compute-only, never applies) and exits non-zero on drift, `0` when in sync. The machine-readable counterpart to `--dry-run`. Lands on every sync verb (`sync`, `sync:account`, `sync:environment`, `sync:app`) via one `addSyncOptions()` entry; detection reuses the existing `planEntryHasWork()` predicate.
- Tidies the README down to a docs signpost — removes the duplicated GitHub Actions OIDC section (fully covered in the CI/CD guide) and the quickstart, and routes readers to the docs.
- Documents `--check` in the command reference, the provisioning guide, and a new "Gate CI on drift" section in the CI/CD guide.

**Is there anything the reviewer needs to know to deploy this?**
- **No behaviour change to existing commands.** `--dry-run` still exits `0`; `--check` is purely additive. Nothing about deploy, sync apply, or the resource set changes.
- **`--check` needs read-capable credentials, not the deployer role.** It `Describe`s the whole stack to compute drift — far broader than the deploy-scoped `yolo-{env}-{app}-deployer` policy. Under the deployer role it would `AccessDenied` and exit non-zero for the wrong reason. The CI/CD guide calls this out with a warning callout (run it with an SSO role or `ReadOnlyAccess`).
- **Exit code conflates drift with error** by design: drift and a broken check (bad creds / AWS API failure / invalid manifest) both exit non-zero. That's intended — either way CI should stop and a human should read the printed plan. (We chose `--check` over overloading `--dry-run` so interactive previews stay exit-`0`; Terraform-style `--detailed-exitcode` was considered and dropped as more surface than needed.)
- No CI/workflow changes are included — this only exposes the gate; wiring it into a workflow is a follow-up.
- 468 Pest tests pass (incl. 2 new `--check` cases), PHPStan clean, Pint clean, VitePress build passes (no dead links).

🤖 Generated with [Claude Code](https://claude.ai/code)