### PR TITLE
fix(LPX-263): set TransitEncryptionEnabled explicitly on Valkey replication group

### DIFF
--- a/src/Resources/ElastiCache/CacheCluster.php
+++ b/src/Resources/ElastiCache/CacheCluster.php
@@ -81,6 +81,10 @@ class CacheCluster implements Resource
             'AutomaticFailoverEnabled' => false,
             'MultiAZEnabled' => false,
             'AtRestEncryptionEnabled' => true,
+            // Valkey 8.0 requires this explicitly once any encryption setting is touched — it no longer
+            // defaults. TLS in-transit is deferred; the cache is SG-locked to the task SG on 6379, so
+            // plaintext stays inside the VPC.
+            'TransitEncryptionEnabled' => false,
             'Port' => self::PORT,
             'CacheSubnetGroupName' => (new CacheSubnetGroup())->name(),
             'CacheParameterGroupName' => (new CacheParameterGroup())->name(),

--- a/tests/Unit/Resources/ElastiCache/CacheClusterTest.php
+++ b/tests/Unit/Resources/ElastiCache/CacheClusterTest.php
@@ -46,6 +46,7 @@ it('creates a single-node Valkey replication group locked to the cache SG', func
     expect($call['args']['AutomaticFailoverEnabled'])->toBeFalse();
     expect($call['args']['MultiAZEnabled'])->toBeFalse();
     expect($call['args']['AtRestEncryptionEnabled'])->toBeTrue();
+    expect($call['args']['TransitEncryptionEnabled'])->toBeFalse();
     expect($call['args']['Port'])->toBe(6379);
     expect($call['args']['CacheSubnetGroupName'])->toBe('yolo-testing-cache-subnet-group');
     expect($call['args']['CacheParameterGroupName'])->toBe('yolo-testing-cache-parameter-group');


### PR DESCRIPTION
## What

A live `yolo sync production` apply failed at the Valkey cache create step:

```
Error executing "CreateReplicationGroup" on elasticache.ap-southeast-2.amazonaws.com:
InvalidParameterValue — You must specify a value (true or false) for the
parameter TransitEncryptionEnabled.
```

## Root cause

`CacheCluster::create()` builds the `CreateReplicationGroup` call with
`AtRestEncryptionEnabled => true` but no `TransitEncryptionEnabled` key. Older Redis
engines defaulted that to `false`; **Valkey 8.0** (this cluster's engine) makes it
mandatory once *any* encryption setting is touched, so the call is rejected.

## Fix

Set `'TransitEncryptionEnabled' => false` explicitly. TLS in-transit was a
deliberately-deferred LPX-263 follow-up — the cache is SG-locked to the task SG on
6379, so plaintext stays inside the VPC. This pins the existing intended behaviour;
it does **not** enable TLS.

## Tests

- Added a `TransitEncryptionEnabled` assertion to the "creates a single-node Valkey
  replication group" test.
- `./vendor/bin/pest` — 470 passed
- `./vendor/bin/pint` — passed
- `./vendor/bin/phpstan analyse` — no errors

No public-surface change (no command / manifest / contract change), so no `docs/`
update required (confirmed: no `TransitEncryption` references in `docs/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)