### PR TITLE
feat(cache): default the shared Valkey cache to engine 9.0

### DIFF
--- a/src/Resources/ElastiCache/CacheCluster.php
+++ b/src/Resources/ElastiCache/CacheCluster.php
@@ -26,9 +26,9 @@ class CacheCluster implements Resource
     // Pinned as a matched pair — a custom parameter group forces a family that
     // is coupled to the engine major. The only pinned version in YOLO; revisit
     // on a Valkey engine bump.
-    public const ENGINE_VERSION = '8.0';
+    public const ENGINE_VERSION = '9.0';
 
-    public const PARAMETER_GROUP_FAMILY = 'valkey8';
+    public const PARAMETER_GROUP_FAMILY = 'valkey9';
 
     public const NODE_TYPE = 'cache.t4g.micro';
 
@@ -81,8 +81,8 @@ class CacheCluster implements Resource
             'AutomaticFailoverEnabled' => false,
             'MultiAZEnabled' => false,
             'AtRestEncryptionEnabled' => true,
-            // Valkey 8.0 requires this explicitly once any encryption setting is touched — it no longer
-            // defaults. TLS in-transit is deferred; the cache is SG-locked to the task SG on 6379, so
+            // Valkey requires this explicitly once any encryption setting is touched — it has no
+            // default. TLS in-transit is deferred; the cache is SG-locked to the task SG on 6379, so
             // plaintext stays inside the VPC.
             'TransitEncryptionEnabled' => false,
             'Port' => self::PORT,

--- a/tests/Unit/Resources/ElastiCache/CacheClusterTest.php
+++ b/tests/Unit/Resources/ElastiCache/CacheClusterTest.php
@@ -41,6 +41,7 @@ it('creates a single-node Valkey replication group locked to the cache SG', func
 
     expect($call['args']['ReplicationGroupId'])->toBe('yolo-testing-cache');
     expect($call['args']['Engine'])->toBe('valkey');
+    expect($call['args']['EngineVersion'])->toBe('9.0');
     expect($call['args']['CacheNodeType'])->toBe('cache.t4g.micro');
     expect($call['args']['NumCacheClusters'])->toBe(1);
     expect($call['args']['AutomaticFailoverEnabled'])->toBeFalse();


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- YOLO pinned the shared ElastiCache cache to **Valkey 8.0**. Bumps the default to **Valkey 9.0** (parameter-group family `valkey9`) so every green-field environment provisions on 9.0 — no more 8.0 anywhere.
- 9.0 is a drop-in for our usage: direct 8.0→9.0 upgrade path, phpredis/predis speak identical RESP (no client change), no removed commands (9.0 actually *un*-deprecated 25), `allkeys-lru` unchanged, and the 9.0 behaviour changes (auth-before-validation, error-message wording) don't touch a cache/session store.
- Locks the engine version in a test (`EngineVersion === '9.0'`) so an accidental downgrade fails CI.

**Is there anything the reviewer needs to know to deploy this?**
- **Constants only affect `create()`** — bumping them does *not* upgrade an existing live cluster (no `SynchronisesConfiguration` on this resource). An already-deployed 8.0 cluster stays 8.0 until it's recreated.
- The one live 8.0 cluster (CL `production`, not yet in use) is being swapped manually out-of-band: delete the replication group + the `valkey8` parameter group, then `yolo sync` recreates both on 9.0. A recreated cluster gets a **new endpoint**, and `REDIS_HOST` is baked at build time, so the app needs a `yolo deploy` afterwards to repoint.
- Subnet group + security group aren't version-tied — untouched.
- No manifest/command/doc surface changes (docs reference "Valkey" version-free). Full suite green (470 passed), pint + phpstan clean.

🤖 Generated with [Claude Code](https://claude.ai/code)