### PR TITLE
feat(sync): heartbeat + realistic timeout for slow AWS waiters

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -147,6 +147,9 @@ Interfaces a step implements to declare its execution context:
 - `ExecutesTenantStep` / `ExecutesSoloStep` / `ExecutesMultitenancyStep` / `ExecutesWebStep` / `ExecutesCommandStep` /
   `ExecutesIvsStep` — per-tenant fan-out and app-mode gating
 - `HasSubSteps` — step contains sub-steps (e.g. manifest build commands)
+- `LongRunning` — step blocks on a slow AWS waiter (cache cluster, sessions table, deploy task); the runner shows
+  its `patienceMessage()` and ticks an elapsed-time heartbeat (via `WaitReporter` + `Aws::waitFor`) so the progress
+  bar keeps moving instead of freezing mid-wait
 
 ### Concerns (`src/Concerns/`)
 

--- a/src/Aws.php
+++ b/src/Aws.php
@@ -13,6 +13,7 @@ use Aws\Sns\SnsClient;
 use Aws\Sqs\SqsClient;
 use Aws\Ssm\SsmClient;
 use Aws\Sts\StsClient;
+use Aws\AwsClientInterface;
 use Illuminate\Support\Str;
 use Aws\Route53\Route53Client;
 use Aws\DynamoDb\DynamoDbClient;
@@ -561,6 +562,36 @@ class Aws
             ->map(fn ($value, $key) => ['key' => $key, 'value' => $value])
             ->values()
             ->all();
+    }
+
+    /**
+     * Wait for an AWS waiter to reach its success state, with two things the
+     * raw SDK `waitUntil` doesn't give us:
+     *
+     *  - an explicit timeout. The SDK's per-waiter defaults are too tight for a
+     *    cold provision — `ReplicationGroupAvailable` caps at 10 minutes
+     *    (40 × 15s), but a fresh single-node Valkey cluster routinely takes
+     *    longer, so a slow-but-fine create would false-fail with a scary
+     *    "waiter failed after attempt #40". `$timeout` / `$interval` set the
+     *    ceiling per call instead.
+     *
+     *  - a heartbeat. A blocking waiter freezes the progress bar, so the
+     *    before-attempt callback pings WaitReporter every `$interval` seconds.
+     *    When the runner has registered a reporter (a LongRunning step), that
+     *    redraws the bar with elapsed time; otherwise it's a no-op.
+     *
+     * @param  array<string, mixed>  $args
+     */
+    public static function waitFor(AwsClientInterface $client, string $waiter, array $args, int $timeout = 600, int $interval = 15): void
+    {
+        $client->waitUntil($waiter, [
+            ...$args,
+            '@waiter' => [
+                'delay' => $interval,
+                'maxAttempts' => max(1, (int) ceil($timeout / $interval)),
+                'before' => fn ($command, $attempt) => WaitReporter::poll(),
+            ],
+        ]);
     }
 
     public static function accountId(): string

--- a/src/Concerns/RunsSteppedCommands.php
+++ b/src/Concerns/RunsSteppedCommands.php
@@ -7,11 +7,13 @@ use Illuminate\Support\Str;
 use Laravel\Prompts\Prompt;
 use Codinglabs\Yolo\Manifest;
 use Laravel\Prompts\Progress;
+use Codinglabs\Yolo\WaitReporter;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Stringable;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Contracts\HasSubSteps;
+use Codinglabs\Yolo\Contracts\LongRunning;
 use Codinglabs\Yolo\Contracts\RunsOnBuild;
 use Codinglabs\Yolo\Contracts\ExecutesTenantStep;
 use Codinglabs\Yolo\Contracts\ExecutesCommandStep;
@@ -268,13 +270,30 @@ trait RunsSteppedCommands
      */
     protected function invokeStep(Step $step, ?Progress $progress, string $label, int $now, array $options): array
     {
-        $progress?->label($label)
-            ->hint(sprintf('%d seconds elapsed', time() - $now))
-            ->render();
-
         $started = time();
 
-        $status = $step->__invoke($options, $this);
+        // A LongRunning step blocks inside an AWS waiter, so its progress frame
+        // would freeze at "0 seconds elapsed" and read as hung. Show the patience
+        // message up front and tick an elapsed-time heartbeat on every waiter
+        // poll (the one moment control returns to us mid-wait) so the bar keeps
+        // moving. Plain steps keep the original elapsed-since-start hint.
+        if ($step instanceof LongRunning && $progress !== null) {
+            $progress->label($label)->hint($step->patienceMessage())->render();
+
+            WaitReporter::using(fn () => $progress->label($label)
+                ->hint(sprintf('%s · %s elapsed', $step->patienceMessage(), static::humaniseElapsed(time() - $started)))
+                ->render());
+        } else {
+            $progress?->label($label)
+                ->hint(sprintf('%d seconds elapsed', time() - $now))
+                ->render();
+        }
+
+        try {
+            $status = $step->__invoke($options, $this);
+        } finally {
+            WaitReporter::clear();
+        }
 
         // Build steps return void, and HasSubSteps steps return their sub-step
         // array (load-bearing for expandStep) — neither is a StepResult. Steps
@@ -558,6 +577,24 @@ trait RunsSteppedCommands
         }
 
         return [$only => $tenants[$only]];
+    }
+
+    /**
+     * Render an elapsed-seconds count as a compact "45s" / "3m" / "12m 30s" so
+     * a LongRunning step's heartbeat reads naturally past the one-minute mark.
+     */
+    protected static function humaniseElapsed(int $seconds): string
+    {
+        if ($seconds < 60) {
+            return sprintf('%ds', $seconds);
+        }
+
+        $minutes = intdiv($seconds, 60);
+        $remainder = $seconds % 60;
+
+        return $remainder === 0
+            ? sprintf('%dm', $minutes)
+            : sprintf('%dm %ds', $minutes, $remainder);
     }
 
     protected static function renderStatus(StepResult|string $status): string

--- a/src/Contracts/LongRunning.php
+++ b/src/Contracts/LongRunning.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Codinglabs\Yolo\Contracts;
+
+/**
+ * Marks a step whose work is a slow AWS provision — a fresh ElastiCache
+ * replication group takes 5–15 minutes, a DynamoDB table tens of seconds, a
+ * deploy task runs migrations. Such steps block inside an AWS waiter, which
+ * would otherwise freeze the progress bar at its last frame and read as hung.
+ *
+ * The stepped-command runner gives a LongRunning step special treatment: it
+ * shows the patience message up front and ticks an elapsed-time heartbeat on
+ * every waiter poll (via WaitReporter), so the UI keeps moving and the user
+ * sees "this is supposed to take a while, and it is progressing".
+ */
+interface LongRunning extends Step
+{
+    /**
+     * A one-line reassurance shown while the step runs, e.g.
+     * "Provisioning the Valkey cache cluster — usually 5–15 minutes.".
+     */
+    public function patienceMessage(): string;
+}

--- a/src/Resources/DynamoDb/SessionsTable.php
+++ b/src/Resources/DynamoDb/SessionsTable.php
@@ -62,9 +62,9 @@ class SessionsTable implements Resource
             ...Aws::tags($this->tags()),
         ]);
 
-        Aws::dynamoDb()->waitUntil('TableExists', [
+        Aws::waitFor(Aws::dynamoDb(), 'TableExists', [
             'TableName' => $this->name(),
-        ]);
+        ], timeout: 5 * 60, interval: 10);
 
         Aws::dynamoDb()->updateTimeToLive([
             'TableName' => $this->name(),

--- a/src/Resources/ElastiCache/CacheCluster.php
+++ b/src/Resources/ElastiCache/CacheCluster.php
@@ -92,9 +92,12 @@ class CacheCluster implements Resource
             ...Aws::tags($this->tags()),
         ]);
 
-        Aws::elastiCache()->waitUntil('ReplicationGroupAvailable', [
+        // A fresh single-node Valkey cluster routinely takes longer than the
+        // SDK's 10-minute default, so wait up to 20 minutes — the heartbeat
+        // keeps the (LongRunning) sync step's progress bar moving meanwhile.
+        Aws::waitFor(Aws::elastiCache(), 'ReplicationGroupAvailable', [
             'ReplicationGroupId' => $this->name(),
-        ]);
+        ], timeout: 20 * 60);
     }
 
     public function synchroniseTags(bool $apply): array

--- a/src/Steps/Deploy/ExecuteDeployStepsStep.php
+++ b/src/Steps/Deploy/ExecuteDeployStepsStep.php
@@ -4,17 +4,22 @@ namespace Codinglabs\Yolo\Steps\Deploy;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Manifest;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\LongRunning;
 use Codinglabs\Yolo\Resources\Ecs\EcsCluster;
 use Codinglabs\Yolo\Resources\Ecs\EcsService;
 use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Resources\Ec2\EcsTaskSecurityGroup;
 
-class ExecuteDeployStepsStep implements Step
+class ExecuteDeployStepsStep implements LongRunning
 {
     public function __construct(protected string $environment) {}
+
+    public function patienceMessage(): string
+    {
+        return 'Running deploy tasks (migrations, etc.) — this can take a few minutes';
+    }
 
     public function __invoke(): StepResult
     {
@@ -61,11 +66,10 @@ class ExecuteDeployStepsStep implements Step
 
         $taskArn = $run['tasks'][0]['taskArn'];
 
-        Aws::ecs()->waitUntil('TasksStopped', [
+        Aws::waitFor(Aws::ecs(), 'TasksStopped', [
             'cluster' => $cluster,
             'tasks' => [$taskArn],
-            '@waiter' => ['maxAttempts' => 120, 'delay' => 10],
-        ]);
+        ], timeout: 20 * 60, interval: 10);
 
         $stopped = Aws::ecs()->describeTasks([
             'cluster' => $cluster,

--- a/src/Steps/Sync/App/SyncCacheClusterStep.php
+++ b/src/Steps/Sync/App/SyncCacheClusterStep.php
@@ -3,8 +3,8 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Manifest;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\LongRunning;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\ElastiCache\CacheCluster;
 
@@ -13,7 +13,7 @@ use Codinglabs\Yolo\Resources\ElastiCache\CacheCluster;
  * into the cache (`cache`). Depends on the cache subnet group, parameter
  * group and security group, so it runs last in the cache sequence.
  */
-class SyncCacheClusterStep implements Step
+class SyncCacheClusterStep implements LongRunning
 {
     use SynchronisesResource;
 
@@ -24,5 +24,10 @@ class SyncCacheClusterStep implements Step
         }
 
         return $this->syncResource(new CacheCluster(), $options);
+    }
+
+    public function patienceMessage(): string
+    {
+        return 'Provisioning the Valkey cache cluster — ElastiCache usually takes 5–15 minutes';
     }
 }

--- a/src/Steps/Sync/App/SyncDynamoDbSessionsTableStep.php
+++ b/src/Steps/Sync/App/SyncDynamoDbSessionsTableStep.php
@@ -3,8 +3,8 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Manifest;
-use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\LongRunning;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\DynamoDb\SessionsTable;
 
@@ -13,7 +13,7 @@ use Codinglabs\Yolo\Resources\DynamoDb\SessionsTable;
  * the `dynamodb` session driver. Other drivers (redis, database, cookie, file)
  * need no YOLO-provisioned infra here.
  */
-class SyncDynamoDbSessionsTableStep implements Step
+class SyncDynamoDbSessionsTableStep implements LongRunning
 {
     use SynchronisesResource;
 
@@ -24,5 +24,10 @@ class SyncDynamoDbSessionsTableStep implements Step
         }
 
         return $this->syncResource(new SessionsTable(), $options);
+    }
+
+    public function patienceMessage(): string
+    {
+        return 'Creating the DynamoDB sessions table — usually under a minute';
     }
 }

--- a/src/WaitReporter.php
+++ b/src/WaitReporter.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Codinglabs\Yolo;
+
+/**
+ * Ambient channel the stepped-command runner uses to surface progress from
+ * deep inside a blocking AWS waiter.
+ *
+ * Resources own their `waitUntil` call and stay UI-agnostic, and a waiter
+ * blocks the main thread so the runner can't tick the progress bar on its own.
+ * The waiter's before-attempt callback is the only code that runs during the
+ * wait, so `Aws::waitFor()` pings `poll()` on each attempt and the runner
+ * registers a reporter (`using()`) around a LongRunning step to turn those
+ * pings into a redraw — then clears it afterwards. No reporter registered makes
+ * `poll()` a no-op, so non-LongRunning waiters are unaffected.
+ */
+class WaitReporter
+{
+    /** @var (callable(): void)|null */
+    protected static $reporter = null;
+
+    public static function using(?callable $reporter): void
+    {
+        static::$reporter = $reporter;
+    }
+
+    public static function poll(): void
+    {
+        if (static::$reporter !== null) {
+            (static::$reporter)();
+        }
+    }
+
+    public static function clear(): void
+    {
+        static::$reporter = null;
+    }
+}

--- a/tests/Unit/Aws/WaitForTest.php
+++ b/tests/Unit/Aws/WaitForTest.php
@@ -1,0 +1,50 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\WaitReporter;
+
+beforeEach(fn () => writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']));
+
+afterEach(fn () => WaitReporter::clear());
+
+it('completes once the waiter reaches its success state and ticks the reporter each poll', function () {
+    $captured = [];
+
+    bindMockElastiCacheClient([
+        'DescribeReplicationGroups' => new Result(['ReplicationGroups' => [
+            ['ReplicationGroupId' => 'yolo-testing-cache', 'Status' => 'available'],
+        ]]),
+    ], $captured);
+
+    $ticks = 0;
+    WaitReporter::using(function () use (&$ticks) {
+        $ticks++;
+    });
+
+    Aws::waitFor(Aws::elastiCache(), 'ReplicationGroupAvailable', [
+        'ReplicationGroupId' => 'yolo-testing-cache',
+    ], timeout: 20 * 60);
+
+    // The before-attempt callback fires at least once (before the first poll),
+    // so the runner's heartbeat gets a chance to redraw even on a fast wait.
+    expect($ticks)->toBeGreaterThanOrEqual(1);
+    expect(array_column($captured, 'name'))->toContain('DescribeReplicationGroups');
+});
+
+it('honours the timeout by capping attempts (timeout/interval) rather than the SDK default', function () {
+    $captured = [];
+
+    // Never becomes available → the waiter must give up at our computed cap.
+    bindMockElastiCacheClient([
+        'DescribeReplicationGroups' => new Result(['ReplicationGroups' => [
+            ['ReplicationGroupId' => 'yolo-testing-cache', 'Status' => 'creating'],
+        ]]),
+    ], $captured);
+
+    // timeout 1s / interval 15s → ceil(1/15) = 1 attempt, so it fails fast with
+    // no inter-attempt sleep instead of riding the SDK's 40-attempt default.
+    expect(fn () => Aws::waitFor(Aws::elastiCache(), 'ReplicationGroupAvailable', [
+        'ReplicationGroupId' => 'yolo-testing-cache',
+    ], timeout: 1, interval: 15))->toThrow(RuntimeException::class);
+});

--- a/tests/Unit/Concerns/LongRunningHeartbeatTest.php
+++ b/tests/Unit/Concerns/LongRunningHeartbeatTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use Laravel\Prompts\Progress;
+use Codinglabs\Yolo\WaitReporter;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Commands\SyncCommand;
+use Codinglabs\Yolo\Contracts\LongRunning;
+use Symfony\Component\Console\Input\ArrayInput;
+
+/**
+ * The runner gives a LongRunning step a patience banner and an elapsed-time
+ * heartbeat that fires on every waiter poll, so a blocking AWS wait keeps the
+ * progress bar moving instead of freezing at "0 seconds elapsed".
+ *
+ * Render/advance are stubbed to no-ops so the assertions run against the
+ * Progress object's public state, not terminal output.
+ */
+function invokeStepWithProgress(LongRunning $step, Progress $progress): void
+{
+    $command = new SyncCommand();
+    $command->input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
+
+    (new ReflectionMethod($command, 'invokeStep'))
+        ->invoke($command, $step, $progress, 'app · Sync the thing', time(), []);
+}
+
+function quietProgress(): Progress
+{
+    return new class(label: 'start', steps: 1) extends Progress
+    {
+        public function render(): void {}
+
+        public function advance(int $step = 1): void {}
+    };
+}
+
+function longRunningStep(): LongRunning
+{
+    return new class() implements LongRunning
+    {
+        public function __invoke(array $options): StepResult
+        {
+            // Simulate a waiter handing control back to the heartbeat mid-wait.
+            WaitReporter::poll();
+
+            return StepResult::CREATED;
+        }
+
+        public function patienceMessage(): string
+        {
+            return 'Provisioning the thing — usually 5–15 minutes';
+        }
+    };
+}
+
+afterEach(fn () => WaitReporter::clear());
+
+it('renders the patience message and an elapsed heartbeat on each poll', function () {
+    $progress = quietProgress();
+
+    invokeStepWithProgress(longRunningStep(), $progress);
+
+    expect($progress->hint)
+        ->toContain('Provisioning the thing — usually 5–15 minutes')
+        ->toContain('elapsed');
+});
+
+it('clears the reporter after the step so a later poll cannot redraw a finished bar', function () {
+    $progress = quietProgress();
+
+    invokeStepWithProgress(longRunningStep(), $progress);
+
+    $progress->hint('SENTINEL');
+    WaitReporter::poll();
+
+    expect($progress->hint)->toBe('SENTINEL');
+});

--- a/tests/Unit/Steps/LongRunningStepsTest.php
+++ b/tests/Unit/Steps/LongRunningStepsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Codinglabs\Yolo\Contracts\LongRunning;
+use Codinglabs\Yolo\Steps\Deploy\ExecuteDeployStepsStep;
+use Codinglabs\Yolo\Steps\Sync\App\SyncCacheClusterStep;
+use Codinglabs\Yolo\Steps\Sync\App\SyncDynamoDbSessionsTableStep;
+
+it('flags the slow provisioning steps as LongRunning with a non-empty patience message', function (LongRunning $step) {
+    expect(trim($step->patienceMessage()))->not->toBe('');
+})->with([
+    'cache cluster' => fn () => new SyncCacheClusterStep(),
+    'sessions table' => fn () => new SyncDynamoDbSessionsTableStep(),
+    'deploy tasks' => fn () => new ExecuteDeployStepsStep('testing'),
+]);

--- a/tests/Unit/WaitReporterTest.php
+++ b/tests/Unit/WaitReporterTest.php
@@ -1,0 +1,38 @@
+<?php
+
+use Codinglabs\Yolo\WaitReporter;
+
+afterEach(fn () => WaitReporter::clear());
+
+it('is a no-op when no reporter is registered', function () {
+    // Nothing registered → poll() must not throw (the common case: a waiter
+    // running outside a LongRunning step).
+    WaitReporter::poll();
+
+    expect(true)->toBeTrue();
+});
+
+it('invokes the registered reporter on poll', function () {
+    $calls = 0;
+    WaitReporter::using(function () use (&$calls) {
+        $calls++;
+    });
+
+    WaitReporter::poll();
+    WaitReporter::poll();
+
+    expect($calls)->toBe(2);
+});
+
+it('stops calling the reporter once cleared', function () {
+    $calls = 0;
+    WaitReporter::using(function () use (&$calls) {
+        $calls++;
+    });
+
+    WaitReporter::poll();
+    WaitReporter::clear();
+    WaitReporter::poll();
+
+    expect($calls)->toBe(1);
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

- A real `yolo sync production` run threw `The ReplicationGroupAvailable waiter failed after attempt #40` — even though `CreateReplicationGroup` **succeeded** and the Valkey cluster came up fine moments later. Two root causes:
  - **Too-tight timeout.** The SDK's default `ReplicationGroupAvailable` waiter caps at 40 × 15s = **10 min**. A fresh single-node ElastiCache cluster routinely takes longer, so a slow-but-fine create false-fails. A *genuine* `create-failed` looks identical at that cap — the error tells you nothing.
  - **Frozen UI.** The stepped-command progress bar renders its hint once, then the blocking `waitUntil` freezes the main thread — it sat at a stale "2 seconds elapsed" for 10 real minutes, then threw red. Reads as broken when it's fine.
- No declarative way to mark a step as *expected* to be slow and reassure the user it's still progressing.

**How**

- **`Contracts\LongRunning`** — a step declares `patienceMessage()`; the runner shows it up front and ticks an elapsed-time heartbeat.
- **`WaitReporter`** (ambient) — a waiter's `before`-attempt callback is the only code that runs mid-wait, so it `poll()`s the reporter; the runner registers one around a `LongRunning` step and clears it in `finally`. No reporter → no-op, so unflagged waiters are unaffected. Resources stay UI-agnostic.
- **`Aws::waitFor()`** — wraps `waitUntil` with an explicit per-call timeout (`ceil(timeout/interval)` → `maxAttempts`, replacing the SDK default) plus the heartbeat.
- Flagged the genuinely-slow waiters:

  | Step | Waiter | Timeout |
  | --- | --- | --- |
  | `SyncCacheClusterStep` | `ReplicationGroupAvailable` | 20 min |
  | `SyncDynamoDbSessionsTableStep` | `TableExists` | 5 min |
  | `ExecuteDeployStepsStep` (deploy) | `TasksStopped` | 20 min |

  The bar now ticks e.g. `Provisioning the Valkey cache cluster — ElastiCache usually takes 5–15 minutes · 3m elapsed`.

**Is there anything the reviewer needs to know to deploy this?**

- **No change to what gets provisioned** — same AWS calls, same resources. Only the *wait window* (longer) and the *UI* (live heartbeat) change. A cache create that previously false-failed at 10 min now waits up to 20.
- `ExecuteDeployStepsStep` **preserves its prior 20-min ECS `TasksStopped` ceiling** (was `@waiter` 120 × 10s) — folded into `waitFor`, not shortened. So no deploy gets a tighter timeout than before.
- The deliberately-skipped case: the 4 S3 `BucketExists` waiters are instant, left on raw `waitUntil` — and no generic ">30s watchdog" (sync PHP can't tick inside a blocking step without `pcntl` hackery; only waiters are slow by nature, and they already expose the `before` hook).
- **No command / manifest / Dockerfile / scope surface changed** → no `docs/` update; `CLAUDE.md`'s contract list gains `LongRunning`.
- `WaitReporter` is global static but cleared in `finally` + test `afterEach`, so no parallel-worker bleed. **522 pest (parallel) / pint / phpstan green.**

🤖 Generated with [Claude Code](https://claude.ai/code)