### PR TITLE
fix(health-check): tolerant ALB target-group defaults for Octane under load

### DIFF
--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -72,9 +72,9 @@ environments:
         # health-check:
         #   path: /health                 # default: /health
         #   interval: 10                  # default: 10 (seconds between checks)
-        #   timeout: 5                    # default: 5
+        #   timeout: 8                    # default: 8 — tolerant of a slow /health under load
         #   healthy-threshold: 2          # default: 2
-        #   unhealthy-threshold: 3        # default: 3
+        #   unhealthy-threshold: 5        # default: 5 — cushion for a slow-but-alive task
         #   grace-period: 60              # default: 60 (ECS health-check grace period)
         #
         # autoscaling:                    # omit the whole block for a fixed single task
@@ -297,15 +297,15 @@ Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely
 
 ### `tasks.web.health-check.*`
 
-ALB target-group health check:
+ALB target-group health check. The defaults are tuned to avoid false-positive failures on a Laravel/Octane app under load: when the FrankenPHP worker pool is saturated the `/health` probe answers slowly (6–7s) rather than failing, so the timeout sits at `8`s — a slow-but-alive task stays in service — with a roomier `5`-failure unhealthy threshold for cushion. A genuine deadlock (no response / 30s+) still trips within ~a minute. Capacity is [autoscaling](/guide/scaling)'s job, not the health check's. Override any field per app if you need to:
 
 | Key | Default | Description |
 |---|---|---|
-| `health-check.path` | `/health` | Path the ALB requests. |
+| `health-check.path` | `/health` | Path the ALB requests. Keep it on a route that exercises PHP so a broken boot still fails the check. |
 | `health-check.interval` | `10` | Seconds between checks. |
-| `health-check.timeout` | `5` | Seconds before a check times out. |
+| `health-check.timeout` | `8` | Seconds before a check times out. Must stay below the interval. |
 | `health-check.healthy-threshold` | `2` | Consecutive successes to mark healthy. |
-| `health-check.unhealthy-threshold` | `3` | Consecutive failures to mark unhealthy. |
+| `health-check.unhealthy-threshold` | `5` | Consecutive failures to mark unhealthy. |
 | `health-check.grace-period` | `60` | Seconds after task start before health checks count (the ECS health-check grace period). |
 
 ### `tasks.web.autoscaling.*`

--- a/src/Resources/ElbV2/TargetGroup.php
+++ b/src/Resources/ElbV2/TargetGroup.php
@@ -177,6 +177,16 @@ class TargetGroup implements Resource, SynchronisesConfiguration
      * of truth so the two paths can't drift apart. Timeout must stay below the
      * interval (an AWS constraint on ModifyTargetGroup).
      *
+     * Defaults are tuned to avoid false-positive failures on a Laravel/Octane
+     * app under CPU load: when the FrankenPHP worker pool is saturated the
+     * /health probe queues behind in-flight requests and answers slowly (6-7s)
+     * rather than failing, so an 8s timeout (still below the 10s interval) keeps
+     * a slow-but-alive task in service, and the roomier unhealthy threshold (5)
+     * adds cushion. A real deadlock (no response / 30s+) still trips within ~a
+     * minute. Capacity is autoscaling's signal, not the health check's. Each
+     * field is overridable per app via tasks.web.health-check.* for the rare app
+     * that needs a different path or timing.
+     *
      * @return array<string, mixed>
      */
     public static function reconcilableHealthCheck(): array
@@ -184,9 +194,9 @@ class TargetGroup implements Resource, SynchronisesConfiguration
         return [
             'HealthCheckPath' => Manifest::get('tasks.web.health-check.path', '/health'),
             'HealthCheckIntervalSeconds' => (int) Manifest::get('tasks.web.health-check.interval', 10),
-            'HealthCheckTimeoutSeconds' => (int) Manifest::get('tasks.web.health-check.timeout', 5),
+            'HealthCheckTimeoutSeconds' => (int) Manifest::get('tasks.web.health-check.timeout', 8),
             'HealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.healthy-threshold', 2),
-            'UnhealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.unhealthy-threshold', 3),
+            'UnhealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.unhealthy-threshold', 5),
             'Matcher' => ['HttpCode' => '200'],
         ];
     }

--- a/tests/Unit/Resources/Fargate/TargetGroupTest.php
+++ b/tests/Unit/Resources/Fargate/TargetGroupTest.php
@@ -56,9 +56,9 @@ function liveTargetGroup(array $overrides = []): array
         'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:targetgroup/yolo-testing-my-app/abc',
         'HealthCheckPath' => '/health',
         'HealthCheckIntervalSeconds' => 10,
-        'HealthCheckTimeoutSeconds' => 5,
+        'HealthCheckTimeoutSeconds' => 8,
         'HealthyThresholdCount' => 2,
-        'UnhealthyThresholdCount' => 3,
+        'UnhealthyThresholdCount' => 5,
         'Matcher' => ['HttpCode' => '200'],
     ], $overrides);
 }
@@ -72,11 +72,55 @@ it('shares one health-check config between create and sync', function () {
     expect(TargetGroup::reconcilableHealthCheck())->toBe([
         'HealthCheckPath' => '/health',
         'HealthCheckIntervalSeconds' => 10,
-        'HealthCheckTimeoutSeconds' => 5,
+        'HealthCheckTimeoutSeconds' => 8,
         'HealthyThresholdCount' => 2,
-        'UnhealthyThresholdCount' => 3,
+        'UnhealthyThresholdCount' => 5,
         'Matcher' => ['HttpCode' => '200'],
     ]);
+});
+
+it('lets the manifest override each health-check field', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['health-check' => [
+            'path' => '/up',
+            'interval' => 15,
+            'timeout' => 10,
+            'healthy-threshold' => 3,
+            'unhealthy-threshold' => 4,
+        ]]],
+    ]);
+
+    expect(TargetGroup::reconcilableHealthCheck())->toBe([
+        'HealthCheckPath' => '/up',
+        'HealthCheckIntervalSeconds' => 15,
+        'HealthCheckTimeoutSeconds' => 10,
+        'HealthyThresholdCount' => 3,
+        'UnhealthyThresholdCount' => 4,
+        'Matcher' => ['HttpCode' => '200'],
+    ]);
+});
+
+it('reconciles a target group still on the old aggressive health-check defaults to the tolerant ones', function () {
+    // CL's live target group sits on the pre-tolerance values (5s timeout, 3
+    // unhealthy). A plain `yolo sync` must drag it onto the new defaults via
+    // ModifyTargetGroup — the health check is reconciled, not create-only.
+    $recorder = bindRecordingElbV2Client(
+        liveTargetGroup(['HealthCheckTimeoutSeconds' => 5, 'UnhealthyThresholdCount' => 3]),
+        deregistrationDelayAttributes('10'),
+    );
+
+    $changes = collect((new TargetGroup())->synchroniseConfiguration());
+
+    expect($recorder->calls)->toContain('ModifyTargetGroup');
+
+    $timeout = $changes->firstWhere('attribute', 'HealthCheckTimeoutSeconds');
+    expect($timeout->from)->toBe('5');
+    expect($timeout->to)->toBe('8');
+
+    $unhealthy = $changes->firstWhere('attribute', 'UnhealthyThresholdCount');
+    expect($unhealthy->from)->toBe('3');
+    expect($unhealthy->to)->toBe('5');
 });
 
 it('modifies the target group when a health-check field has drifted', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

YOLO's ALB target-group health-check defaults are too aggressive for a Laravel/Octane app. Live settings on CL's target group: `/health`, **timeout 5s**, **unhealthy threshold 3**, interval 10s, healthy threshold 2, codes 200.

- Under CPU saturation the `/health` probe queues behind the busy FrankenPHP worker pool and answers in **6–7s** — past the 5s timeout — so 3 consecutive "fails" (~25–30s) mark a **slow-but-alive** task unhealthy and ECS replaces it.
- Load testing proved the probe is *succeeding slowly* (0% errors, ~6–7s responses), **not failing**. The timeout was mislabelling success as failure → killing busy tasks and, on a single-task service, causing an outage + replacement death-loop.

**The fix** — bump the **defaults** so they don't false-positive under load (these stay configurable per app via `tasks.web.health-check.*`; only the defaults move):

| Default | Before | After |
|---|---|---|
| Timeout | 5s | **8s** (primary lever; stays < 10s interval as AWS requires) |
| Unhealthy threshold | 3 | **5** (cushion) |
| Interval / healthy / path / matcher | — | unchanged (10s / 2 / `/health` / 200) |

Path stays `/health` so the probe still exercises PHP — a broken boot is caught. A real deadlock (no response / 30s+) still trips within ~a minute; a transient load spike rides out. **Capacity is autoscaling's signal, not the health check's.**

**Is there anything the reviewer needs to know to deploy this?**

- **Not create-only — existing target groups self-heal.** `TargetGroup` already implements `SynchronisesConfiguration`, and `reconcileHealthCheck()` already diffs live-vs-desired on every `yolo sync`, firing `ModifyTargetGroup` on drift (unlike `CacheCluster`, which is create-only). So **CL's existing target group (5s / 3) gets dragged to 8s / 5 via `ModifyTargetGroup` on the next `yolo sync`** — no new plumbing. A test proves that old-defaults → tolerant path; another proves a manifest override still flows through.
- **To apply to live CL**, a `yolo sync production` is required after merge — the `ModifyTargetGroup` shows in the plan before the confirm gate. No AWS/`yolo` commands were run against any account in this change.
- Rebased onto `main` after #80 (DynamoDB→Valkey sessions) merged, since it also touched `manifest.md` — clean auto-merge, no conflicts.

**Validation:** `pest --parallel` 516 passed · `pint` passed · `phpstan` no errors · VitePress docs build clean (no dead links).

🤖 Generated with [Claude Code](https://claude.ai/code)