### PR TITLE
refactor(audit): drop pre-yolo:scope inference fallback

### DIFF
--- a/src/Audit/Arn.php
+++ b/src/Audit/Arn.php
@@ -3,8 +3,8 @@
 namespace Codinglabs\Yolo\Audit;
 
 /**
- * A parsed AWS ARN. Only the pieces the legacy audit needs to classify a
- * resource — service, region, and the type/id split of the resource segment.
+ * A parsed AWS ARN. Only the pieces the audit needs to classify a resource —
+ * service, region, and the type/id split of the resource segment.
  */
 class Arn
 {

--- a/src/Audit/Audit.php
+++ b/src/Audit/Audit.php
@@ -182,7 +182,7 @@ class Audit
 
                 return [
                     'arn' => $resource['ResourceARN'],
-                    'scope' => static::scope($parsed, $tags),
+                    'scope' => static::scope($tags),
                     'type' => static::type($parsed),
                     'name' => $tags[self::NAME_TAG] ?? $parsed?->resourceId ?? $resource['ResourceARN'],
                     'app' => $app,
@@ -200,34 +200,21 @@ class Audit
     }
 
     /**
-     * Ownership scope of a resource — account / env / app — mirroring the
-     * `Enums\Scope` a resource declares in code. Reads the explicit `yolo:scope`
-     * tag stamped by sync; falls back to inference for resources synced before
-     * the tag rollout (a `yolo:app` tag means app-scope; the GitHub OIDC provider
-     * is account-scope; everything else yolo-tagged is env-shared infra).
+     * Ownership scope of a resource — account / env / app — read straight from
+     * the `yolo:scope` tag that sync stamps on everything it creates (via
+     * `ResolvesTags`, for every scope including the account-global OIDC provider).
+     * A resource with no `yolo:scope` tag isn't YOLO-scoped — it's an unexpected,
+     * unowned resource — so it's bucketed under `env` for display.
      *
      * @param  array<string, string>  $tags
      */
-    public static function scope(?Arn $arn, array $tags): string
+    public static function scope(array $tags): string
     {
         $scope = $tags[self::SCOPE_TAG] ?? null;
 
-        return match (true) {
-            in_array($scope, [self::SCOPE_ACCOUNT, self::SCOPE_ENV, self::SCOPE_APP], true) => $scope,
-            isset($tags[self::APP_TAG]) => self::SCOPE_APP,
-            static::isAccountGlobal($arn) => self::SCOPE_ACCOUNT,
-            default => self::SCOPE_ENV,
-        };
-    }
-
-    /**
-     * Account-global resources carry no env/app scoping. Today the only one YOLO
-     * provisions is the GitHub OIDC identity provider (one per account, shared by
-     * every environment).
-     */
-    protected static function isAccountGlobal(?Arn $arn): bool
-    {
-        return $arn !== null && $arn->service === 'iam' && $arn->resourceType === 'oidc-provider';
+        return in_array($scope, [self::SCOPE_ACCOUNT, self::SCOPE_ENV, self::SCOPE_APP], true)
+            ? $scope
+            : self::SCOPE_ENV;
     }
 
     /**

--- a/tests/Unit/Audit/AuditTest.php
+++ b/tests/Unit/Audit/AuditTest.php
@@ -101,45 +101,23 @@ it('flags a yolo:app pointing at a dead app as unexpected (app cluster gone)', f
         ->and($report['resources'][0]['reason'])->toBe(Audit::REASON_DEAD_APP);
 });
 
-it('falls back to inference for resources synced before the yolo:scope rollout', function () {
-    // An app-scope resource pre-rollout still has yolo:app and resolves as ok.
-    $appReport = Audit::classify([
-        auditResource('arn:aws:ecs:ap-southeast-2:111:service/yolo-production-codinglabs/web', ['yolo:app' => 'codinglabs']),
-    ], liveApps: ['codinglabs']);
-
-    expect($appReport['okCount'])->toBe(1)
-        ->and($appReport['unexpectedCount'])->toBe(0);
-
-    // A pre-rollout env-shared resource (no yolo:app, no yolo:scope) reads as
-    // unexpected/no-owner until sync backfills the scope tag. That's the cost of
-    // a positive ownership signal — preferable to false-greening genuine debris.
-    $envReport = Audit::classify([
-        auditResource('arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-production/abc', ['Name' => 'yolo-production']),
-    ], liveApps: []);
-
-    expect($envReport['okCount'])->toBe(0)
-        ->and($envReport['unexpectedCount'])->toBe(1)
-        ->and($envReport['resources'][0]['reason'])->toBe(Audit::REASON_NO_OWNER);
-});
-
-it('assigns an ownership scope to each resource', function () {
+it('assigns an ownership scope from the yolo:scope tag, defaulting unowned resources to env', function () {
     $report = Audit::classify([
-        // yolo:app present → app scope (even when drift, an orphaned app resource)
-        auditResource('arn:aws:ecr:ap-southeast-2:111:repository/yolo-production-ghost', ['yolo:app' => 'ghost']),
-        // no yolo:app, env-shared infra → env scope
-        auditResource('arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-production/abc'),
-        // the GitHub OIDC provider is account-global → account scope
-        auditResource('arn:aws:iam::111:oidc-provider/token.actions.githubusercontent.com'),
-        // an explicit yolo:scope tag wins over inference
+        // explicit yolo:scope tags (stamped by sync on everything it creates) map
+        // straight through — including the account-global OIDC provider
+        auditResource('arn:aws:ecr:ap-southeast-2:111:repository/yolo-production-ghost', ['yolo:app' => 'ghost', 'yolo:scope' => 'app']),
         auditResource('arn:aws:s3:::some-bucket', ['yolo:scope' => 'env']),
+        auditResource('arn:aws:iam::111:oidc-provider/token.actions.githubusercontent.com', ['yolo:scope' => 'account']),
+        // no yolo:scope marker at all → an unowned resource, bucketed under env
+        auditResource('arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-production/abc'),
     ], liveApps: []);
 
     $byArn = collect($report['resources'])->keyBy('arn');
 
     expect($byArn['arn:aws:ecr:ap-southeast-2:111:repository/yolo-production-ghost']['scope'])->toBe('app')
-        ->and($byArn['arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-production/abc']['scope'])->toBe('env')
+        ->and($byArn['arn:aws:s3:::some-bucket']['scope'])->toBe('env')
         ->and($byArn['arn:aws:iam::111:oidc-provider/token.actions.githubusercontent.com']['scope'])->toBe('account')
-        ->and($byArn['arn:aws:s3:::some-bucket']['scope'])->toBe('env');
+        ->and($byArn['arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-production/abc']['scope'])->toBe('env');
 });
 
 it('orders rows by scope (account → env → app), then unexpected-first within a scope', function () {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

Clean-up follow-up to #83. `Audit::scope()` carried a backwards-compat inference fallback: when a resource had no `yolo:scope` tag, it guessed the scope — app-scope from a `yolo:app` tag, account-scope from the OIDC provider's ARN shape, env otherwise. That existed only for resources synced *before* the `yolo:scope` tag rollout.

Sync now stamps `yolo:scope` on everything it creates (via `ResolvesTags`, for every scope — including the account-global OIDC provider, which explicitly carries `yolo:scope=account`). So the inference is dead weight, and we don't need the back-compat.

- `scope()` now reads the `yolo:scope` tag and nothing else.
- A resource with no `yolo:scope` is, by definition, not YOLO-scoped — an unexpected/unowned resource — and is bucketed under `env` for display.
- Removes the `isAccountGlobal()` helper and the `Arn` argument that only the inference needed.
- Drops the back-compat test; tightens the scope test to the tag-only model.

**Is there anything the reviewer needs to know to deploy this?**

- **No behaviour change for any current resource.** Every YOLO-managed resource carries `yolo:scope` today, so it always hit the explicit-tag arm anyway — including the OIDC provider. The removed arms only ever fired for pre-rollout (un-re-synced) resources, which is exactly the back-compat we're dropping.
- Pure read-side classification; no AWS calls, no infrastructure change.
- 517 tests pass · phpstan clean · pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)
