### PR TITLE
feat(health-check): default the ALB health route to Laravel's /up

### DIFF
--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -63,7 +63,7 @@ For your image to work with YOLO, the Dockerfile must:
    ENTRYPOINT ["/app/.yolo-entrypoint.sh"]
    CMD ["supervisord", "-n"]
    ```
-4. **Expose the web port**, and make sure it matches `tasks.web.port` in your manifest (default `8000`). The ALB health-checks this port.
+4. **Expose the web port**, and make sure it matches `tasks.web.port` in your manifest (default `8000`). The ALB health-checks this port at `/up` (Laravel's built-in [health route](https://laravel.com/docs/deployment#the-health-route)) — override the path or timing via [`tasks.web.health-check.*`](/reference/manifest#tasks-web-health-check).
 5. Have **`supervisor`** installed (the default Dockerfile installs it via `apk add`).
 
 ## Processes in the container

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -70,9 +70,9 @@ environments:
         # task-role: arn:aws:iam::123456789012:role/...        # default: shared yolo-{env} role
         #
         # health-check:
-        #   path: /health                 # default: /health
+        #   path: /up                     # default: /up (Laravel's built-in health route)
         #   interval: 10                  # default: 10 (seconds between checks)
-        #   timeout: 8                    # default: 8 — tolerant of a slow /health under load
+        #   timeout: 8                    # default: 8 — tolerant of a slow /up under load
         #   healthy-threshold: 2          # default: 2
         #   unhealthy-threshold: 5        # default: 5 — cushion for a slow-but-alive task
         #   grace-period: 60              # default: 60 (ECS health-check grace period)
@@ -317,11 +317,13 @@ Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely
 
 ### `tasks.web.health-check.*`
 
-ALB target-group health check. The defaults are tuned to avoid false-positive failures on a Laravel/Octane app under load: when the FrankenPHP worker pool is saturated the `/health` probe answers slowly (6–7s) rather than failing, so the timeout sits at `8`s — a slow-but-alive task stays in service — with a roomier `5`-failure unhealthy threshold for cushion. A genuine deadlock (no response / 30s+) still trips within ~a minute. Capacity is [autoscaling](/guide/scaling)'s job, not the health check's. Override any field per app if you need to:
+ALB target-group health check. The path defaults to Laravel's built-in [`/up` health route](https://laravel.com/docs/deployment#the-health-route), which returns `200` only once the framework boots without exceptions (and `500` otherwise) — so a broken boot fails the check. Requests to it also dispatch Laravel's `Illuminate\Foundation\Events\DiagnosingHealth` event, so you can add a listener that checks your database or cache and throws to mark the app unhealthy.
+
+The other defaults are tuned to avoid false-positive failures on a Laravel/Octane app under load: when the FrankenPHP worker pool is saturated the `/up` probe answers slowly (6–7s) rather than failing, so the timeout sits at `8`s — a slow-but-alive task stays in service — with a roomier `5`-failure unhealthy threshold for cushion. A genuine deadlock (no response / 30s+) still trips within ~a minute. Capacity is [autoscaling](/guide/scaling)'s job, not the health check's. Override any field per app if you need to:
 
 | Key | Default | Description |
 |---|---|---|
-| `health-check.path` | `/health` | Path the ALB requests. Keep it on a route that exercises PHP so a broken boot still fails the check. |
+| `health-check.path` | `/up` | Path the ALB requests — defaults to Laravel's built-in `/up` health route. Keep it on a route that exercises PHP so a broken boot still fails the check. |
 | `health-check.interval` | `10` | Seconds between checks. |
 | `health-check.timeout` | `8` | Seconds before a check times out. Must stay below the interval. |
 | `health-check.healthy-threshold` | `2` | Consecutive successes to mark healthy. |

--- a/src/Resources/ElbV2/TargetGroup.php
+++ b/src/Resources/ElbV2/TargetGroup.php
@@ -179,7 +179,7 @@ class TargetGroup implements Resource, SynchronisesConfiguration
      *
      * Defaults are tuned to avoid false-positive failures on a Laravel/Octane
      * app under CPU load: when the FrankenPHP worker pool is saturated the
-     * /health probe queues behind in-flight requests and answers slowly (6-7s)
+     * /up probe queues behind in-flight requests and answers slowly (6-7s)
      * rather than failing, so an 8s timeout (still below the 10s interval) keeps
      * a slow-but-alive task in service, and the roomier unhealthy threshold (5)
      * adds cushion. A real deadlock (no response / 30s+) still trips within ~a
@@ -192,7 +192,7 @@ class TargetGroup implements Resource, SynchronisesConfiguration
     public static function reconcilableHealthCheck(): array
     {
         return [
-            'HealthCheckPath' => Manifest::get('tasks.web.health-check.path', '/health'),
+            'HealthCheckPath' => Manifest::get('tasks.web.health-check.path', '/up'),
             'HealthCheckIntervalSeconds' => (int) Manifest::get('tasks.web.health-check.interval', 10),
             'HealthCheckTimeoutSeconds' => (int) Manifest::get('tasks.web.health-check.timeout', 8),
             'HealthyThresholdCount' => (int) Manifest::get('tasks.web.health-check.healthy-threshold', 2),

--- a/tests/Unit/Resources/Fargate/TargetGroupTest.php
+++ b/tests/Unit/Resources/Fargate/TargetGroupTest.php
@@ -54,7 +54,7 @@ function liveTargetGroup(array $overrides = []): array
 {
     return array_merge([
         'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:targetgroup/yolo-testing-my-app/abc',
-        'HealthCheckPath' => '/health',
+        'HealthCheckPath' => '/up',
         'HealthCheckIntervalSeconds' => 10,
         'HealthCheckTimeoutSeconds' => 8,
         'HealthyThresholdCount' => 2,
@@ -70,7 +70,7 @@ function deregistrationDelayAttributes(string $value): array
 
 it('shares one health-check config between create and sync', function () {
     expect(TargetGroup::reconcilableHealthCheck())->toBe([
-        'HealthCheckPath' => '/health',
+        'HealthCheckPath' => '/up',
         'HealthCheckIntervalSeconds' => 10,
         'HealthCheckTimeoutSeconds' => 8,
         'HealthyThresholdCount' => 2,
@@ -83,7 +83,7 @@ it('lets the manifest override each health-check field', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['health-check' => [
-            'path' => '/up',
+            'path' => '/health',
             'interval' => 15,
             'timeout' => 10,
             'healthy-threshold' => 3,
@@ -92,7 +92,7 @@ it('lets the manifest override each health-check field', function () {
     ]);
 
     expect(TargetGroup::reconcilableHealthCheck())->toBe([
-        'HealthCheckPath' => '/up',
+        'HealthCheckPath' => '/health',
         'HealthCheckIntervalSeconds' => 15,
         'HealthCheckTimeoutSeconds' => 10,
         'HealthyThresholdCount' => 3,


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- The ALB target-group health check defaulted to `/health`, a route every app had to hand-roll. Flipping the default to **`/up`** — Laravel's built-in health route (11+) — means a stock Laravel app is health-checkable out of the box.
- `/up` boots the full framework and returns `200` only on a clean boot (`500` otherwise), so it still satisfies YOLO's "exercise PHP so a broken boot fails the check" requirement — no static Caddy 200 that would mask a broken boot.

**Is there anything the reviewer needs to know to deploy this?**
- The path stays overridable per app via `tasks.web.health-check.path` — only the **default** changed.
- `TargetGroup` implements `SynchronisesConfiguration`, so this reaches **live** target groups on the next `yolo sync` — it'll `ModifyTargetGroup` any existing group still on `/health` over to `/up`. An already-deployed app that defines `/health` but **not** `/up` would start failing health checks after a sync. Stock Laravel apps (CL included) already ship `/up`, so no impact there — just eyeball any older app that predates the `/up` route before syncing it.

### Changes
- `TargetGroup::reconcilableHealthCheck()` default `/health` → `/up` (+ rationale comment).
- Tests: default fixtures → `/up`; the override test now sets `/health` so it still proves the manifest override bites.
- Docs: manifest reference (example + table + prose) and the images/container-contract guide updated, with the prose now explaining the `/up` boot behaviour and the `DiagnosingHealth` event, linked to [Laravel's health-route docs](https://laravel.com/docs/deployment#the-health-route).

### Verification
- 553 Pest passing · pint clean · phpstan clean · VitePress build clean (no dead links).

🤖 Generated with [Claude Code](https://claude.ai/code)