### PR TITLE
LPX-661: Inertia SSR support (bundled Node process)

### DIFF
--- a/docs/guide/building-and-deploying.md
+++ b/docs/guide/building-and-deploying.md
@@ -26,8 +26,8 @@ yolo deploy production
 
 1. Purge the build directory and stage a clean copy of your app.
 2. Pull `.env.<environment>` from S3 and stamp in `APP_VERSION` (and `ASSET_URL` if a CDN is configured).
-3. Run your manifest's `build` hooks (`composer install`, `npm run build`, …).
-4. Generate the entrypoint and supervisord config (see [The Container Image](/guide/images)).
+3. Run your manifest's `build` hooks (`composer install`, `npm run build`, …). With [Inertia SSR](/guide/images#inertia-ssr) enabled, this is also where `npm run build` produces the SSR bundle that gets baked into the image.
+4. Generate the entrypoint and supervisord config (see [The Container Image](/guide/images)). When `tasks.web.ssr` is on, this is where YOLO checks your Dockerfile for the Node runtime SSR needs.
 5. Log in to ECR, build the Docker image, and push it.
 
 The image-building steps (4–5) only run when your manifest declares `tasks` — a headless app with no web task still builds its source artefact.

--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -81,10 +81,22 @@ tasks:
 - **Web** always runs — FrankenPHP serving Laravel Octane.
 - **`queue: true`** adds a `queue:work` program.
 - **`scheduler: true`** adds a busybox `crond` that fires `php artisan schedule:run` every minute. (YOLO uses cron, not `schedule:work`, so the scheduler survives `SIGTERM` cleanly.)
+- **`ssr: true`** adds Inertia's SSR renderer — see [Inertia SSR](#inertia-ssr) below.
 
 ::: tip Independent task groups
 Today web, queue, and scheduler share one container and scale together. Splitting them into independent ECS services (so you can scale the web tier without duplicating the scheduler) is on the roadmap — the manifest reserves `tasks.queue` / `tasks.scheduler` for it.
 :::
+
+## Inertia SSR
+
+Set [`tasks.web.ssr: true`](/reference/manifest#tasks-web) to server-render your Inertia + Vue pages (better SEO, faster first paint). YOLO adds an `ssr` program to supervisord that runs `php artisan inertia:start-ssr` — a Node process listening on `127.0.0.1:13714`. PHP calls it on localhost for each render, so **SSR is always bundled in the web container** — never its own service. YOLO injects `INERTIA_SSR_ENABLED=true` (unless your `.env` already sets it); the render URL comes from Inertia's default `config/inertia.php`.
+
+Two things are on you:
+
+1. **A Node runtime in your image.** YOLO owns the entrypoint and supervisord config but not the Dockerfile, so add Node yourself — e.g. `RUN apk add --no-cache nodejs` on the default Alpine base. When `ssr` is on, `yolo build` checks the Dockerfile for a Node runtime and asks for confirmation if it can't find one (a warning only — it never blocks a non-interactive CI build).
+2. **An SSR bundle from your build.** Your `npm run build` must emit the SSR bundle (`bootstrap/ssr/`) — that's standard [Inertia SSR](https://inertiajs.com/server-side-rendering) setup in your `vite.config.js`. The bundle is copied into the image automatically (it isn't excluded by `.dockerignore` or the build's `node_modules` cleanup).
+
+If the SSR process is down, Inertia falls back to client-side rendering, so the app keeps serving — the ALB health check stays on PHP's `/up` and isn't coupled to SSR. supervisord restarts a crashed renderer automatically.
 
 ## The `.dockerignore`
 

--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -11,7 +11,8 @@ You own a small `Dockerfile`; YOLO generates the moving parts (entrypoint, proce
 ```dockerfile
 FROM dunglas/frankenphp:1-php8.4-alpine
 
-RUN apk add --no-cache git supervisor \
+# nodejs is the runtime for Inertia SSR (tasks.web.ssr); drop it if you don't use SSR.
+RUN apk add --no-cache git supervisor nodejs \
     && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache excimer
 
 WORKDIR /app
@@ -93,7 +94,7 @@ Set [`tasks.web.ssr: true`](/reference/manifest#tasks-web) to server-render your
 
 Two things are on you:
 
-1. **A Node runtime in your image.** YOLO owns the entrypoint and supervisord config but not the Dockerfile, so add Node yourself — e.g. `RUN apk add --no-cache nodejs` on the default Alpine base. When `ssr` is on, `yolo build` checks the Dockerfile for a Node runtime and asks for confirmation if it can't find one (a warning only — it never blocks a non-interactive CI build).
+1. **A Node runtime in your image.** The scaffolded Dockerfile already installs `nodejs`, so SSR works out of the box. If you've slimmed it out (or moved to a base image without Node), add it back — `yolo build` checks the Dockerfile for a Node runtime when `ssr` is on and asks for confirmation if it can't find one (a warning only — it never blocks a non-interactive CI build).
 2. **An SSR bundle from your build.** Your `npm run build` must emit the SSR bundle (`bootstrap/ssr/`) — that's standard [Inertia SSR](https://inertiajs.com/server-side-rendering) setup in your `vite.config.js`. The bundle is copied into the image automatically (it isn't excluded by `.dockerignore` or the build's `node_modules` cleanup).
 
 If the SSR process is down, Inertia falls back to client-side rendering, so the app keeps serving — the ALB health check stays on PHP's `/up` and isn't coupled to SSR. supervisord restarts a crashed renderer automatically.

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -63,6 +63,7 @@ environments:
         enable-execute-command: true   # default: false — enables `yolo run` to attach (gate with MFA)
         queue: true              # default: false — run queue:work in the container
         scheduler: true          # default: false — run cron + schedule:run
+        # ssr: true                       # default: false — bundle Inertia SSR (needs Node in the Dockerfile)
         # platform: linux/amd64           # default: linux/amd64
         # shutdown-grace-period: 10       # default: 10 (web) / 70 (queue) — SIGTERM→SIGKILL window
         # log-retention: 30               # default: 30 — CloudWatch Logs retention (days)
@@ -310,6 +311,7 @@ Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely
 | `tasks.web.enable-execute-command` | `false` | Enable ECS Exec so [`yolo run`](/reference/commands#yolo-run) can attach. Gate access with MFA on your IAM. |
 | `tasks.web.queue` | `false` | Run `queue:work` **bundled** in the web container (warm, instant pickup). `true`, or an object to override its `shutdown-grace-period`. For independent scaling / scale-to-zero, extract it to a top-level [`tasks.queue`](#tasks-queue) instead — configuring both is an error. |
 | `tasks.web.scheduler` | `false` | Run the Laravel scheduler (cron + `schedule:run`) **bundled** in the web container. `true`, or an object form like `queue`. To make it a true singleton, extract it to a top-level [`tasks.scheduler`](#tasks-scheduler) instead — not both. |
+| `tasks.web.ssr` | `false` | Run Inertia's SSR renderer (`inertia:start-ssr`, a Node process on `127.0.0.1:13714`) **bundled** in the web container, so PHP server-renders your Vue pages. `true`, or an object to override its `shutdown-grace-period`. SSR is always bundled — never its own service. Needs a Node runtime in your Dockerfile and an SSR bundle from `npm run build`; YOLO injects `INERTIA_SSR_ENABLED=true` unless your `.env` sets it. See [Inertia SSR](/guide/images#inertia-ssr). |
 | `tasks.web.shutdown-grace-period` | `10` (web), `70` (queue) | Seconds a process gets on `SIGTERM` before `SIGKILL`. For web it's also the ALB drain window and the container `stopTimeout`. See [graceful shutdown](/guide/images#graceful-shutdown). |
 | `tasks.web.log-retention` | `30` | CloudWatch Logs retention (days). Must be a valid CloudWatch retention value. |
 | `tasks.web.execution-role` | shared `yolo-{env}` role | Override the ECS execution role ARN. |

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -23,6 +23,7 @@ class BuildCommand extends SteppedCommand
     ];
 
     protected array $fargateSteps = [
+        Steps\Build\Fargate\CheckSsrRuntimeStep::class,
         Steps\Build\Fargate\GenerateEntrypointScriptStep::class,
         Steps\Build\Fargate\GenerateSupervisorConfigStep::class,
         Steps\Build\Fargate\LoginToEcrStep::class,

--- a/src/ProcessCommands.php
+++ b/src/ProcessCommands.php
@@ -36,4 +36,15 @@ class ProcessCommands
     {
         return 'crond -f -d 8 -c /app/docker/crontabs';
     }
+
+    /**
+     * Inertia's SSR renderer — a Node process PHP calls over 127.0.0.1:13714 on
+     * each render. It's bundled in the web container (never its own service) so
+     * the call stays on localhost; a dead renderer degrades Inertia to
+     * client-side rendering rather than taking the app down.
+     */
+    public static function ssr(): string
+    {
+        return 'php artisan inertia:start-ssr';
+    }
 }

--- a/src/ShutdownTimings.php
+++ b/src/ShutdownTimings.php
@@ -36,6 +36,11 @@ class ShutdownTimings
     // outlasts this belongs on the queue, not the cron tick.
     private const SCHEDULER_DEFAULT_GRACE = 10;
 
+    // The bundled SSR renderer's graceful-stop window. A render is sub-second and
+    // stateless (Inertia falls back to client-side rendering if it's gone), so it
+    // only needs a moment to finish an in-flight render before SIGKILL.
+    private const SSR_DEFAULT_GRACE = 5;
+
     // Headroom between the longest graceful stop and ECS's SIGKILL so a process
     // draining right up to its window isn't cut off at the wire.
     private const STOP_TIMEOUT_BUFFER = 5;
@@ -65,13 +70,17 @@ class ShutdownTimings
 
     /**
      * Enabled supervisord program => its graceful-stop window (seconds). Octane
-     * always runs; queue and scheduler are opt-in via tasks.web.*.
+     * always runs; ssr, queue and scheduler are opt-in via tasks.web.*.
      *
      * @return array<string, int>
      */
     public static function programGraces(): array
     {
         $graces = ['octane' => static::webGrace()];
+
+        if (static::enabled('ssr')) {
+            $graces['ssr'] = static::grace('ssr', static::SSR_DEFAULT_GRACE);
+        }
 
         if (static::enabled('queue')) {
             $graces['queue'] = static::grace('queue', static::QUEUE_DEFAULT_GRACE);

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -99,6 +99,14 @@ class ConfigureEnvAndVersionStep implements Step
             $defaults['SESSION_DRIVER'] = $sessionDriver;
         }
 
+        // Inertia SSR: when the web container bundles the SSR Node process
+        // (tasks.web.ssr), turn Inertia's SSR on so PHP renders pages through it.
+        // The render URL defaults to 127.0.0.1:13714 in config/inertia.php, so only
+        // the enable flag is pinned — and only if the app hasn't set it already.
+        if (Manifest::bundles('ssr')) {
+            $defaults['INERTIA_SSR_ENABLED'] = 'true';
+        }
+
         foreach ($defaults as $key => $value) {
             if (! $this->envDefines($envPath, $key)) {
                 $values[$key] = $value;

--- a/src/Steps/Build/Fargate/CheckSsrRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckSsrRuntimeStep.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Build\Fargate;
+
+use RuntimeException;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Illuminate\Filesystem\Filesystem;
+
+use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\warning;
+
+/**
+ * When the app bundles Inertia SSR (tasks.web.ssr), the runtime image needs a
+ * Node runtime to run `inertia:start-ssr` — but YOLO doesn't own the Dockerfile
+ * (it owns the base image + PHP extensions), so it can't install one. This step
+ * eyeballs the Dockerfile for a Node runtime and, when it can't see one, warns
+ * and asks for confirmation before building.
+ *
+ * It's a warn-and-confirm, never a hard fail: the regex can't see every way Node
+ * lands in an image (a custom base image, a script install), and a genuinely
+ * missing runtime only crash-loops the SSR program — Inertia degrades to
+ * client-side rendering, so the site still serves. In a non-interactive build
+ * (the deploy GHA) the confirm returns its default and the build proceeds, so the
+ * heuristic never hangs a pipeline — the warning still lands in the log.
+ */
+class CheckSsrRuntimeStep implements Step
+{
+    public function __construct(
+        protected string $environment,
+        protected Filesystem $filesystem = new Filesystem()
+    ) {}
+
+    public function __invoke(): StepResult
+    {
+        if (! Manifest::bundles('ssr')) {
+            return StepResult::SUCCESS;
+        }
+
+        $dockerfile = Paths::base('Dockerfile');
+
+        if ($this->filesystem->exists($dockerfile) && $this->hasNodeRuntime($this->filesystem->get($dockerfile))) {
+            return StepResult::SUCCESS;
+        }
+
+        warning(
+            'tasks.web.ssr is on but no Node runtime was found in your Dockerfile. Inertia SSR '
+            . 'runs `inertia:start-ssr` under Node — add one (e.g. `apk add nodejs`) or the SSR '
+            . 'process will crash-loop and the app will fall back to client-side rendering.'
+        );
+
+        if (! confirm(label: 'Continue building without a detected Node runtime?', default: true)) {
+            throw new RuntimeException('Build aborted: tasks.web.ssr is on but the Dockerfile has no Node runtime.');
+        }
+
+        return StepResult::SUCCESS;
+    }
+
+    protected function hasNodeRuntime(string $dockerfile): bool
+    {
+        return preg_match('/\bnode(js)?\b/i', $dockerfile) === 1;
+    }
+}

--- a/src/Steps/Build/Fargate/CheckSsrRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckSsrRuntimeStep.php
@@ -36,7 +36,7 @@ class CheckSsrRuntimeStep implements Step
     public function __invoke(): StepResult
     {
         if (! Manifest::bundles('ssr')) {
-            return StepResult::SUCCESS;
+            return StepResult::SKIPPED;
         }
 
         $dockerfile = Paths::base('Dockerfile');

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -15,14 +15,15 @@ use Illuminate\Filesystem\Filesystem;
  * so the running processes can't drift from the manifest and the octane port
  * always matches tasks.web.port (the same value the target group health-checks).
  *
- * Octane (the web server) always runs; the scheduler and queue worker run only
- * when tasks.web.scheduler / tasks.web.queue are explicitly true. The code
- * default is false (octane only) — `yolo init` ships a manifest that turns both
- * on, so a fresh app gets the full web task while the absence of config stays
- * conservative. This step only models the web container's bundled programs; a
- * queue/scheduler extracted into its own service (top-level tasks.queue /
- * tasks.scheduler) runs as that service's sole process and is dispatched by the
- * entrypoint, not supervisord.
+ * Octane (the web server) always runs; the SSR renderer, scheduler and queue
+ * worker run only when tasks.web.ssr / tasks.web.scheduler / tasks.web.queue are
+ * explicitly true. The code default is false (octane only) — `yolo init` ships a
+ * manifest that turns the queue and scheduler on, so a fresh app gets the full
+ * web task while the absence of config stays conservative. This step only models
+ * the web container's bundled programs; a queue/scheduler extracted into its own
+ * service (top-level tasks.queue / tasks.scheduler) runs as that service's sole
+ * process and is dispatched by the entrypoint, not supervisord. SSR is always
+ * bundled (PHP calls it on localhost), so it never has a standalone form.
  */
 class GenerateSupervisorConfigStep implements Step
 {
@@ -59,6 +60,13 @@ class GenerateSupervisorConfigStep implements Step
             $this->header(),
             $this->program('octane', ProcessCommands::octane(), stopwaitsecs: $graces['octane']),
         ];
+
+        if (isset($graces['ssr'])) {
+            // Inertia's Node SSR renderer, sitting alongside octane so PHP reaches
+            // it on localhost. autorestart brings it back if it crashes; while it's
+            // down Inertia just renders client-side, so the app keeps serving.
+            $blocks[] = $this->program('ssr', ProcessCommands::ssr(), stopwaitsecs: $graces['ssr']);
+        }
 
         if (isset($graces['scheduler'])) {
             // Cron (crond) fires an ephemeral schedule:run each minute rather than a

--- a/stubs/Dockerfile.stub
+++ b/stubs/Dockerfile.stub
@@ -6,7 +6,8 @@
 # argument; each ECS task definition passes its own, so one image serves all.
 FROM dunglas/frankenphp:1-php8.4-alpine
 
-RUN apk add --no-cache git supervisor \
+# nodejs is the runtime for Inertia SSR (tasks.web.ssr); drop it if you don't use SSR.
+RUN apk add --no-cache git supervisor nodejs \
     && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache excimer
 
 WORKDIR /app

--- a/tests/Unit/ShutdownTimingsTest.php
+++ b/tests/Unit/ShutdownTimingsTest.php
@@ -59,6 +59,26 @@ it('gives the queue worker a longer default than the web tier', function () {
     expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'queue' => 70]);
 });
 
+it('gives the bundled ssr renderer a short default grace alongside octane', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'ssr' => 5]);
+});
+
+it('honours an ssr shutdown-grace-period override via the object form', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => ['shutdown-grace-period' => 12]]],
+    ]);
+
+    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'ssr' => 12]);
+});
+
 it('honours a queue shutdown-grace-period override via the object form', function () {
     writeManifest([
         'apex' => 'example.com',

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -220,6 +220,44 @@ it('does not pin SESSION_DRIVER when the manifest does not select one', function
     expect(file_get_contents(Paths::build('.env.testing')))->not->toContain('SESSION_DRIVER=');
 });
 
+it('enables Inertia SSR when tasks.web.ssr is on', function () {
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    expect(file_get_contents(Paths::build('.env.testing')))->toContain('INERTIA_SSR_ENABLED=true');
+});
+
+it('does not enable Inertia SSR when tasks.web.ssr is off', function () {
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    expect(file_get_contents(Paths::build('.env.testing')))->not->toContain('INERTIA_SSR_ENABLED');
+});
+
+it('respects an INERTIA_SSR_ENABLED already set in the .env', function () {
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    file_put_contents(Paths::build('.env.testing'), "INERTIA_SSR_ENABLED=false\n");
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('INERTIA_SSR_ENABLED=false');
+    expect($env)->not->toContain('INERTIA_SSR_ENABLED=true');
+});
+
 it('respects a SESSION_DRIVER already set in the .env', function () {
     rebuildEnvFixture([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',

--- a/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
@@ -25,14 +25,14 @@ afterEach(function () {
     is_file(Paths::base('Dockerfile')) && unlink(Paths::base('Dockerfile'));
 });
 
-it('passes without reading the Dockerfile when ssr is off', function () {
+it('skips without reading the Dockerfile when ssr is off', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => []],
     ]);
 
     // No Dockerfile on disk — proof the step short-circuits before touching it.
-    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SUCCESS);
+    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SKIPPED);
 });
 
 it('passes when the Dockerfile installs a Node runtime', function (string $dockerfile) {

--- a/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Codinglabs\Yolo\Paths;
+use Laravel\Prompts\Prompt;
+use Codinglabs\Yolo\Enums\StepResult;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Codinglabs\Yolo\Steps\Build\Fargate\CheckSsrRuntimeStep;
+
+/**
+ * The guard runs non-interactively here, so the confirm() that fires on a missing
+ * Node runtime returns its default (true) and the build proceeds — exactly the
+ * behaviour of the deploy GHA. The warning is swallowed by the buffered output.
+ */
+beforeEach(function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    Prompt::interactive(false);
+    Prompt::setOutput(new BufferedOutput());
+});
+
+afterEach(function () {
+    is_file(Paths::base('Dockerfile')) && unlink(Paths::base('Dockerfile'));
+});
+
+it('passes without reading the Dockerfile when ssr is off', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+
+    // No Dockerfile on disk — proof the step short-circuits before touching it.
+    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SUCCESS);
+});
+
+it('passes when the Dockerfile installs a Node runtime', function (string $dockerfile) {
+    file_put_contents(Paths::base('Dockerfile'), $dockerfile);
+
+    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SUCCESS);
+})->with([
+    'apk nodejs' => ["FROM dunglas/frankenphp:1-php8.4-alpine\nRUN apk add --no-cache nodejs npm\n"],
+    'apt nodejs' => ["FROM dunglas/frankenphp:1-php8.4\nRUN apt-get install -y nodejs\n"],
+    'FROM node stage' => ["FROM node:22-alpine AS assets\nFROM dunglas/frankenphp:1-php8.4-alpine\n"],
+    'COPY --from=node' => ["FROM dunglas/frankenphp:1-php8.4-alpine\nCOPY --from=node:22 /usr/local/bin/node /usr/local/bin/node\n"],
+]);
+
+it('proceeds (non-interactively) when no Node runtime is detected', function () {
+    file_put_contents(Paths::base('Dockerfile'), "FROM dunglas/frankenphp:1-php8.4-alpine\nRUN apk add --no-cache git supervisor\n");
+
+    // Warn-and-confirm: in a non-interactive build the confirm auto-approves, so
+    // the build is never blocked by the heuristic.
+    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SUCCESS);
+});
+
+it('proceeds when the Dockerfile is missing entirely', function () {
+    // The missing-Dockerfile error belongs to the image build, not this guard.
+    expect((new CheckSsrRuntimeStep('testing'))())->toBe(StepResult::SUCCESS);
+});

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -102,6 +102,24 @@ it('honours a queue shutdown-grace-period override via the object form', functio
     expect($config)->toContain('stopwaitsecs=90');
 });
 
+it('runs the inertia ssr renderer when tasks.web.ssr is enabled', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('[program:ssr]');
+    expect($config)->toContain('command=php artisan inertia:start-ssr');
+    // Stateless renderer → short stop wait (the only non-octane program here).
+    expect($config)->toContain('stopwaitsecs=5');
+});
+
+it('does not run the ssr renderer by default', function () {
+    expect(generatedSupervisorConfig())->not->toContain('[program:ssr]');
+});
+
 it('runs the queue worker without the scheduler when only queue is enabled', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Closes [LPX-661](https://linear.app/codinglabsau/issue/LPX-661/inertia-ssr-support-bundled-node-process).

**What problems are you solving?**
- YOLO can't run Inertia SSR — the FrankenPHP image is PHP-only, there's no SSR process, and no manifest knob. This adds **opt-in, bundled** Inertia SSR so apps can server-render Vue pages (SEO + faster first paint). First canary: the CL public marketing site.

**How**
Inertia SSR is a Node process PHP calls over `127.0.0.1:13714` on every render, so PHP + Node must share a network namespace. That welds SSR to the web task — it's a 4th supervisord program alongside Octane/queue/scheduler, **never its own service**. Bundling also keeps the SSR bundle version-locked to the assets it renders.

- **`ProcessCommands::ssr()`** → `php artisan inertia:start-ssr`, emitted as a `[program:ssr]` block when `tasks.web.ssr` is on. Gated on the existing generic `Manifest::bundles()` helper — **no validator change** (`tasks.web.*` is already a wildcard) and **no entrypoint change** (SSR is web-only, so it rides the default supervisord branch).
- **`ShutdownTimings`** — a short 5s default grace for the stateless renderer (overridable via the object form).
- **`ConfigureEnvAndVersionStep`** — injects `INERTIA_SSR_ENABLED=true` only-if-unset; the render URL comes from Inertia's `config/inertia.php` default.
- **`CheckSsrRuntimeStep`** (new build step) — when SSR is on, regex-checks the Dockerfile for a Node runtime and warns + confirms if it can't find one. **Warn-and-confirm, never a hard fail**, and TTY-only. Returns `SKIPPED` when SSR is off (matching the sync steps' convention for an unconfigured feature).
- **Default Dockerfile ships `nodejs`** — `yolo init`'s scaffold installs the Node runtime, so SSR works out of the box on a flip of the flag (CL's apps are Inertia-heavy). It's the `node` binary only (npm is build-time, runs on the host); a non-SSR app can delete the line to save ~35MB.
- **Docs** — images / manifest / building-and-deploying.

**Is there anything the reviewer needs to know to deploy this?**
- **Fully inert unless an app sets `tasks.web.ssr`.** No live app does, so this is a no-op on every current deploy. CL's existing `yolo.yml` is unchanged. The baked-in `nodejs` is the only thing every new scaffold picks up (~35MB; existing Dockerfiles are untouched).
- **The app still owns the SSR bundle** — `npm run build` must emit `bootstrap/ssr/` (standard Inertia SSR `vite.config.js` setup). The bundle already survives the build context (not excluded by rsync, `.dockerignore`, or the `rm -rf node_modules` hook), so no build-pipeline change was needed.
- **Failure posture is soft:** a dead SSR process degrades Inertia to client-side rendering, so the ALB health check stays PHP-only (`/up`) and `autorestart=true` brings the renderer back. The Dockerfile check never blocks a non-interactive CI build — it warns and proceeds.
- **Out of scope (follow-ons):** standalone SSR ECS service (only if it becomes a CPU bottleneck at LP scale); CloudFront-in-front-of-ALB guest-HTML caching (the real capacity play — render only on a cache miss).

Verification: Pint ✓ · PHPStan ✓ · Pest 567 passed (parallel) ✓ · VitePress build ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)