### PR TITLE
LPX-664: Derive queue/scheduler bundling from task presence

### DIFF
--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -44,7 +44,7 @@ During `yolo build`, YOLO writes two files into the build context that your Dock
 | File | Purpose |
 |---|---|
 | `.yolo-entrypoint.sh` | The container entrypoint. Runs your `deploy-all` hooks (e.g. `php artisan optimize`) on startup, then dispatches on the container command: a role (`web` / `queue` / `scheduler`) is supervised and traps `SIGTERM` so the web tier keeps serving across the ALB drain window before forwarding the stop; any other command — a one-off task such as a deploy migration — is `exec`'d directly (no supervise, no drain). ECS can override the command, not the entrypoint, which is why the dispatch lives here. |
-| `docker/supervisord.conf` | The supervisord program tree, generated from your `tasks.web.*` settings — FrankenPHP/Octane for web, plus `queue:work` and the scheduler if you've enabled them. A crontab is generated alongside it when the scheduler is on. |
+| `docker/supervisord.conf` | The web container's supervisord program tree — FrankenPHP/Octane, plus the `queue:work` worker and the scheduler unless you've extracted them into their own services. A crontab is generated alongside it (the scheduler always runs somewhere). A standalone queue that also hosts the scheduler gets a second `docker/supervisord.queue.conf`. |
 
 Because these are generated, your Dockerfile doesn't need to know how to run Octane, the queue, or the scheduler — it just copies the config and runs the entrypoint.
 
@@ -72,23 +72,21 @@ For your image to work with YOLO, the Dockerfile must:
 
 ## Processes in the container
 
-What runs inside the container is driven by `tasks.web` in your manifest:
+Every app runs three roles — web, the queue worker, and the scheduler — and by default they all share the one web container:
 
 ```yaml
 tasks:
   web:
     port: 8000
-    queue: true       # run queue:work alongside the web server
-    scheduler: true   # run the Laravel scheduler (cron + schedule:run)
 ```
 
 - **Web** always runs — `php artisan octane:start` serving Laravel Octane. `octane:start` boots whichever server your app's `OCTANE_SERVER` names; `yolo init` seeds `OCTANE_SERVER=frankenphp` in your `.env` to match the scaffolded Dockerfile. The server is an app concern, not infrastructure YOLO injects — to run a different Octane server, change the base image **and** `OCTANE_SERVER` together.
-- **`queue: true`** adds a `queue:work` program.
-- **`scheduler: true`** adds a busybox `crond` that fires `php artisan schedule:run` every minute. (YOLO uses cron, not `schedule:work`, so the scheduler survives `SIGTERM` cleanly.)
+- **The queue worker** runs `queue:work`, bundled in the web container until you extract it.
+- **The scheduler** runs a busybox `crond` that fires `php artisan schedule:run` every minute, bundled until you extract it. (YOLO uses cron, not `schedule:work`, so the scheduler survives `SIGTERM` cleanly.)
 - **`ssr: true`** adds Inertia's SSR renderer — see [Inertia SSR](#inertia-ssr) below.
 
 ::: tip Independent task groups
-Today web, queue, and scheduler share one container and scale together. Splitting them into independent ECS services (so you can scale the web tier without duplicating the scheduler) is on the roadmap — the manifest reserves `tasks.queue` / `tasks.scheduler` for it.
+Extract the queue and/or scheduler into their own ECS service — so you can scale the web tier without duplicating the scheduler — by adding a top-level `tasks.queue` / `tasks.scheduler` block. Where each role then runs is derived from which blocks you've added; see [Where each role runs](/reference/manifest#where-each-role-runs) and [Scaling](/guide/scaling).
 :::
 
 ## Inertia SSR

--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -86,7 +86,7 @@ tasks:
 - **`ssr: true`** adds Inertia's SSR renderer — see [Inertia SSR](#inertia-ssr) below.
 
 ::: tip Independent task groups
-Extract the queue and/or scheduler into their own ECS service — so you can scale the web tier without duplicating the scheduler — by adding a top-level `tasks.queue` / `tasks.scheduler` block. Where each role then runs is derived from which blocks you've added; see [Where each role runs](/reference/manifest#where-each-role-runs) and [Scaling](/guide/scaling).
+Run web in isolation by extracting the **worker tier**: add a top-level `tasks.queue` block and the queue worker and scheduler move to their own service, leaving web as pure Octane. Add `tasks.scheduler` too for a dedicated singleton cron. Where each role runs is derived from which blocks you've added; see [Where each role runs](/reference/manifest#where-each-role-runs) and [Scaling](/guide/scaling).
 :::
 
 ## Inertia SSR

--- a/docs/guide/scaling.md
+++ b/docs/guide/scaling.md
@@ -1,6 +1,6 @@
 # Scaling
 
-By default an app runs as **one Fargate task** doing everything — Octane plus, if enabled, the bundled queue worker and scheduler (`tasks.web.queue` / `tasks.web.scheduler`). That's the cheap floor and fine at low scale. The three workloads have different scaling shapes, though, so each can be **extracted into its own ECS service** that scales independently:
+By default an app runs as **one Fargate task** doing everything — Octane plus the bundled queue worker and scheduler. That's the cheap floor and fine at low scale. The three workloads have different scaling shapes, though, so each can be **extracted into its own ECS service** that scales independently:
 
 | Service | How it scales | Opt in with |
 |---|---|---|
@@ -8,7 +8,7 @@ By default an app runs as **one Fargate task** doing everything — Octane plus,
 | **queue** | backlog-per-task, **scales to zero** | top-level `tasks.queue` |
 | **scheduler** | never — pinned singleton (exactly one task) | top-level `tasks.scheduler` |
 
-Extraction is additive and per-workload: keep the queue bundled but give the scheduler its own service, or any mix. A workload can't be both bundled (`tasks.web.queue`) and extracted (`tasks.queue`) at once — `sync` hard-fails if you configure both.
+Extraction is additive and per-workload: keep the queue bundled but give the scheduler its own service, or any mix. Bundling is derived from presence — there are no `tasks.web.queue` / `tasks.web.scheduler` flags; each workload rides the web container until a top-level `tasks.queue` / `tasks.scheduler` block extracts it. One wrinkle: with only the queue extracted, the scheduler rides that queue container (see [the scheduler](#the-scheduler)).
 
 You can scale the web (and queue) service two ways:
 
@@ -24,8 +24,6 @@ Add a `tasks.web.autoscaling` block to the environment to turn it on:
 ```yaml
 tasks:
   web:
-    queue: true
-    scheduler: true
     autoscaling:
       min: 1
       max: 6
@@ -113,7 +111,7 @@ That makes the choice of *where* the queue lives a latency decision:
 
 | Topology | Idle cost | Pickup latency | Use for |
 |---|---|---|---|
-| Bundled (`tasks.web.queue: true`) | included in web | **instant** (worker always warm) | light, latency-sensitive jobs |
+| Bundled (no `tasks.queue` block) | included in web | **instant** (worker always warm) | light, latency-sensitive jobs |
 | Standalone, `min: 0` | **~$0** | ~30–60s cold start from idle | bursty, latency-tolerant async |
 | Standalone, `min: 1+` | one always-on task | instant, then autoscales | high-volume, always-busy |
 
@@ -125,7 +123,7 @@ The scheduler (`crond` firing `schedule:run` every minute) must run as a **singl
 
 ### 1. `->onOneServer()`
 
-Keep the scheduler bundled in the web container (`tasks.web.scheduler: true`) and add Laravel's [`onOneServer()`](https://laravel.com/docs/scheduling#running-tasks-on-one-server) to **every** scheduled task. It takes an atomic lock in the shared cache so only one replica runs each task per minute:
+Keep the scheduler bundled in its default container (the web container, or the standalone queue if you've extracted one) and add Laravel's [`onOneServer()`](https://laravel.com/docs/scheduling#running-tasks-on-one-server) to **every** scheduled task. It takes an atomic lock in the shared cache so only one replica runs each task per minute:
 
 ```php
 $schedule->command('reports:send')->daily()->onOneServer();
@@ -149,5 +147,5 @@ tasks:
 YOLO pins it at exactly one task (never a scalable target) and deploys it **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout stops the old cron before starting the new one — a deploy never briefly runs two schedulers (a missed cron minute is harmless; a double-run isn't). This removes the `onOneServer()` *requirement* entirely — it's genuinely a singleton now — though leaving `onOneServer()` on is harmless. The web tier then scales without any scheduler concern.
 
 ::: tip
-When you enable autoscaling on a web task that still **bundles** the scheduler, `yolo sync` prints a one-line advisory pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
+When the scheduler is bundled into a host that runs more than one task — an autoscaling web task, or the standalone queue (which always autoscales) — `yolo sync` prints a one-line advisory pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
 :::

--- a/docs/guide/scaling.md
+++ b/docs/guide/scaling.md
@@ -8,7 +8,7 @@ By default an app runs as **one Fargate task** doing everything — Octane plus 
 | **queue** | backlog-per-task, **scales to zero** | top-level `tasks.queue` |
 | **scheduler** | never — pinned singleton (exactly one task) | top-level `tasks.scheduler` |
 
-Extraction is additive and per-workload: keep the queue bundled but give the scheduler its own service, or any mix. Bundling is derived from presence — there are no `tasks.web.queue` / `tasks.web.scheduler` flags; each workload rides the web container until a top-level `tasks.queue` / `tasks.scheduler` block extracts it. One wrinkle: with only the queue extracted, the scheduler rides that queue container (see [the scheduler](#the-scheduler)).
+Extraction is opt-in by presence — there are no `tasks.web.queue` / `tasks.web.scheduler` flags. Add a top-level `tasks.queue` block to peel the **worker tier** (the queue worker *and* the scheduler) out of web, leaving web as pure Octane; add `tasks.scheduler` as well to give cron its own pinned-singleton task (see [the scheduler](#the-scheduler)).
 
 You can scale the web (and queue) service two ways:
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -308,16 +308,17 @@ Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely
 
 ### Where each role runs
 
-Every app runs three roles — **web** (Octane), the **queue worker**, and the **scheduler** (cron + `schedule:run`). There's no opt-out; the only choice is *where* each runs. The queue worker and the scheduler bundle into the web container by default, and you extract one into its own ECS service by adding a top-level [`tasks.queue`](#tasks-queue) / [`tasks.scheduler`](#tasks-scheduler) block. Bundling is derived from that presence — there are no `tasks.web.queue` / `tasks.web.scheduler` flags. The scheduler cascades onto the standalone queue if there is one (no point running a separate one-task service for cron when the queue is already a managed tier):
+Every app runs three roles — **web** (Octane), the **queue worker**, and the **scheduler** (cron + `schedule:run`). There's no opt-out; the only choice is *where* each runs. By default all three share the one web container — the cheap single-task floor.
 
-| Manifest | web container | queue container | scheduler container |
+To run web in isolation, **extract the worker tier**: add a top-level [`tasks.queue`](#tasks-queue) block and the queue worker *and* the scheduler move out to their own service, leaving web as pure Octane. Add [`tasks.scheduler`](#tasks-scheduler) as well to give cron its own pinned-singleton task. Placement is derived from which blocks are present — there are no `tasks.web.queue` / `tasks.web.scheduler` flags.
+
+| Manifest | web container | worker container | scheduler container |
 | --- | --- | --- | --- |
 | `web` only | web + queue + scheduler | — | — |
 | `web` + `queue` | web | queue + scheduler | — |
-| `web` + `scheduler` | web + queue | — | scheduler |
 | `web` + `queue` + `scheduler` | web | queue | scheduler |
 
-When the queue hosts the scheduler (the `web` + `queue` row), the queue can't scale to zero — cron would stop when it idled — so its floor is pinned at `min: 1` (an explicit `tasks.queue.min: 0` there is rejected).
+The scheduler rides the worker container (the `web` + `queue` row) rather than getting its own task — there's no point paying for a separate one-task service for cron when the queue is already a managed tier. Because cron then runs on the autoscaling queue, guard scheduled tasks with `->onOneServer()`, or add `tasks.scheduler` for a true singleton. A queue that hosts the scheduler can't scale to zero — cron would stop when it idled — so its floor is pinned at `min: 1` (an explicit `tasks.queue.min: 0` there is rejected).
 
 | Key | Default | Description |
 |---|---|---|

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -4,7 +4,7 @@
 
 ## A complete example
 
-Every key YOLO understands, in one annotated `yolo.yml`. **Required keys are uncommented; everything else is commented out showing its default**, so you can copy this and uncomment only what you need to change. `yolo init` scaffolds a minimal subset of this — a web app with the queue and scheduler on.
+Every key YOLO understands, in one annotated `yolo.yml`. **Required keys are uncommented; everything else is commented out showing its default**, so you can copy this and uncomment only what you need to change. `yolo init` scaffolds a minimal subset of this — a plain web app whose one container runs all three roles (web, queue worker, scheduler).
 
 ```yaml
 name: codinglabs                 # required — app name, prefixes every app-scoped resource
@@ -55,17 +55,19 @@ environments:
     #   depth-alarm-period: 300             # default: 300 — evaluation period (seconds)
     #   depth-alarm-evaluation-periods: 3   # default: 3 — periods that must breach
 
+    # Every app runs three roles — web, the queue worker, and the scheduler. With
+    # just `web` below they share the one web container; uncommenting `queue` and/or
+    # `scheduler` further down extracts them into their own service (see the cascade
+    # table under tasks.web.*).
     tasks:
       web:
         cpu: '512'               # default: '512' — Fargate CPU units
         memory: '1024'           # default: '1024' — Fargate memory (MB)
         port: 8000               # default: 8000 — must match the Dockerfile & health check
         enable-execute-command: true   # default: false — enables `yolo run` to attach (gate with MFA)
-        queue: true              # default: false — run queue:work in the container
-        scheduler: true          # default: false — run cron + schedule:run
         # ssr: true                       # default: false — bundle Inertia SSR (needs Node in the Dockerfile)
         # platform: linux/amd64           # default: linux/amd64
-        # shutdown-grace-period: 10       # default: 10 (web) / 70 (queue) — SIGTERM→SIGKILL window
+        # shutdown-grace-period: 10       # default: 10 — web SIGTERM→SIGKILL window (also the ALB drain)
         # log-retention: 30               # default: 30 — CloudWatch Logs retention (days)
         # execution-role: arn:aws:iam::123456789012:role/...   # default: shared yolo-{env} role
         # task-role: arn:aws:iam::123456789012:role/...        # default: shared yolo-{env} role
@@ -87,8 +89,9 @@ environments:
         #   scale-in-cooldown: 300        # default: 300
 
       # Extract the queue into its own ECS service (scale independently of web).
-      # Mutually exclusive with `web.queue` above — configure a queue in one place,
-      # not both. A standalone queue scales to zero by default.
+      # Presence is the opt-in. A standalone queue scales to zero by default —
+      # unless it also hosts the scheduler (no `scheduler` block below), where the
+      # floor is pinned at min 1 so cron isn't killed when it idles.
       # queue:
       #   min: 0                          # default: 0 — 0 = scale to zero when idle
       #   max: 10                         # default: 10
@@ -100,8 +103,9 @@ environments:
       #   enable-execute-command: false   # default: false
 
       # Extract the scheduler into its own pinned-singleton service (always one
-      # task; deploys stop-then-start so a rollout never runs two crons). Mutually
-      # exclusive with `web.scheduler` above.
+      # task; deploys stop-then-start so a rollout never runs two crons), which
+      # drops the onOneServer() requirement. Without this block the scheduler rides
+      # the standalone queue if there is one, else the web container.
       # scheduler:
       #   cpu: '256'                      # default: '256'
       #   memory: '512'                   # default: '512'
@@ -302,6 +306,19 @@ On a web app, omitting `session` gives you the `redis` default; set a driver to 
 
 Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely for a build-only / headless app with no container.
 
+### Where each role runs
+
+Every app runs three roles — **web** (Octane), the **queue worker**, and the **scheduler** (cron + `schedule:run`). There's no opt-out; the only choice is *where* each runs. The queue worker and the scheduler bundle into the web container by default, and you extract one into its own ECS service by adding a top-level [`tasks.queue`](#tasks-queue) / [`tasks.scheduler`](#tasks-scheduler) block. Bundling is derived from that presence — there are no `tasks.web.queue` / `tasks.web.scheduler` flags. The scheduler cascades onto the standalone queue if there is one (no point running a separate one-task service for cron when the queue is already a managed tier):
+
+| Manifest | web container | queue container | scheduler container |
+| --- | --- | --- | --- |
+| `web` only | web + queue + scheduler | — | — |
+| `web` + `queue` | web | queue + scheduler | — |
+| `web` + `scheduler` | web + queue | — | scheduler |
+| `web` + `queue` + `scheduler` | web | queue | scheduler |
+
+When the queue hosts the scheduler (the `web` + `queue` row), the queue can't scale to zero — cron would stop when it idled — so its floor is pinned at `min: 1` (an explicit `tasks.queue.min: 0` there is rejected).
+
 | Key | Default | Description |
 |---|---|---|
 | `tasks.web.port` | `8000` | Container port. Must match the Dockerfile's exposed port and the health check. |
@@ -309,10 +326,8 @@ Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely
 | `tasks.web.memory` | `'1024'` | Fargate memory (MB). |
 | `tasks.web.platform` | `linux/amd64` | Docker build platform. |
 | `tasks.web.enable-execute-command` | `false` | Enable ECS Exec so [`yolo run`](/reference/commands#yolo-run) can attach. Gate access with MFA on your IAM. |
-| `tasks.web.queue` | `false` | Run `queue:work` **bundled** in the web container (warm, instant pickup). `true`, or an object to override its `shutdown-grace-period`. For independent scaling / scale-to-zero, extract it to a top-level [`tasks.queue`](#tasks-queue) instead — configuring both is an error. |
-| `tasks.web.scheduler` | `false` | Run the Laravel scheduler (cron + `schedule:run`) **bundled** in the web container. `true`, or an object form like `queue`. To make it a true singleton, extract it to a top-level [`tasks.scheduler`](#tasks-scheduler) instead — not both. |
 | `tasks.web.ssr` | `false` | Run Inertia's SSR renderer (`inertia:start-ssr`, a Node process on `127.0.0.1:13714`) **bundled** in the web container, so PHP server-renders your Vue pages. `true`, or an object to override its `shutdown-grace-period`. SSR is always bundled — never its own service. Needs a Node runtime in your Dockerfile and an SSR bundle from `npm run build`; YOLO injects `INERTIA_SSR_ENABLED=true` unless your `.env` sets it. See [Inertia SSR](/guide/images#inertia-ssr). |
-| `tasks.web.shutdown-grace-period` | `10` (web), `70` (queue) | Seconds a process gets on `SIGTERM` before `SIGKILL`. For web it's also the ALB drain window and the container `stopTimeout`. See [graceful shutdown](/guide/images#graceful-shutdown). |
+| `tasks.web.shutdown-grace-period` | `10` | Seconds the web process gets on `SIGTERM` before `SIGKILL`. It's also the ALB drain window and the container `stopTimeout`. See [graceful shutdown](/guide/images#graceful-shutdown). |
 | `tasks.web.log-retention` | `30` | CloudWatch Logs retention (days). Must be a valid CloudWatch retention value. |
 | `tasks.web.execution-role` | shared `yolo-{env}` role | Override the ECS execution role ARN. |
 | `tasks.web.task-role` | shared `yolo-{env}` role | Override the ECS task role ARN. |
@@ -348,8 +363,6 @@ Add an `autoscaling` block to turn on [Application Auto Scaling](/guide/scaling)
 ```yaml
 tasks:
   web:
-    queue: true
-    scheduler: true
     autoscaling:
       min: 1
       max: 6
@@ -358,16 +371,16 @@ tasks:
 ```
 
 ::: warning Bundled scheduler
-When the scheduler runs in the same task (`tasks.web.scheduler: true`), scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). `sync` prints a one-line advisory in this case. See [Scaling → the scheduler](/guide/scaling#the-scheduler).
+A plain web app bundles the scheduler in the web container, so scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). `sync` prints a one-line advisory whenever the scheduler is bundled into an autoscaling host (the web task, or the standalone queue, which always autoscales). See [Scaling → the scheduler](/guide/scaling#the-scheduler).
 :::
 
 ---
 
 ## `tasks.queue.*`
 
-A top-level `tasks.queue` block extracts the queue worker into its **own** ECS service, so it scales independently of web. Presence is the opt-in — an empty block (`queue:`) gives a scale-to-zero worker on default sizing. Mutually exclusive with the bundled [`tasks.web.queue`](#tasks-web): configure the queue in one place, not both, or `sync` hard-fails.
+A top-level `tasks.queue` block extracts the queue worker into its **own** ECS service, so it scales independently of web. Presence is the opt-in — an empty block (`queue:`) gives a scale-to-zero worker on default sizing. Without it, the worker stays bundled in the web container (see [Where each role runs](#where-each-role-runs)).
 
-A standalone queue **scales to zero by default** (`min: 0`): zero tasks — and zero compute cost — when the queue is empty, scaling up on backlog. The trade-off is a ~30–60s Fargate cold start on the first message after idle, so it suits bursty, latency-tolerant work. For latency-sensitive jobs that must start instantly, keep them bundled in the web container (`tasks.web.queue: true`, a warm worker) or set a standing floor (`min: 1`).
+A standalone queue **scales to zero by default** (`min: 0`): zero tasks — and zero compute cost — when the queue is empty, scaling up on backlog. The trade-off is a ~30–60s Fargate cold start on the first message after idle, so it suits bursty, latency-tolerant work. For latency-sensitive jobs that must start instantly, leave the queue bundled in the warm web container or set a standing floor (`min: 1`). One caveat: when the queue also hosts the scheduler (a `tasks.queue` block with no [`tasks.scheduler`](#tasks-scheduler)), it can't scale to zero — the floor is pinned at `min: 1`, and an explicit `tasks.queue.min: 0` is rejected.
 
 Scaling is **backlog-per-task** target tracking (`ApproximateNumberOfMessagesVisible / RunningTaskCount`, CloudWatch metric math — no Lambda). A scale-to-zero queue (`min: 0`) also gets a step-scaling alarm that lifts it 0→1 the instant a message arrives (target tracking can't divide by zero running tasks).
 
@@ -388,7 +401,7 @@ See [Scaling → the queue](/guide/scaling#the-queue-scale-to-zero).
 
 ## `tasks.scheduler.*`
 
-A top-level `tasks.scheduler` block extracts the scheduler (busybox `crond` firing `schedule:run`) into its **own** ECS service, pinned at exactly one task — a genuine singleton, so `->onOneServer()` is no longer required. It deploys **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout never briefly runs two crons; a missed cron minute is harmless, a double-run isn't. Mutually exclusive with the bundled [`tasks.web.scheduler`](#tasks-web).
+A top-level `tasks.scheduler` block extracts the scheduler (busybox `crond` firing `schedule:run`) into its **own** ECS service, pinned at exactly one task — a genuine singleton, so `->onOneServer()` is no longer required. It deploys **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout never briefly runs two crons; a missed cron minute is harmless, a double-run isn't. Without this block the scheduler rides the standalone queue if there is one, else the web container (see [Where each role runs](#where-each-role-runs)).
 
 The scheduler never scales (a per-minute cron can't tolerate a cold start), so it has no `min`/`max`.
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -5,6 +5,7 @@ namespace Codinglabs\Yolo\Commands;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Concerns\RegistersAws;
 use Codinglabs\Yolo\Concerns\HasAfterCallbacks;
 use Symfony\Component\Console\Input\InputInterface;
@@ -91,28 +92,32 @@ abstract class Command extends SymfonyCommand
             && $this->ensureManifestKeyDeclared('account-id')
             && $this->ensureCacheStoreValid()
             && $this->ensureSessionDriverValid()
-            && $this->ensureTaskGroupsNotDoublyDefined();
+            && $this->ensureSchedulerHostNotScaleToZero();
     }
 
     /**
-     * A workload runs either bundled in the web container (`tasks.web.queue` /
-     * `tasks.web.scheduler`) or as its own service (a top-level `tasks.queue` /
-     * `tasks.scheduler` block) — never both. Configuring both is ambiguous (is the
-     * queue in the web task or a service of its own?), so hard-fail and tell the
-     * operator which line to drop.
+     * When the scheduler rides the standalone queue (a `tasks.queue` block but no
+     * dedicated `tasks.scheduler` service), the queue can't scale to zero — cron
+     * would stop the moment it idled to no tasks. The floor defaults to 1 in that
+     * topology, but an explicit `tasks.queue.min: 0` is a contradiction, so
+     * hard-fail and point at the two ways out.
      */
-    protected function ensureTaskGroupsNotDoublyDefined(): bool
+    protected function ensureSchedulerHostNotScaleToZero(): bool
     {
-        foreach (['queue', 'scheduler'] as $group) {
-            if (Manifest::bundles($group) && Manifest::has("tasks.$group")) {
-                error(sprintf(
-                    "yolo.yml runs `%s` both bundled under `tasks.web.%s` and as its own service `tasks.%s` — pick one.\n"
-                    . 'Drop `tasks.web.%s` to extract it into a standalone service, or drop `tasks.%s` to keep it in the web container.',
-                    $group, $group, $group, $group, $group,
-                ));
+        if (Manifest::schedulerHost() !== ServerGroup::QUEUE) {
+            return true;
+        }
 
-                return false;
-            }
+        $min = Manifest::get('tasks.queue.min');
+
+        if ($min !== null && is_numeric($min) && (int) $min === 0) {
+            error(
+                "yolo.yml runs the scheduler inside the standalone queue (there's no `tasks.scheduler` service), "
+                . "so the queue can't scale to zero — cron would stop when it idles to 0 tasks.\n"
+                . 'Set `tasks.queue.min` to 1 or more, or extract the scheduler into its own `tasks.scheduler` service.'
+            );
+
+            return false;
         }
 
         return true;

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
 use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\ServerGroup;
 
 use function Laravel\Prompts\warning;
 
@@ -37,17 +38,30 @@ class SyncAppCommand extends SyncSteppedCommand
     }
 
     /**
-     * A soft, non-blocking nudge (not a guard) when autoscaling is enabled on a
-     * web task that also bundles the scheduler. Scaling the bundled task to N
-     * replicas runs cron N times, so every scheduled task must use ->onOneServer().
+     * A soft, non-blocking nudge (not a guard) when the scheduler is bundled into a
+     * host that can run more than one task — the autoscaling web container, or the
+     * standalone queue (which always autoscales). Cron then fires on every replica,
+     * so every scheduled task must use ->onOneServer(). A dedicated tasks.scheduler
+     * service is a pinned singleton and needs no nudge.
      */
     public static function schedulerAdvisory(): ?string
     {
-        if (! Manifest::has('tasks.web.autoscaling') || empty(Manifest::get('tasks.web.scheduler'))) {
+        $host = Manifest::schedulerHost();
+
+        $hostAutoscales = match ($host) {
+            ServerGroup::WEB => Manifest::has('tasks.web.autoscaling'),
+            ServerGroup::QUEUE => true, // a standalone queue is always autoscaled (min↔max)
+            ServerGroup::SCHEDULER => false, // dedicated singleton — never multi-fires
+        };
+
+        if (! $hostAutoscales) {
             return null;
         }
 
-        return 'Autoscaling a bundled web+scheduler task runs cron on every replica — guard each scheduled task with ->onOneServer() or it fires N times.';
+        return sprintf(
+            'The scheduler is bundled into the autoscaling %s task — cron fires on every replica. Guard each scheduled task with ->onOneServer(), or extract the scheduler into its own tasks.scheduler service.',
+            $host->value,
+        );
     }
 
     public function scopes(): array

--- a/src/Enums/ServerGroup.php
+++ b/src/Enums/ServerGroup.php
@@ -5,8 +5,10 @@ namespace Codinglabs\Yolo\Enums;
 /**
  * The three workloads an app runs. Each can live in its own ECS service +
  * task-definition (`web` always; `queue` / `scheduler` when extracted via a
- * top-level `tasks.queue` / `tasks.scheduler` block), or — for queue/scheduler —
- * bundled inside the web container via `tasks.web.queue` / `tasks.web.scheduler`.
+ * top-level `tasks.queue` / `tasks.scheduler` block). A queue/scheduler that isn't
+ * extracted is bundled into another container, derived from task presence: the
+ * queue worker rides web, and the scheduler rides the standalone queue if there is
+ * one, else web (see Manifest::queueHost / schedulerHost).
  *
  * The enum value doubles as the resource-name suffix (`yolo-{env}-{app}-web`),
  * the task-definition container name, the entrypoint role argument and the

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -34,7 +34,20 @@ class Manifest
         'sqs.depth-alarm-threshold', 'sqs.depth-alarm-period', 'sqs.depth-alarm-evaluation-periods',
         'cache.store',
         'session.driver',
-        'tasks.web.*', 'tasks.queue.*', 'tasks.scheduler.*',
+        // tasks.web has a fixed, known shape, so every key is listed explicitly: a
+        // mistyped or removed key (e.g. the old tasks.web.queue / tasks.web.scheduler
+        // bundling flags, now derived from task presence) hard-fails as unrecognised
+        // rather than being silently ignored. health-check / autoscaling / the ssr
+        // object form are the only nested subtrees. The standalone tasks.queue /
+        // tasks.scheduler service blocks stay free-form.
+        'tasks.web',
+        'tasks.web.port', 'tasks.web.cpu', 'tasks.web.memory', 'tasks.web.platform',
+        'tasks.web.enable-execute-command', 'tasks.web.shutdown-grace-period',
+        'tasks.web.log-retention', 'tasks.web.log-group',
+        'tasks.web.execution-role', 'tasks.web.task-role',
+        'tasks.web.ssr', 'tasks.web.ssr.*',
+        'tasks.web.health-check.*', 'tasks.web.autoscaling.*',
+        'tasks.queue.*', 'tasks.scheduler.*',
         'build', 'deploy', 'deploy-all',
     ];
 
@@ -296,18 +309,60 @@ class Manifest
     }
 
     /**
-     * Whether the web container also runs this workload in-process (bundled mode)
-     * — `tasks.web.queue` / `tasks.web.scheduler` set truthy (a bare `true` or an
-     * object of overrides). The bare-flag form goes through strict bool validation
-     * so a typo can't silently disable a bundled process. The alternative is to
-     * extract the workload into its own service (see hasStandaloneQueue /
-     * hasStandaloneScheduler); a workload can't be both at once.
+     * Whether the web container bundles an opt-in in-process program — today only
+     * `tasks.web.ssr` (Inertia's SSR renderer). Truthy is a bare `true` or an
+     * object of overrides (e.g. shutdown-grace-period); the bare-flag form goes
+     * through strict bool validation so a typo can't silently disable it.
+     *
+     * Queue and scheduler bundling is NOT a flag — it's derived from task presence
+     * (see queueHost / schedulerHost): each rides the web container unless a
+     * top-level tasks.queue / tasks.scheduler block extracts it into its own service.
      */
     public static function bundles(string $program): bool
     {
         $value = static::get("tasks.web.$program", false);
 
         return is_array($value) || Helpers::validateStrictBool($value, "tasks.web.$program");
+    }
+
+    /**
+     * Which container runs the queue worker: a standalone `tasks.queue` service if
+     * extracted, else bundled in the web container. The worker always runs
+     * somewhere — there's no opt-out.
+     */
+    public static function queueHost(): ServerGroup
+    {
+        return static::hasStandaloneQueue() ? ServerGroup::QUEUE : ServerGroup::WEB;
+    }
+
+    /**
+     * Which container runs the scheduler (crond + schedule:run): a dedicated
+     * `tasks.scheduler` service if extracted, else the standalone queue if there is
+     * one, else the web container. The cron always runs somewhere — there's no
+     * opt-out — so management work lands on the least request-facing service that
+     * exists. This is also the deploy/management tier (see deployGroup).
+     */
+    public static function schedulerHost(): ServerGroup
+    {
+        return match (true) {
+            static::hasStandaloneScheduler() => ServerGroup::SCHEDULER,
+            static::hasStandaloneQueue() => ServerGroup::QUEUE,
+            default => ServerGroup::WEB,
+        };
+    }
+
+    /**
+     * The autoscaling/desired-count floor for the standalone queue. A scale-to-zero
+     * queue (`min: 0`, the default) idles to no tasks — but when the queue also
+     * hosts the scheduler (no dedicated `tasks.scheduler` service), it can't scale
+     * to zero or cron would stop, so the floor defaults to 1. An explicit
+     * `tasks.queue.min: 0` in that topology is rejected by the validator.
+     */
+    public static function queueMin(): int
+    {
+        $default = static::schedulerHost() === ServerGroup::QUEUE ? 1 : 0;
+
+        return Helpers::validateNonNegativeInt(static::get('tasks.queue.min', $default), 'tasks.queue.min');
     }
 
     /**
@@ -349,18 +404,13 @@ class Manifest
 
     /**
      * The service group a one-off deploy/management task (the `deploy:` hooks,
-     * e.g. migrations) templates its task definition on: a dedicated scheduler if
-     * extracted, else a standalone queue, else web. Mirrors `yolo run`'s
-     * scheduler → queue → web fallback — management work lands on the least
-     * request-facing service that exists, and web (always present) is the floor.
+     * e.g. migrations) templates its task definition on. It's the same least
+     * request-facing tier the scheduler rides — a dedicated scheduler if extracted,
+     * else a standalone queue, else web — so the one-off lands off the request path.
      */
     public static function deployGroup(): ServerGroup
     {
-        return match (true) {
-            static::hasStandaloneScheduler() => ServerGroup::SCHEDULER,
-            static::hasStandaloneQueue() => ServerGroup::QUEUE,
-            default => ServerGroup::WEB,
-        };
+        return static::schedulerHost();
     }
 
     public static function apex(): string

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -34,12 +34,11 @@ class Manifest
         'sqs.depth-alarm-threshold', 'sqs.depth-alarm-period', 'sqs.depth-alarm-evaluation-periods',
         'cache.store',
         'session.driver',
-        // tasks.web has a fixed, known shape, so every key is listed explicitly: a
-        // mistyped or removed key (e.g. the old tasks.web.queue / tasks.web.scheduler
-        // bundling flags, now derived from task presence) hard-fails as unrecognised
-        // rather than being silently ignored. health-check / autoscaling / the ssr
-        // object form are the only nested subtrees. The standalone tasks.queue /
-        // tasks.scheduler service blocks stay free-form.
+        // Each task group has a fixed, known shape, so every key is listed
+        // explicitly: an unrecognised key under tasks.web / tasks.queue /
+        // tasks.scheduler hard-fails rather than being silently accepted by a
+        // wildcard. health-check / autoscaling / the ssr object form are the only
+        // nested subtrees.
         'tasks.web',
         'tasks.web.port', 'tasks.web.cpu', 'tasks.web.memory', 'tasks.web.platform',
         'tasks.web.enable-execute-command', 'tasks.web.shutdown-grace-period',
@@ -47,7 +46,13 @@ class Manifest
         'tasks.web.execution-role', 'tasks.web.task-role',
         'tasks.web.ssr', 'tasks.web.ssr.*',
         'tasks.web.health-check.*', 'tasks.web.autoscaling.*',
-        'tasks.queue.*', 'tasks.scheduler.*',
+        'tasks.queue',
+        'tasks.queue.min', 'tasks.queue.max', 'tasks.queue.backlog-per-task',
+        'tasks.queue.cpu', 'tasks.queue.memory', 'tasks.queue.spot',
+        'tasks.queue.shutdown-grace-period', 'tasks.queue.enable-execute-command',
+        'tasks.scheduler',
+        'tasks.scheduler.cpu', 'tasks.scheduler.memory',
+        'tasks.scheduler.shutdown-grace-period', 'tasks.scheduler.enable-execute-command',
         'build', 'deploy', 'deploy-all',
     ];
 

--- a/src/Resources/ApplicationAutoScaling/ScalableTarget.php
+++ b/src/Resources/ApplicationAutoScaling/ScalableTarget.php
@@ -53,8 +53,10 @@ class ScalableTarget
     public function min(): int
     {
         if ($this->group === ServerGroup::QUEUE) {
-            // A standalone queue's floor may be 0 (scale to zero) — that's the opt-in.
-            return Helpers::validateNonNegativeInt(Manifest::get('tasks.queue.min', 0), 'tasks.queue.min');
+            // A standalone queue's floor may be 0 (scale to zero) — that's the opt-in
+            // — unless it also hosts the scheduler, where Manifest::queueMin floors it
+            // at 1 so cron isn't killed when the queue idles to zero.
+            return Manifest::queueMin();
         }
 
         return Helpers::validatePositiveInt(Manifest::get('tasks.web.autoscaling.min', 1), 'tasks.web.autoscaling.min');

--- a/src/Resources/Ecs/EcsService.php
+++ b/src/Resources/Ecs/EcsService.php
@@ -253,13 +253,14 @@ class EcsService implements Resource
 
     /**
      * The desired count to create the service at. The queue starts at its
-     * autoscaling floor — 0 when it scales to zero — so a fresh idle queue costs
-     * nothing; web and the scheduler start at one task.
+     * autoscaling floor (Manifest::queueMin) — 0 when it scales to zero, so a fresh
+     * idle queue costs nothing, but ≥1 when the queue also hosts the scheduler (cron
+     * can't ride a task that idles to zero). Web and the scheduler start at one task.
      */
     protected function initialDesiredCount(): int
     {
         if ($this->group === ServerGroup::QUEUE) {
-            return (int) Manifest::get('tasks.queue.min', 0);
+            return Manifest::queueMin();
         }
 
         return 1;

--- a/src/ShutdownTimings.php
+++ b/src/ShutdownTimings.php
@@ -5,22 +5,22 @@ namespace Codinglabs\Yolo;
 use Codinglabs\Yolo\Enums\ServerGroup;
 
 /**
- * One source of truth for how a container shuts down, so supervisord's
+ * One source of truth for how each container shuts down, so supervisord's
  * per-program stop waits and ECS's stopTimeout can't drift apart.
  *
- * Each process shares one key — `shutdown-grace-period`: how long it gets to finish work on
- * SIGTERM before being killed. Octane sits behind the ALB, so its grace doubles
- * as the target group's deregistration delay and the entrypoint drain. The queue
- * worker defaults longer (its in-flight job can outlast an ALB drain); the
- * scheduler inherits octane's. Override a process's window by setting shutdown-grace-period,
- * expanding the opt-in flags to objects where needed:
+ * Each process has one knob — `shutdown-grace-period`: how long it gets to finish
+ * work on SIGTERM before being killed. Octane sits behind the ALB, so its grace
+ * doubles as the target group's deregistration delay and the entrypoint drain. The
+ * queue worker defaults longer (its in-flight job can outlast an ALB drain); the
+ * scheduler just needs its current cron tick to finish. Programs are placed by task
+ * presence (Manifest::queueHost / schedulerHost), not flags — so the graces for a
+ * given container follow from which group it is:
  *
  *     tasks:
  *       web:
- *         shutdown-grace-period: 10               # web process; also the ALB drain window
- *         queue:
- *           shutdown-grace-period: 90             # let a long job finish before SIGKILL
- *         scheduler: true
+ *         shutdown-grace-period: 10     # web (octane) process; also the ALB drain window
+ *       queue:
+ *         shutdown-grace-period: 90     # standalone queue worker — let a long job finish
  */
 class ShutdownTimings
 {
@@ -69,87 +69,89 @@ class ShutdownTimings
     }
 
     /**
-     * Enabled supervisord program => its graceful-stop window (seconds). Octane
-     * always runs; ssr, queue and scheduler are opt-in via tasks.web.*.
+     * The standalone queue worker's graceful-stop window. Defaults longer than web
+     * because an in-flight job can outlast an ALB drain. Read from `tasks.queue`
+     * (only present when extracted); a queue bundled in the web container has no
+     * block to override, so it gets the default.
+     */
+    public static function queueGrace(): int
+    {
+        return (int) Manifest::get('tasks.queue.shutdown-grace-period', static::QUEUE_DEFAULT_GRACE);
+    }
+
+    /**
+     * The scheduler's graceful-stop window — just long enough to wait out an
+     * in-flight schedule:run tick. Read from `tasks.scheduler` (only present when
+     * extracted); a bundled scheduler gets the default.
+     */
+    public static function schedulerGrace(): int
+    {
+        return (int) Manifest::get('tasks.scheduler.shutdown-grace-period', static::SCHEDULER_DEFAULT_GRACE);
+    }
+
+    /**
+     * The bundled SSR renderer's graceful-stop window (the object form of
+     * `tasks.web.ssr` can override it). SSR is always bundled in the web container.
+     */
+    public static function ssrGrace(): int
+    {
+        $value = Manifest::get('tasks.web.ssr');
+
+        return is_array($value) ? (int) ($value['shutdown-grace-period'] ?? static::SSR_DEFAULT_GRACE) : static::SSR_DEFAULT_GRACE;
+    }
+
+    /**
+     * The supervisord programs that run in a given container => each one's
+     * graceful-stop window. Placement is by task presence, not flags: octane and
+     * (when enabled) ssr are always web; the queue worker and the scheduler ride
+     * whichever container hosts them (Manifest::queueHost / schedulerHost). Every
+     * app runs all three roles somewhere, so a plain web app's web container runs
+     * octane + queue + scheduler.
      *
      * @return array<string, int>
      */
-    public static function programGraces(): array
+    public static function programGraces(ServerGroup $group = ServerGroup::WEB): array
     {
-        $graces = ['octane' => static::webGrace()];
-
-        if (static::enabled('ssr')) {
-            $graces['ssr'] = static::grace('ssr', static::SSR_DEFAULT_GRACE);
-        }
-
-        if (static::enabled('queue')) {
-            $graces['queue'] = static::grace('queue', static::QUEUE_DEFAULT_GRACE);
-        }
-
-        if (static::enabled('scheduler')) {
-            $graces['scheduler'] = static::grace('scheduler', static::webGrace());
-        }
-
-        return $graces;
-    }
-
-    /**
-     * The ECS SIGKILL ceiling: long enough to cover the drain plus the slowest
-     * program's graceful stop (they stop in parallel once the drain forwards the
-     * signal), with buffer, but never past Fargate's 120s limit.
-     */
-    public static function stopTimeout(): int
-    {
-        return min(
-            static::drain() + max(static::programGraces()) + static::STOP_TIMEOUT_BUFFER,
-            static::MAX_STOP_TIMEOUT,
-        );
-    }
-
-    /**
-     * The graceful-stop window for a standalone service's sole process, read from
-     * its own task block (`tasks.{group}.shutdown-grace-period`). The queue worker
-     * defaults longer (an in-flight job can run a while); the scheduler just needs
-     * its current cron tick to finish.
-     */
-    public static function standaloneGrace(ServerGroup $group): int
-    {
-        return match ($group) {
-            ServerGroup::WEB => static::webGrace(),
-            ServerGroup::QUEUE => (int) Manifest::get('tasks.queue.shutdown-grace-period', static::QUEUE_DEFAULT_GRACE),
-            ServerGroup::SCHEDULER => (int) Manifest::get('tasks.scheduler.shutdown-grace-period', static::SCHEDULER_DEFAULT_GRACE),
+        $graces = match ($group) {
+            ServerGroup::WEB => [
+                'octane' => static::webGrace(),
+                'ssr' => Manifest::bundles('ssr') ? static::ssrGrace() : null,
+                'scheduler' => Manifest::schedulerHost() === ServerGroup::WEB ? static::schedulerGrace() : null,
+                'queue' => Manifest::queueHost() === ServerGroup::WEB ? static::queueGrace() : null,
+            ],
+            ServerGroup::QUEUE => [
+                'scheduler' => Manifest::schedulerHost() === ServerGroup::QUEUE ? static::schedulerGrace() : null,
+                'queue' => static::queueGrace(),
+            ],
+            ServerGroup::SCHEDULER => [
+                'scheduler' => static::schedulerGrace(),
+            ],
         };
+
+        return array_filter($graces, fn (?int $grace) => $grace !== null);
     }
 
     /**
-     * ECS's SIGTERM-to-SIGKILL ceiling for a service's task. The web container
-     * bundles several processes behind the ALB drain, so it uses the full
-     * drain-plus-slowest-program calc. A standalone queue/scheduler runs one
-     * process with no ALB to drain, so it just needs its grace plus buffer.
+     * ECS's SIGTERM-to-SIGKILL ceiling for a group's task, with buffer and capped
+     * at Fargate's 120s. The drain runs the scheduler down first (cron halted,
+     * in-flight schedule:run waited out — overlapping the ALB window on web), then
+     * supervisord stops the remaining programs in parallel for the slowest of their
+     * graces. Without a scheduler it's the drain window plus the slowest program.
+     * Only the web container has an ALB drain window; queue/scheduler tasks have no
+     * load balancer to keep serving for.
      */
     public static function stopTimeoutFor(ServerGroup $group): int
     {
-        if ($group === ServerGroup::WEB) {
-            return static::stopTimeout();
+        $graces = static::programGraces($group);
+        $drainWindow = $group === ServerGroup::WEB ? static::drain() : 0;
+
+        if (isset($graces['scheduler'])) {
+            $rest = array_diff_key($graces, ['scheduler' => 0]);
+            $total = max($drainWindow, $graces['scheduler']) + ($rest === [] ? 0 : max($rest));
+        } else {
+            $total = $drainWindow + max($graces);
         }
 
-        return min(static::standaloneGrace($group) + static::STOP_TIMEOUT_BUFFER, static::MAX_STOP_TIMEOUT);
-    }
-
-    protected static function enabled(string $program): bool
-    {
-        // Whether the web container bundles this program — the object form (with
-        // overrides like shutdown-grace-period) means enabled; a bare flag still
-        // goes through strict validation so a typo can't silently disable it.
-        return Manifest::bundles($program);
-    }
-
-    protected static function grace(string $program, int $default): int
-    {
-        $value = Manifest::get("tasks.web.$program");
-
-        return is_array($value)
-            ? (int) ($value['shutdown-grace-period'] ?? $default)
-            : $default;
+        return min($total + static::STOP_TIMEOUT_BUFFER, static::MAX_STOP_TIMEOUT);
     }
 }

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -52,15 +52,15 @@ class ConfigureEnvAndVersionStep implements Step
             'AWS_DEFAULT_REGION' => Manifest::get('region'),
         ];
 
-        // tasks.web.queue is the single switch for "this app uses the SQS queue".
-        // On: wire the connection to the queue YOLO provisions (it owns the name +
-        // URL, so the app can't point at the wrong one) — the queue:work supervisor
-        // program runs alongside. No static AWS keys; the task role carries access.
-        // Off: force `sync` so jobs run inline rather than routing to a queue with
-        // no worker consuming it (the framework default of `database` has the same
-        // no-worker pitfall). Solo has one queue; multitenancy resolves the
-        // per-tenant queue at runtime, so SQS_QUEUE is not pinned for it.
-        if (Helpers::validateStrictBool(Manifest::get('tasks.web.queue', false), 'tasks.web.queue')) {
+        // Every web app runs a queue worker somewhere — bundled in the web container
+        // or its own standalone service (queue:work always runs; there's no opt-out)
+        // — so wire the connection to the queue YOLO provisions for it (it owns the
+        // name + URL, so the app can't point at the wrong one). No static AWS keys;
+        // the task role carries access. Solo has one queue; multitenancy resolves the
+        // per-tenant queue at runtime, so SQS_QUEUE is not pinned for it. A non-web
+        // app has no worker, so force `sync` rather than route to a queue nothing
+        // consumes (the framework default of `database` has the same no-worker pitfall).
+        if (Manifest::has('tasks.web')) {
             $defaults['QUEUE_CONNECTION'] = 'sqs';
             $defaults['SQS_PREFIX'] = sprintf('https://sqs.%s.amazonaws.com/%s', Manifest::get('region'), Aws::accountId());
 

--- a/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
+++ b/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
@@ -16,10 +16,13 @@ use Codinglabs\Yolo\Enums\ServerGroup;
  * every workload — the ECS task definition passes the role (web | queue |
  * scheduler) as the container command, and the entrypoint dispatches on it:
  *
- *  - web       → supervisord (octane + any bundled queue/scheduler), drained
+ *  - web       → supervisord (octane + any bundled queue/scheduler/ssr), drained
  *                behind the ALB so a deploy doesn't 502. The default role.
- *  - queue     → the queue worker; queue:work finishes its in-flight job on
- *                SIGTERM, so the generic supervise-and-forward is the whole drain.
+ *  - queue     → the standalone queue worker. queue:work alone finishes its
+ *                in-flight job on SIGTERM, so the generic supervise-and-forward is
+ *                the whole drain; when it also hosts the scheduler (no dedicated
+ *                scheduler service) it runs supervisord instead (queue:work +
+ *                crond) and drains cron like web does, minus the ALB window.
  *  - scheduler → busybox crond; the drain halts cron and waits out any in-flight
  *                schedule:run so a deploy never cuts a scheduled command short.
  *  - anything  → exec'd directly, replacing the shell (no supervise, no drain).
@@ -32,8 +35,9 @@ use Codinglabs\Yolo\Enums\ServerGroup;
  *
  * The queue and scheduler branches are emitted only when the app extracts them
  * into their own service (a top-level tasks.queue / tasks.scheduler block), so a
- * plain web app's entrypoint mentions neither. deploy-all: hooks run on every
- * container start regardless of role, before the dispatch.
+ * plain web app's entrypoint mentions neither — it bundles all three roles into
+ * the one web container. deploy-all: hooks run on every container start regardless
+ * of role, before the dispatch.
  */
 class GenerateEntrypointScriptStep implements Step
 {
@@ -94,7 +98,7 @@ exit "$status"
 
 SH,
             $this->indent($this->webDrainBody(), 12),
-            $this->schedulerDrainCase(),
+            $this->queueDrainCase() . $this->schedulerDrainCase(),
             $this->commandCases(),
         );
 
@@ -109,14 +113,20 @@ SH,
 
     /**
      * The cmd dispatch branches for the roles this app extracts into their own
-     * service. Web is the `*)` default (supervisord), so it needs no branch.
+     * service. Web is the explicit first branch (supervisord), so it needs none
+     * here. A standalone queue that also hosts the scheduler runs supervisord
+     * (queue:work + crond); a queue-only service runs the worker directly.
      */
     protected function commandCases(): string
     {
         $cases = '';
 
         if (Manifest::hasStandaloneQueue()) {
-            $cases .= sprintf("    queue)     cmd='%s' ;;\n", ProcessCommands::queue());
+            $cmd = Manifest::schedulerHost() === ServerGroup::QUEUE
+                ? 'supervisord -c /app/docker/supervisord.queue.conf -n'
+                : ProcessCommands::queue();
+
+            $cases .= sprintf("    queue)     cmd='%s' ;;\n", $cmd);
         }
 
         if (Manifest::hasStandaloneScheduler()) {
@@ -127,9 +137,26 @@ SH,
     }
 
     /**
+     * The standalone queue's drain branch — emitted only when the queue co-hosts
+     * the scheduler (no dedicated scheduler service), so it runs supervisord and
+     * must halt cron the same way web does. A queue-only service needs no branch:
+     * queue:work finishes its in-flight job on the generic SIGTERM forward.
+     */
+    protected function queueDrainCase(): string
+    {
+        if (Manifest::schedulerHost() !== ServerGroup::QUEUE) {
+            return '';
+        }
+
+        return sprintf(
+            "        queue)\n%s            ;;\n",
+            $this->indent($this->supervisordSchedulerDrain(0, '/app/docker/supervisord.queue.conf'), 12),
+        );
+    }
+
+    /**
      * The standalone scheduler's drain branch, emitted only when the scheduler is
-     * its own service. The queue role needs no drain branch — queue:work finishes
-     * its in-flight job on the generic SIGTERM forward.
+     * its own service.
      */
     protected function schedulerDrainCase(): string
     {
@@ -144,25 +171,33 @@ SH,
      * The web role's drain, run before the stop is forwarded to supervisord. ECS
      * sends SIGTERM the moment it deregisters the task, but the ALB takes a few
      * seconds to stop routing to a draining target, so we keep serving for the
-     * drain window first. With a bundled scheduler it also halts cron and waits
-     * out any in-flight schedule:run. A headless app has no target group, so the
-     * sleep is dropped and we stop at once.
+     * drain window first. When the web container hosts the scheduler (it isn't
+     * extracted) it also halts cron and waits out any in-flight schedule:run. A
+     * headless app has no target group, so the sleep is dropped and we stop at once.
      */
     protected function webDrainBody(): string
     {
         $drain = ShutdownTimings::drain();
-        $graces = ShutdownTimings::programGraces();
 
-        if (! isset($graces['scheduler'])) {
-            return $drain > 0 ? "sleep $drain\n" : '';
+        if (Manifest::schedulerHost() === ServerGroup::WEB) {
+            return $this->supervisordSchedulerDrain($drain, '/etc/supervisord.conf');
         }
 
-        // Stop cron first so no new schedule:run fires during the drain, then hold
-        // the container open until the drain window has elapsed *and* any in-flight
-        // schedule:run has finished — bounded by the scheduler's grace so a long job
-        // can't stall the deploy past the stopTimeout.
+        return $drain > 0 ? "sleep $drain\n" : '';
+    }
+
+    /**
+     * Drain a supervisord container that hosts the scheduler: stop cron first so no
+     * new schedule:run fires, then hold the container open until the drain window
+     * has elapsed (octane keeps serving behind the ALB on web; zero on a queue
+     * container, which has no ALB) *and* any in-flight schedule:run has finished —
+     * bounded by the scheduler's grace so a long job can't stall the deploy past the
+     * stopTimeout. The generic forwarder then stops the remaining programs.
+     */
+    protected function supervisordSchedulerDrain(int $drainWindow, string $conf): string
+    {
         return sprintf(<<<'SH'
-supervisorctl -c /etc/supervisord.conf stop scheduler >/dev/null 2>&1
+supervisorctl -c %s stop scheduler >/dev/null 2>&1
 waited=0
 while [ "$waited" -lt %d ]; do
     if [ "$waited" -ge %d ] && ! pgrep -f 'artisan schedule:run' >/dev/null 2>&1; then
@@ -172,7 +207,7 @@ while [ "$waited" -lt %d ]; do
     waited=$((waited + 1))
 done
 
-SH, max($drain, $graces['scheduler']), $drain);
+SH, $conf, max($drainWindow, ShutdownTimings::schedulerGrace()), $drainWindow);
     }
 
     /**
@@ -194,7 +229,7 @@ while [ "$waited" -lt %d ]; do
     waited=$((waited + 1))
 done
 
-SH, ShutdownTimings::standaloneGrace(ServerGroup::SCHEDULER));
+SH, ShutdownTimings::schedulerGrace());
     }
 
     /**

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -3,27 +3,29 @@
 namespace Codinglabs\Yolo\Steps\Build\Fargate;
 
 use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\ProcessCommands;
 use Codinglabs\Yolo\ShutdownTimings;
 use Codinglabs\Yolo\Enums\StepResult;
 use Illuminate\Filesystem\Filesystem;
+use Codinglabs\Yolo\Enums\ServerGroup;
 
 /**
- * Generates the container's supervisord.conf into the build context from the
+ * Generates each container's supervisord.conf into the build context from the
  * manifest — the same way GenerateEntrypointScriptStep generates the entrypoint,
  * so the running processes can't drift from the manifest and the octane port
  * always matches tasks.web.port (the same value the target group health-checks).
  *
- * Octane (the web server) always runs; the SSR renderer, scheduler and queue
- * worker run only when tasks.web.ssr / tasks.web.scheduler / tasks.web.queue are
- * explicitly true. The code default is false (octane only) — `yolo init` ships a
- * manifest that turns the queue and scheduler on, so a fresh app gets the full
- * web task while the absence of config stays conservative. This step only models
- * the web container's bundled programs; a queue/scheduler extracted into its own
- * service (top-level tasks.queue / tasks.scheduler) runs as that service's sole
- * process and is dispatched by the entrypoint, not supervisord. SSR is always
- * bundled (PHP calls it on localhost), so it never has a standalone form.
+ * Which program runs where is derived from task presence (Manifest::queueHost /
+ * schedulerHost), not flags. The web container always runs octane (plus the SSR
+ * renderer when tasks.web.ssr is on, and the queue worker / scheduler unless
+ * they've been extracted). A standalone queue that also hosts the scheduler runs
+ * two processes (queue:work + crond), so it gets its own supervisord.queue.conf; a
+ * queue-only or scheduler-only standalone service runs a single process the
+ * entrypoint exec's directly, with no supervisord config. The web config stays at
+ * the path the scaffolded Dockerfile copies (docker/supervisord.conf); the queue
+ * config rides along under docker/ via the Dockerfile's `COPY . /app`.
  */
 class GenerateSupervisorConfigStep implements Step
 {
@@ -34,19 +36,28 @@ class GenerateSupervisorConfigStep implements Step
 
     public function __invoke(): StepResult
     {
-        $graces = ShutdownTimings::programGraces();
+        // The web container always runs supervisord (octane + whatever it hosts).
+        $this->writeConfig('docker/supervisord.conf', ServerGroup::WEB);
 
-        $path = Paths::build('docker/supervisord.conf');
-        $this->filesystem->ensureDirectoryExists(dirname($path));
-        $this->filesystem->put($path, $this->config($graces));
-
-        // The scheduler runs as cron, not a schedule:work daemon, so the per-minute
-        // trigger lives in a crontab crond reads — written only when enabled.
-        if (isset($graces['scheduler'])) {
-            $this->writeCrontab();
+        // A standalone queue only needs supervisord when it co-hosts the scheduler
+        // (queue:work + crond = two processes). A queue-only service runs a single
+        // exec'd process — no config — so the entrypoint dispatches it directly.
+        if (Manifest::schedulerHost() === ServerGroup::QUEUE) {
+            $this->writeConfig('docker/supervisord.queue.conf', ServerGroup::QUEUE);
         }
 
+        // The scheduler runs cron in some container of every app, so the crontab it
+        // reads is always generated (the standalone scheduler service runs crond too).
+        $this->writeCrontab();
+
         return StepResult::SUCCESS;
+    }
+
+    protected function writeConfig(string $relativePath, ServerGroup $group): void
+    {
+        $path = Paths::build($relativePath);
+        $this->filesystem->ensureDirectoryExists(dirname($path));
+        $this->filesystem->put($path, $this->config(ShutdownTimings::programGraces($group)));
     }
 
     /**
@@ -54,31 +65,21 @@ class GenerateSupervisorConfigStep implements Step
      */
     protected function config(array $graces): string
     {
-        // Stop waits come from ShutdownTimings so a program's graceful-stop window
-        // matches the container stopTimeout derived from the same source.
-        $blocks = [
-            $this->header(),
-            $this->program('octane', ProcessCommands::octane(), stopwaitsecs: $graces['octane']),
-        ];
+        $blocks = [$this->header()];
 
-        if (isset($graces['ssr'])) {
-            // Inertia's Node SSR renderer, sitting alongside octane so PHP reaches
-            // it on localhost. autorestart brings it back if it crashes; while it's
-            // down Inertia just renders client-side, so the app keeps serving.
-            $blocks[] = $this->program('ssr', ProcessCommands::ssr(), stopwaitsecs: $graces['ssr']);
-        }
-
-        if (isset($graces['scheduler'])) {
-            // Cron (crond) fires an ephemeral schedule:run each minute rather than a
-            // long-lived schedule:work daemon — so the trigger halts cleanly on
-            // shutdown and only the in-flight run is waited out (see the entrypoint).
-            $blocks[] = $this->program('scheduler', ProcessCommands::scheduler(), stopwaitsecs: $graces['scheduler']);
-        }
-
-        if (isset($graces['queue'])) {
-            // Longer stop wait so an in-flight job can finish on SIGTERM before
-            // supervisor force-kills the worker.
-            $blocks[] = $this->program('queue', ProcessCommands::queue(), stopwaitsecs: $graces['queue']);
+        // One block per program present in this container, in a stable order. Stop
+        // waits come from ShutdownTimings so a program's graceful-stop window matches
+        // the container stopTimeout derived from the same source.
+        //  - octane    the web server (web container only)
+        //  - ssr       Inertia's Node renderer beside octane; autorestart brings it
+        //              back if it crashes, and Inertia renders client-side while it's down
+        //  - scheduler busybox crond firing an ephemeral schedule:run each minute (not a
+        //              schedule:work daemon — the trigger halts cleanly on shutdown)
+        //  - queue     queue:work, with a longer stop wait so an in-flight job can finish
+        foreach (['octane', 'ssr', 'scheduler', 'queue'] as $program) {
+            if (isset($graces[$program])) {
+                $blocks[] = $this->program($program, ProcessCommands::{$program}(), stopwaitsecs: $graces[$program]);
+            }
         }
 
         return implode("\n\n", $blocks) . "\n";
@@ -99,7 +100,7 @@ class GenerateSupervisorConfigStep implements Step
     protected function header(): string
     {
         return implode("\n", [
-            '# Auto-generated by YOLO from tasks.web.* in yolo.yml — do not edit.',
+            '# Auto-generated by YOLO from yolo.yml — do not edit.',
             '[supervisord]',
             'nodaemon=true',
             'user=www-data',

--- a/stubs/Dockerfile.stub
+++ b/stubs/Dockerfile.stub
@@ -1,9 +1,10 @@
 # Scaffolded by `yolo init`. Owns the base image + PHP extensions — customise
 # freely. YOLO generates the .yolo-entrypoint.sh (deploy-all hooks + per-role
-# dispatch) and docker/supervisord.conf (octane + any bundled queue/scheduler
-# from tasks.web.*) into the build context at build time, so this Dockerfile just
-# runs them. The entrypoint takes the role (web | queue | scheduler) as its
-# argument; each ECS task definition passes its own, so one image serves all.
+# dispatch) and the supervisord config(s) under docker/ (octane plus whichever of
+# the queue worker / scheduler that container hosts) into the build context at
+# build time, so this Dockerfile just runs them. The entrypoint takes the role
+# (web | queue | scheduler) as its argument; each ECS task definition passes its
+# own, so one image serves all.
 FROM dunglas/frankenphp:1-php8.4-alpine
 
 # nodejs is the runtime for Inertia SSR (tasks.web.ssr); drop it if you don't use SSR.

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -27,32 +27,34 @@ environments:
     # session:
     #   driver: redis         # default; database | cookie | file to change the backend
 
+    # Every app runs three roles — web (Octane), the queue worker, and the
+    # scheduler (cron). With just `web` below, all three share the one web
+    # container. Extracting the queue and/or scheduler (the commented blocks
+    # further down) moves them into their own service; the scheduler then rides the
+    # standalone queue if there is one, else stays in web.
     tasks:
       web:
         cpu: '512'
         memory: '1024'
         port: 8000
         enable-execute-command: true   # ECS Exec shell access (gate with MFA on your IAM)
-        queue: true                    # run queue:work in the web container
-        scheduler: true                # run the scheduler (cron + schedule:run) in the web container
 
-        # shutdown-grace-period: seconds a process gets to finish work on SIGTERM before it's killed
-        # (default 10). For web it's also the ALB drain window (no deploy 502s) and the container
-        # stop timeout derives from it — bump for long in-flight requests (uploads, exports, SSE).
-        # web/queue/scheduler share the key; expand queue or scheduler to an object to override:
-        #   queue:
-        #     shutdown-grace-period: 90
+        # shutdown-grace-period: seconds the web process gets to finish work on SIGTERM before it's
+        # killed (default 10). It's also the ALB drain window (no deploy 502s) and the container stop
+        # timeout derives from it — bump for long in-flight requests (uploads, exports, SSE).
+        # shutdown-grace-period: 10
 
       # Extract a workload into its own ECS service so it scales independently of
-      # web. Opt in by uncommenting — but configure each workload in ONE place:
-      # either bundled above (web.queue / web.scheduler) or extracted here, never
-      # both. A standalone queue scales to zero by default; the scheduler is a
-      # pinned singleton (exactly one task), which drops the onOneServer() need.
+      # web — just uncomment its block (presence is the opt-in). A standalone queue
+      # scales to zero by default; the scheduler is a pinned singleton (exactly one
+      # task), which drops the onOneServer() need. With only a queue extracted, the
+      # scheduler rides that queue (so its floor is pinned at min 1).
       # queue:
       #   min: 0                 # 0 = scale to zero when idle (default)
       #   max: 10
       #   backlog-per-task: 100  # target messages per running task
       #   spot: true             # ~70% cheaper interruptible capacity
+      #   shutdown-grace-period: 70   # let an in-flight job finish on SIGTERM
       # scheduler:
       #   cpu: '256'
       #   memory: '512'

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -138,33 +138,75 @@ it('accepts session.driver redis when cache.store is redis', function () {
     expect(invokeManifestIntegrity())->toBeTrue();
 });
 
-it('bails when the queue is both bundled and a standalone service', function () {
+it('bails on the removed tasks.web.queue bundling flag (now derived from task presence)', function () {
     writeManifest([
         'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true], 'queue' => ['min' => 0]],
+        'tasks' => ['web' => ['queue' => true]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+    expect(test()->promptOutput->fetch())->toContain('tasks.web.queue');
+});
+
+it('bails on the removed tasks.web.scheduler bundling flag', function () {
+    writeManifest([
+        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['scheduler' => true]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+    expect(test()->promptOutput->fetch())->toContain('tasks.web.scheduler');
+});
+
+it('accepts the known tasks.web keys', function () {
+    writeManifest([
+        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [
+            'port' => 8000, 'cpu' => '512', 'memory' => '1024',
+            'enable-execute-command' => true, 'ssr' => true,
+            'health-check' => ['timeout' => 8],
+            'autoscaling' => ['min' => 1, 'max' => 4],
+        ]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});
+
+it('bails when the scheduler rides a queue explicitly set to scale to zero', function () {
+    writeManifest([
+        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => ['min' => 0]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeFalse();
 
     $output = test()->promptOutput->fetch();
-    expect($output)->toContain('tasks.web.queue');
-    expect($output)->toContain('tasks.queue');
+    expect($output)->toContain('tasks.queue.min');
+    expect($output)->toContain('tasks.scheduler');
 });
 
-it('bails when the scheduler is both bundled and a standalone service', function () {
+it('accepts a scheduler-hosting queue with a standing floor of one', function () {
     writeManifest([
         'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true], 'scheduler' => []],
+        'tasks' => ['web' => [], 'queue' => ['min' => 1]],
     ]);
 
-    expect(invokeManifestIntegrity())->toBeFalse();
-    expect(test()->promptOutput->fetch())->toContain('tasks.scheduler');
+    expect(invokeManifestIntegrity())->toBeTrue();
 });
 
-it('accepts a bundled queue with a standalone scheduler (mix and match per workload)', function () {
+it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)', function () {
     writeManifest([
         'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true], 'scheduler' => []],
+        'tasks' => ['web' => [], 'queue' => []],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});
+
+it('accepts a scale-to-zero queue when the scheduler is its own service', function () {
+    writeManifest([
+        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => ['min' => 0], 'scheduler' => []],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -138,38 +138,38 @@ it('accepts session.driver redis when cache.store is redis', function () {
     expect(invokeManifestIntegrity())->toBeTrue();
 });
 
-it('bails on the removed tasks.web.queue bundling flag (now derived from task presence)', function () {
+it('accepts the known shape of every task group', function () {
     writeManifest([
         'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
-    ]);
-
-    expect(invokeManifestIntegrity())->toBeFalse();
-    expect(test()->promptOutput->fetch())->toContain('tasks.web.queue');
-});
-
-it('bails on the removed tasks.web.scheduler bundling flag', function () {
-    writeManifest([
-        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true]],
-    ]);
-
-    expect(invokeManifestIntegrity())->toBeFalse();
-    expect(test()->promptOutput->fetch())->toContain('tasks.web.scheduler');
-});
-
-it('accepts the known tasks.web keys', function () {
-    writeManifest([
-        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [
-            'port' => 8000, 'cpu' => '512', 'memory' => '1024',
-            'enable-execute-command' => true, 'ssr' => true,
-            'health-check' => ['timeout' => 8],
-            'autoscaling' => ['min' => 1, 'max' => 4],
-        ]],
+        'tasks' => [
+            'web' => [
+                'port' => 8000, 'cpu' => '512', 'memory' => '1024', 'platform' => 'linux/amd64',
+                'enable-execute-command' => true, 'shutdown-grace-period' => 10, 'ssr' => true,
+                'health-check' => ['timeout' => 8], 'autoscaling' => ['min' => 1, 'max' => 4],
+            ],
+            'queue' => [
+                'min' => 1, 'max' => 10, 'backlog-per-task' => 100, 'cpu' => '256',
+                'memory' => '512', 'spot' => true, 'shutdown-grace-period' => 70,
+                'enable-execute-command' => false,
+            ],
+            'scheduler' => [
+                'cpu' => '256', 'memory' => '512', 'shutdown-grace-period' => 10,
+                'enable-execute-command' => false,
+            ],
+        ],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();
+});
+
+it('bails on an unrecognised key inside a task group', function () {
+    writeManifest([
+        'account-id' => '848509375702', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['nonsense' => true]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+    expect(test()->promptOutput->fetch())->toContain('tasks.web.nonsense');
 });
 
 it('bails when the scheduler rides a queue explicitly set to scale to zero', function () {

--- a/tests/Unit/Commands/SyncAppSchedulerAdvisoryTest.php
+++ b/tests/Unit/Commands/SyncAppSchedulerAdvisoryTest.php
@@ -2,33 +2,46 @@
 
 use Codinglabs\Yolo\Commands\SyncAppCommand;
 
-it('gives no advisory when autoscaling is not configured', function () {
+it('gives no advisory for a dedicated scheduler service', function () {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true]],
+        'tasks' => ['web' => ['autoscaling' => ['max' => 4]], 'scheduler' => []],
     ]);
 
     expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
 });
 
-it('gives no advisory when the scheduler is not bundled', function () {
+it('gives no advisory when the web host that bundles the scheduler does not autoscale', function () {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+
+    expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
+});
+
+it('advises onOneServer when the scheduler is bundled into an autoscaling web task', function () {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => ['max' => 4]]],
     ]);
 
-    expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
+    expect(SyncAppCommand::schedulerAdvisory())
+        ->toContain('onOneServer()')
+        ->toContain('web');
 });
 
-it('advises onOneServer when autoscaling a bundled scheduler', function () {
+it('advises onOneServer when the scheduler rides the standalone queue (always autoscaled)', function () {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true, 'autoscaling' => ['max' => 4]]],
+        'tasks' => ['web' => [], 'queue' => []],
     ]);
 
     expect(SyncAppCommand::schedulerAdvisory())
-        ->toContain('onOneServer()');
+        ->toContain('onOneServer()')
+        ->toContain('queue');
 });

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -214,18 +214,68 @@ describe('server groups', function () {
     });
 
     it('does not list a bundled queue as its own group', function () {
-        writeManifest(['tasks' => ['web' => ['queue' => true]]]);
+        writeManifest(['tasks' => ['web' => []]]);
 
         expect(Manifest::serverGroups())->toBe([ServerGroup::WEB]);
         expect(Manifest::hasStandaloneQueue())->toBeFalse();
-        expect(Manifest::bundles('queue'))->toBeTrue();
+        expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
     });
 
-    it('detects a standalone queue and reads it as not bundled', function () {
-        writeManifest(['tasks' => ['web' => [], 'queue' => ['min' => 0]]]);
+    it('detects a standalone queue and lists it as its own group', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
 
         expect(Manifest::hasStandaloneQueue())->toBeTrue();
-        expect(Manifest::bundles('queue'))->toBeFalse();
+        expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
+    });
+});
+
+describe('queue and scheduler hosts', function () {
+    it('bundles both the queue worker and the scheduler into web for a plain web app', function () {
+        writeManifest(['tasks' => ['web' => []]]);
+
+        expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
+        expect(Manifest::schedulerHost())->toBe(ServerGroup::WEB);
+    });
+
+    it('rides the scheduler on the standalone queue when only the queue is extracted', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+
+        expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
+        expect(Manifest::schedulerHost())->toBe(ServerGroup::QUEUE);
+    });
+
+    it('keeps the queue worker in web but gives the scheduler its own service when only the scheduler is extracted', function () {
+        writeManifest(['tasks' => ['web' => [], 'scheduler' => []]]);
+
+        expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
+        expect(Manifest::schedulerHost())->toBe(ServerGroup::SCHEDULER);
+    });
+
+    it('gives each role its own container when both are extracted', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
+
+        expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
+        expect(Manifest::schedulerHost())->toBe(ServerGroup::SCHEDULER);
+    });
+});
+
+describe('queue floor', function () {
+    it('defaults a standalone queue to scale to zero when the scheduler is extracted', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
+
+        expect(Manifest::queueMin())->toBe(0);
+    });
+
+    it('defaults a scheduler-hosting queue to a floor of one', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+
+        expect(Manifest::queueMin())->toBe(1);
+    });
+
+    it('honours an explicit queue min', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => ['min' => 3], 'scheduler' => []]]);
+
+        expect(Manifest::queueMin())->toBe(3);
     });
 });
 
@@ -254,9 +304,9 @@ describe('deploy group', function () {
         expect(Manifest::deployGroup())->toBe(ServerGroup::SCHEDULER);
     });
 
-    it('falls back to web when queue and scheduler are bundled, not standalone', function () {
-        writeManifest(['tasks' => ['web' => ['queue' => true, 'scheduler' => true]]]);
+    it('tracks the scheduler host — deploy hooks run on the management tier', function () {
+        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
 
-        expect(Manifest::deployGroup())->toBe(ServerGroup::WEB);
+        expect(Manifest::deployGroup())->toBe(Manifest::schedulerHost());
     });
 });

--- a/tests/Unit/Resources/ApplicationAutoScaling/ScalableTargetTest.php
+++ b/tests/Unit/Resources/ApplicationAutoScaling/ScalableTargetTest.php
@@ -77,10 +77,10 @@ it('reports drift but does not register on a dry-run', function () {
     expect(collect($captured)->pluck('name'))->not->toContain('RegisterScalableTarget');
 });
 
-it('builds the queue service resource id and defaults its floor to zero', function () {
+it('builds the queue service resource id and defaults its floor to zero when the scheduler is extracted', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
     ]);
 
     expect(ScalableTarget::resourceId(ServerGroup::QUEUE))->toBe('service/yolo-testing-my-app/yolo-testing-my-app-queue');
@@ -88,10 +88,21 @@ it('builds the queue service resource id and defaults its floor to zero', functi
     expect((new ScalableTarget(ServerGroup::QUEUE))->max())->toBe(10);
 });
 
+it('floors the queue at one task when it also hosts the scheduler', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => []],
+    ]);
+
+    // No dedicated scheduler service → the scheduler rides the queue, so it can't
+    // scale to zero (cron would stop) — the floor defaults to 1.
+    expect((new ScalableTarget(ServerGroup::QUEUE))->min())->toBe(1);
+});
+
 it('registers the queue target with a zero floor (scale to zero)', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 0, 'max' => 20]],
+        'tasks' => ['web' => [], 'queue' => ['min' => 0, 'max' => 20], 'scheduler' => []],
     ]);
 
     $captured = [];

--- a/tests/Unit/ShutdownTimingsTest.php
+++ b/tests/Unit/ShutdownTimingsTest.php
@@ -5,6 +5,8 @@ use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
 beforeEach(function () {
+    // A plain web app: the web container bundles all three roles (octane + queue +
+    // scheduler), since neither queue nor scheduler is extracted.
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
@@ -35,38 +37,72 @@ it('skips the drain entirely when headless (no ALB to drain)', function () {
     expect(ShutdownTimings::drain())->toBe(0);
 });
 
-it('runs only octane by default, inheriting the drain for its stop window', function () {
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10]);
+it('bundles octane, scheduler and queue into the web container for a plain web app', function () {
+    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'scheduler' => 10, 'queue' => 70]);
 });
 
-it('octane and scheduler inherit the web shutdown-grace-period', function () {
+it('runs octane alone in the web container when both queue and scheduler are extracted', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 20, 'scheduler' => true]],
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
     ]);
 
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 20, 'scheduler' => 20]);
+    expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['octane' => 10]);
 });
 
-it('gives the queue worker a longer default than the web tier', function () {
+it('tracks the web shutdown-grace-period for octane; the bundled scheduler keeps its own default', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
+        'tasks' => ['web' => ['shutdown-grace-period' => 20]],
     ]);
 
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'queue' => 70]);
+    expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['octane' => 20, 'scheduler' => 10, 'queue' => 70]);
 });
 
-it('gives the bundled ssr renderer a short default grace alongside octane', function () {
+it('runs the scheduler and queue worker together in a standalone queue container', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => []],
+    ]);
+
+    // Queue extracted, scheduler not — so the scheduler rides the queue container,
+    // and the web container is left with octane alone.
+    expect(ShutdownTimings::programGraces(ServerGroup::QUEUE))->toBe(['scheduler' => 10, 'queue' => 70]);
+    expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['octane' => 10]);
+});
+
+it('runs the queue worker alone in its container when the scheduler is its own service', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+    ]);
+
+    expect(ShutdownTimings::programGraces(ServerGroup::QUEUE))->toBe(['queue' => 70]);
+    expect(ShutdownTimings::programGraces(ServerGroup::SCHEDULER))->toBe(['scheduler' => 10]);
+});
+
+it('honours a standalone queue shutdown-grace-period override', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => []],
+    ]);
+
+    expect(ShutdownTimings::programGraces(ServerGroup::QUEUE))->toBe(['queue' => 90]);
+});
+
+it('bundles the ssr renderer into the web container when tasks.web.ssr is on', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['ssr' => true]],
     ]);
 
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'ssr' => 5]);
+    expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['octane' => 10, 'ssr' => 5, 'scheduler' => 10, 'queue' => 70]);
 });
 
 it('honours an ssr shutdown-grace-period override via the object form', function () {
@@ -76,113 +112,80 @@ it('honours an ssr shutdown-grace-period override via the object form', function
         'tasks' => ['web' => ['ssr' => ['shutdown-grace-period' => 12]]],
     ]);
 
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'ssr' => 12]);
+    expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['octane' => 10, 'ssr' => 12, 'scheduler' => 10, 'queue' => 70]);
 });
 
-it('honours a queue shutdown-grace-period override via the object form', function () {
+it('sizes the web stop timeout around the drain, the scheduler wait and the slowest bundled program', function () {
+    // scheduler drains first within max(drain 10, scheduler 10), then supervisord
+    // stops octane + queue in parallel for max(10, 70); plus the 5s buffer.
+    expect(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB))->toBe(85);
+});
+
+it('drops the ALB drain window from the web stop timeout when headless', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+
+    // no drain window: max(0, scheduler 10) + max(octane 10, queue 70) + 5 buffer.
+    expect(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB))->toBe(85);
+});
+
+it('caps the web stop timeout at the Fargate maximum of 120s', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => ['shutdown-grace-period' => 90]]],
+        'tasks' => ['web' => ['shutdown-grace-period' => 300]],
     ]);
 
-    expect(ShutdownTimings::programGraces())->toBe(['octane' => 10, 'queue' => 90]);
+    expect(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB))->toBe(120);
 });
 
-it('treats the queue object form as enabled even without an explicit flag', function () {
+it('rejects a non-boolean, non-object ssr flag', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => ['shutdown-grace-period' => 30], 'scheduler' => false]],
+        'tasks' => ['web' => ['ssr' => 'sometimes']],
     ]);
 
-    $graces = ShutdownTimings::programGraces();
-
-    expect($graces)->toHaveKey('queue');
-    expect($graces)->not->toHaveKey('scheduler');
-});
-
-it('derives the stop timeout from the drain plus the slowest program', function () {
-    // octane only: drain 10 + max(octane 10) + 5 buffer.
-    expect(ShutdownTimings::stopTimeout())->toBe(25);
-});
-
-it('sizes the stop timeout around a long queue grace', function () {
-    writeManifest([
-        'apex' => 'example.com',
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
-    ]);
-
-    // drain 10 + max(octane 10, queue 70) + 5 buffer.
-    expect(ShutdownTimings::stopTimeout())->toBe(85);
-});
-
-it('drops the drain from the stop timeout when headless', function () {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
-    ]);
-
-    // no drain + max(octane 10, queue 70) + 5 buffer.
-    expect(ShutdownTimings::stopTimeout())->toBe(75);
-});
-
-it('caps the stop timeout at the Fargate maximum of 120s', function () {
-    writeManifest([
-        'apex' => 'example.com',
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => ['shutdown-grace-period' => 300]]],
-    ]);
-
-    expect(ShutdownTimings::stopTimeout())->toBe(120);
-});
-
-it('rejects a non-boolean, non-object program flag', function () {
-    writeManifest([
-        'apex' => 'example.com',
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => 'sometimes']],
-    ]);
-
-    expect(fn () => ShutdownTimings::programGraces())
+    expect(fn () => ShutdownTimings::programGraces(ServerGroup::WEB))
         ->toThrow(IntegrityCheckException::class);
 });
 
 describe('standalone services', function () {
-    it('defaults the standalone queue grace longer than the scheduler', function () {
+    it('sizes a queue-only stop timeout as the grace plus buffer (no ALB drain, no scheduler)', function () {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
             'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
         ]);
 
-        expect(ShutdownTimings::standaloneGrace(ServerGroup::QUEUE))->toBe(70);
-        expect(ShutdownTimings::standaloneGrace(ServerGroup::SCHEDULER))->toBe(10);
+        // 70 (default queue grace) + 5 buffer; no ALB drain, no co-hosted scheduler.
+        expect(ShutdownTimings::stopTimeoutFor(ServerGroup::QUEUE))->toBe(75);
     });
 
-    it('honours a per-service shutdown-grace-period override', function () {
-        writeManifest([
-            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 110]],
-        ]);
-
-        expect(ShutdownTimings::standaloneGrace(ServerGroup::QUEUE))->toBe(110);
-    });
-
-    it('sizes a standalone stop timeout as the grace plus buffer (no ALB drain)', function () {
+    it('sizes a queue+scheduler stop timeout as the scheduler wait plus the queue grace', function () {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
             'tasks' => ['web' => [], 'queue' => []],
         ]);
 
-        // 70 (default queue grace) + 5 buffer; no ALB drain folded in.
-        expect(ShutdownTimings::stopTimeoutFor(ServerGroup::QUEUE))->toBe(75);
+        // scheduler drains first (max(0, 10)), then the queue worker stops (70); plus buffer.
+        expect(ShutdownTimings::stopTimeoutFor(ServerGroup::QUEUE))->toBe(85);
+    });
+
+    it('sizes a scheduler-only stop timeout as its grace plus buffer', function () {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        ]);
+
+        expect(ShutdownTimings::stopTimeoutFor(ServerGroup::SCHEDULER))->toBe(15);
     });
 
     it('caps a standalone stop timeout at the Fargate maximum', function () {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 200]],
+            'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 200], 'scheduler' => []],
         ]);
 
         expect(ShutdownTimings::stopTimeoutFor(ServerGroup::QUEUE))->toBe(120);

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -70,10 +70,10 @@ it('does not inject AWS_BUCKET when the manifest does not define one', function 
     expect(file_get_contents(Paths::build('.env.testing')))->not->toContain('AWS_BUCKET=');
 });
 
-it('injects the SQS connection block when tasks.web.queue is on', function () {
+it('wires the SQS connection for every web app (the worker always runs somewhere)', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
+        'tasks' => ['web' => []],
     ]);
 
     is_dir(Paths::build()) || mkdir(Paths::build(), 0755, true);
@@ -89,7 +89,8 @@ it('injects the SQS connection block when tasks.web.queue is on', function () {
     expect($env)->toContain('SQS_QUEUE=yolo-testing-my-app');
 });
 
-it('forces QUEUE_CONNECTION=sync when the queue is off (no worker to consume)', function () {
+it('forces QUEUE_CONNECTION=sync for a non-web app (no worker to consume)', function () {
+    // No tasks.web → no container, so no queue worker; routing to SQS would dead-end.
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
 
     $env = file_get_contents(Paths::build('.env.testing'));
@@ -116,7 +117,7 @@ it('respects a QUEUE_CONNECTION already set in the .env', function () {
 it('does not pin SQS_QUEUE for a multitenant app (worker resolves it per tenant)', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
+        'tasks' => ['web' => []],
         'tenants' => ['acme' => ['domain' => 'acme.test']],
     ]);
 

--- a/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
@@ -44,12 +44,16 @@ it('supervises a known role so SIGTERM can be trapped and drained', function () 
     expect($script)->toContain('wait "$child"');
 });
 
-it('dispatches a web-only app to supervisord via an explicit branch, no queue or scheduler', function () {
+it('dispatches the web role to supervisord and bundles the scheduler drain for a plain web app', function () {
     $script = generatedEntrypointScript();
 
     expect($script)->toContain("web)       cmd='supervisord -c /etc/supervisord.conf -n'");
-    expect($script)->not->toContain('queue)');
-    expect($script)->not->toContain('scheduler)');
+    // No standalone queue/scheduler service → no extra cmd branches.
+    expect($script)->not->toContain('queue)     cmd=');
+    expect($script)->not->toContain('scheduler) cmd=');
+    // The web container hosts the scheduler, so its drain halts cron and waits.
+    expect($script)->toContain('supervisorctl -c /etc/supervisord.conf stop scheduler');
+    expect($script)->toContain("pgrep -f 'artisan schedule:run'");
 });
 
 it('execs an unknown command directly instead of booting the web server', function () {
@@ -62,14 +66,36 @@ it('execs an unknown command directly instead of booting the web server', functi
     expect($script)->not->toContain("*)         cmd='supervisord");
 });
 
-it('adds a queue branch running the worker when the queue is its own service', function () {
+it('runs a standalone queue under supervisord when it co-hosts the scheduler', function () {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => [], 'queue' => []],
     ]);
 
-    expect(generatedEntrypointScript())->toContain("queue)     cmd='php artisan queue:work");
+    $script = generatedEntrypointScript();
+
+    // queue:work + crond is two processes → supervisord, drained like web (cron first).
+    expect($script)->toContain("queue)     cmd='supervisord -c /app/docker/supervisord.queue.conf -n'");
+    expect($script)->toContain('supervisorctl -c /app/docker/supervisord.queue.conf stop scheduler');
+    // The web container no longer hosts the scheduler — its drain is a plain sleep.
+    expect($script)->toContain("sleep 10\n");
+    expect($script)->not->toContain('scheduler) cmd=');
+});
+
+it('runs a standalone queue as a single worker process when the scheduler is its own service', function () {
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+    ]);
+
+    $script = generatedEntrypointScript();
+
+    // Queue alone → exec'd worker (no supervisord); the scheduler is its own crond.
+    expect($script)->toContain("queue)     cmd='php artisan queue:work");
+    expect($script)->not->toContain('supervisord -c /app/docker/supervisord.queue.conf');
+    expect($script)->toContain("scheduler) cmd='crond");
 });
 
 it('adds a scheduler branch running cron when the scheduler is its own service', function () {
@@ -83,9 +109,19 @@ it('adds a scheduler branch running cron when the scheduler is its own service',
 
     expect($script)->toContain("scheduler) cmd='crond");
     expect($script)->toContain("pgrep -f 'artisan schedule:run'");
+    // The queue still rides the web container; the web drain is a plain sleep.
+    expect($script)->toContain("sleep 10\n");
+    expect($script)->not->toContain('queue)     cmd=');
 });
 
 it('drains for the web shutdown-grace-period before forwarding the stop', function () {
+    // Extract the scheduler so the web drain is the plain ALB-window sleep.
+    writeManifest([
+        'apex' => 'example.com',
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'scheduler' => []],
+    ]);
+
     expect(generatedEntrypointScript())->toContain("sleep 10\n");
 });
 
@@ -93,41 +129,25 @@ it('tracks the manifest web shutdown-grace-period for the drain duration', funct
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45]],
+        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => []],
     ]);
 
     expect(generatedEntrypointScript())->toContain("sleep 45\n");
 });
 
-it('omits the drain sleep when headless — no ALB target to drain', function () {
+it('omits the ALB drain window when headless — no target to drain', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45]],
+        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => []],
     ]);
 
     $script = generatedEntrypointScript();
 
-    // Still supervises + traps so the stop is forwarded cleanly, just no lame-duck sleep.
-    expect($script)->not->toContain('sleep');
+    // Still supervises + traps so the stop is forwarded cleanly, just no lame-duck
+    // ALB sleep window.
+    expect($script)->not->toContain('sleep 45');
     expect($script)->toContain('trap drain TERM');
     expect($script)->toContain('kill -TERM "$child"');
-});
-
-it('does not mention the scheduler when it is disabled', function () {
-    expect(generatedEntrypointScript())->not->toContain('schedule:run');
-});
-
-it('halts cron and waits out an in-flight schedule:run when the scheduler is enabled', function () {
-    writeManifest([
-        'apex' => 'example.com',
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true]],
-    ]);
-
-    $script = generatedEntrypointScript();
-
-    expect($script)->toContain('supervisorctl -c /etc/supervisord.conf stop scheduler');
-    expect($script)->toContain("pgrep -f 'artisan schedule:run'");
 });
 
 it('forwards SIGTERM to the child and waits for a clean shutdown', function () {

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -10,6 +10,7 @@ beforeEach(function () {
     ]);
 
     is_file(Paths::build('docker/supervisord.conf')) && unlink(Paths::build('docker/supervisord.conf'));
+    is_file(Paths::build('docker/supervisord.queue.conf')) && unlink(Paths::build('docker/supervisord.queue.conf'));
     is_file(Paths::build('docker/crontabs/www-data')) && unlink(Paths::build('docker/crontabs/www-data'));
 });
 
@@ -36,22 +37,10 @@ it('defaults the octane port to 8000', function () {
     expect(generatedSupervisorConfig())->toContain('--port=8000');
 });
 
-it('runs octane only by default — scheduler and queue are opt-in', function () {
+it('bundles octane, the scheduler and the queue worker into the web config for a plain web app', function () {
     $config = generatedSupervisorConfig();
 
     expect($config)->toContain('[program:octane]');
-    expect($config)->not->toContain('[program:scheduler]');
-    expect($config)->not->toContain('[program:queue]');
-});
-
-it('runs the scheduler and queue worker when explicitly enabled', function () {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true, 'scheduler' => true]],
-    ]);
-
-    $config = generatedSupervisorConfig();
-
     expect($config)->toContain('[program:scheduler]');
     // The scheduler runs as cron, not a schedule:work daemon.
     expect($config)->toContain('command=crond -f -d 8 -c /app/docker/crontabs');
@@ -60,12 +49,66 @@ it('runs the scheduler and queue worker when explicitly enabled', function () {
     expect($config)->toContain('command=php artisan queue:work --tries=3 --max-time=3600');
 });
 
-it('writes a crontab firing schedule:run each minute when the scheduler is enabled', function () {
+it('runs octane alone in the web config when both queue and scheduler are extracted', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['scheduler' => true]],
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
     ]);
 
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('[program:octane]');
+    expect($config)->not->toContain('[program:scheduler]');
+    expect($config)->not->toContain('[program:queue]');
+});
+
+it('drops the scheduler from the web config when it has its own service, keeping the bundled queue', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'scheduler' => []],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('[program:octane]');
+    expect($config)->toContain('[program:queue]');
+    expect($config)->not->toContain('[program:scheduler]');
+});
+
+it('writes a second supervisord config for a standalone queue that hosts the scheduler', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => []],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    // Web container: octane only (queue + scheduler extracted onto the queue).
+    $web = file_get_contents(Paths::build('docker/supervisord.conf'));
+    expect($web)->toContain('[program:octane]');
+    expect($web)->not->toContain('[program:queue]');
+    expect($web)->not->toContain('[program:scheduler]');
+
+    // Queue container: queue worker + crond, no octane.
+    $queue = file_get_contents(Paths::build('docker/supervisord.queue.conf'));
+    expect($queue)->toContain('[program:queue]');
+    expect($queue)->toContain('[program:scheduler]');
+    expect($queue)->not->toContain('[program:octane]');
+});
+
+it('writes no queue supervisord config when the standalone queue is a single process', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    // Queue-only and scheduler-only services run a single exec'd process — no config.
+    expect(is_file(Paths::build('docker/supervisord.queue.conf')))->toBeFalse();
+});
+
+it('writes a crontab firing schedule:run each minute (the scheduler always runs somewhere)', function () {
     (new GenerateSupervisorConfigStep('testing'))();
 
     $crontab = file_get_contents(Paths::build('docker/crontabs/www-data'));
@@ -74,32 +117,28 @@ it('writes a crontab firing schedule:run each minute when the scheduler is enabl
     expect($crontab)->toContain('php artisan schedule:run');
 });
 
-it('writes no crontab when the scheduler is disabled', function () {
-    generatedSupervisorConfig();
-
-    expect(is_file(Paths::build('docker/crontabs/www-data')))->toBeFalse();
-});
-
 it('uses the web shutdown-grace-period for octanes stop wait', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 25]],
+        'tasks' => ['web' => ['shutdown-grace-period' => 25], 'queue' => [], 'scheduler' => []],
     ]);
 
-    // Octane is the only program, so the only stopwaitsecs in the file is its own.
+    // Octane is the only program in the web config here (queue + scheduler extracted),
+    // so the only stopwaitsecs is its own.
     expect(generatedSupervisorConfig())->toContain('stopwaitsecs=25');
 });
 
-it('honours a queue shutdown-grace-period override via the object form', function () {
+it('honours a standalone queue shutdown-grace-period override', function () {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => ['shutdown-grace-period' => 90]]],
+        'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => []],
     ]);
 
-    $config = generatedSupervisorConfig();
+    (new GenerateSupervisorConfigStep('testing'))();
 
-    expect($config)->toContain('[program:queue]');
-    expect($config)->toContain('stopwaitsecs=90');
+    // A queue-only standalone service has no supervisord config of its own; the
+    // worker's grace surfaces as the queue task's stopTimeout, not here.
+    expect(is_file(Paths::build('docker/supervisord.queue.conf')))->toBeFalse();
 });
 
 it('runs the inertia ssr renderer when tasks.web.ssr is enabled', function () {
@@ -112,23 +151,10 @@ it('runs the inertia ssr renderer when tasks.web.ssr is enabled', function () {
 
     expect($config)->toContain('[program:ssr]');
     expect($config)->toContain('command=php artisan inertia:start-ssr');
-    // Stateless renderer → short stop wait (the only non-octane program here).
+    // Stateless renderer → short stop wait.
     expect($config)->toContain('stopwaitsecs=5');
 });
 
 it('does not run the ssr renderer by default', function () {
     expect(generatedSupervisorConfig())->not->toContain('[program:ssr]');
-});
-
-it('runs the queue worker without the scheduler when only queue is enabled', function () {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['queue' => true]],
-    ]);
-
-    $config = generatedSupervisorConfig();
-
-    expect($config)->toContain('[program:queue]');
-    expect($config)->not->toContain('[program:scheduler]');
-    expect($config)->toContain('[program:octane]');
 });

--- a/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
@@ -108,7 +108,7 @@ it('falls back to defaults when manifest omits task config', function () {
 
 it('wires the container stop timeout to the shutdown-timings resolver', function () {
     expect(SyncTaskDefinitionStep::payload()['containerDefinitions'][0]['stopTimeout'])
-        ->toBe(ShutdownTimings::stopTimeout());
+        ->toBe(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB));
 });
 
 it('enables init process in the web container for proper PID 1 signal handling', function () {


### PR DESCRIPTION
## Summary

Closes the gap left by [LPX-649](https://linear.app/codinglabsau/issue/LPX-649): bundling of the queue worker and scheduler is now **derived from which `tasks.*` blocks exist**, and the explicit `tasks.web.queue` / `tasks.web.scheduler` flags are **removed**. Builds on [#88](https://github.com/codinglabsau/yolo/pull/88)'s `Manifest::deployGroup()` + entrypoint exec-catchall (now merged to `main`).

Every app runs all three roles — web (Octane), the queue worker, and the scheduler. By default they share the one web container (the cheap single-task floor). To run web in isolation, **extract the worker tier**: add `tasks.queue` and the queue worker *and* scheduler move to their own service; add `tasks.scheduler` too for a dedicated singleton cron.

| Manifest | web container | worker container | scheduler container |
| --- | --- | --- | --- |
| `web` only | web + queue + scheduler | — | — |
| `web` + `queue` | web | **queue + scheduler** | — |
| `web` + `queue` + `scheduler` | web | queue | scheduler |

(The scheduler rides the worker container rather than getting its own task — no point paying for a separate one-task service for cron when the queue is already a managed tier.)

### What changed
- **Manifest** — `queueHost()` / `schedulerHost()` / `queueMin()`; `deployGroup()` delegates to `schedulerHost()`; `bundles()` is now ssr-only.
- **ShutdownTimings** — `programGraces()` is per-`ServerGroup`; `stopTimeoutFor()` covers each container's drain (scheduler drained first, then the rest in parallel).
- **Per-role supervisord** — a worker container that co-hosts the scheduler (queue + crond) gets its own `docker/supervisord.queue.conf` and a supervisord drain; a single-process service stays an exec'd process. The web config stays at `docker/supervisord.conf` so app Dockerfiles don't change.
- **SQS is universal** — every web app wires `QUEUE_CONNECTION=sqs` (the old `tasks.web.queue` "uses SQS" switch is gone); a non-web app stays `sync`.
- **Queue floor** — pinned at `min: 1` when the queue hosts the scheduler (cron can't ride a scale-to-zero task); an explicit `tasks.queue.min: 0` there hard-fails.
- **Scheduler advisory** — rekeyed: fires when the scheduler is bundled into an autoscaling host (web with autoscaling, or the standalone queue, which always autoscales).
- **Validator** — each task group (`tasks.web` / `tasks.queue` / `tasks.scheduler`) is now an explicit-shape allow-list, so an unrecognised key — including a leftover `tasks.web.queue` / `tasks.web.scheduler` — hard-fails rather than being silently accepted by a wildcard.
- **Docs + stubs** — manifest/scaling/images reframed around the worker tier; `yolo.yml.stub` / `Dockerfile.stub` drop the flags.

## Anything the reviewer needs to know
- **No backwards compatibility** (pre-1.0, CL-only): the removed flags are a clean removal, not deprecated. **CL and burleighspace manifests carry `tasks.web.queue: true` / `tasks.web.scheduler: true` today and will hard-fail their next `yolo` command until those two lines are dropped.** Runtime behaviour is otherwise unchanged for them — a plain web app still bundles all three roles.
- **burleighspace gets a queue worker + SQS back**: SQS is now universal, reversing the earlier "no queue" cleanup. Confirmed acceptable.
- The scheduler-only-extracted topology (`web` + `tasks.scheduler`, queue staying in web) is still valid in code but intentionally **undocumented** — extracting the worker tier is the supported path to isolate web.
- Validated: Pint, PHPStan, **586 Pest tests** green locally; CI green.

🤖 Generated with [Claude Code](https://claude.ai/code)