### PR TITLE
feat(s3): reconcile browser-upload CORS on the app bucket during sync

### DIFF
--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -213,7 +213,7 @@ These live directly under an environment and provision or configure the app's AW
 
 ### `bucket`
 
-Name of an app S3 bucket for application storage. Injected into the container as `AWS_BUCKET`, and this app's [ECS task role](#task-role-policies) is automatically granted read+write on it (object get/put/delete + multipart, plus bucket listing) — so the container reaches its bucket through the role. The grant is scoped to this one bucket. YOLO creates the bucket (Block Public Access on) when it doesn't already exist; an existing bucket (e.g. one adopted from another platform) is left untouched but still gets the role grant.
+Name of an app S3 bucket for application storage. Injected into the container as `AWS_BUCKET`, and this app's [ECS task role](#task-role-policies) is automatically granted read+write on it (object get/put/delete + multipart, plus bucket listing) — so the container reaches its bucket through the role. The grant is scoped to this one bucket. YOLO creates the bucket (Block Public Access on) when it doesn't already exist. On every sync it reconciles the bucket's CORS — a permissive ruleset (origins `*`, methods `GET`/`PUT`/`HEAD`) that lets the browser PUT directly to the bucket via a presigned URL — together with its `yolo:*` tags, surfacing any change in the plan and `--check`. The presigned URL (auth + same-origin), not CORS, is the access gate. Block Public Access is applied at create only and is never reconciled onto an existing bucket, so an adopted bucket (e.g. one carried over from another platform) keeps serving any public objects unchanged.
 
 ### `alb`
 

--- a/src/Resources/S3/S3Bucket.php
+++ b/src/Resources/S3/S3Bucket.php
@@ -5,20 +5,28 @@ namespace Codinglabs\Yolo\Resources\S3;
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 
 /**
  * The optional application data bucket (AWS_BUCKET) — user-facing storage for
- * the app's own objects. Provisioned only when the manifest defines `bucket`.
+ * the app's own objects, and the target for direct browser→S3 uploads via a
+ * presigned PUT. Provisioned only when the manifest defines `bucket`.
  *
- * Block Public Access is applied on create, but never reconciled onto an
- * existing bucket: an app may already serve public objects and flipping BPA
- * under it would break that. SyncS3BucketStep therefore leaves existing buckets
- * untouched (no tag sync either), unlike the create-or-sync Resource default.
+ * Block Public Access is applied on create but NEVER reconciled onto an existing
+ * bucket: an app may already serve public objects and flipping BPA under it would
+ * break that. CORS and tags, by contrast, ARE reconciled on every sync (the
+ * standard create-or-sync Resource path) — CORS so the cross-origin upload PUT
+ * keeps working without Vapor, tags so `yolo audit` can attribute the bucket.
+ * Owning CORS is safe: it grants no data access (the presigned URL / signed-
+ * storage endpoint is the gate), and the permissive ruleset matches what existing
+ * (incl. Vapor-adopted) buckets already carry, so the first sync is a near no-op.
  */
-class S3Bucket implements Resource
+class S3Bucket implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
 
@@ -60,10 +68,58 @@ class S3Bucket implements Resource
         ]);
 
         $this->synchroniseTags(apply: true);
+
+        $this->synchroniseConfiguration();
     }
 
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseS3Tags($this->name(), $this->tags(), $apply);
+    }
+
+    /**
+     * Reconcile the bucket's CORS to the managed ruleset so the browser→S3
+     * presigned-PUT upload path works without Vapor. Read-compared-then-written
+     * so a clean sync writes nothing and a dry-run reports the drift; returns it
+     * as Change[]. Block Public Access is deliberately not reconciled here (it's
+     * create-only — see the class docblock); tags ride synchroniseTags().
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $desired = [$this->desiredCors()];
+        $current = S3::bucketCors($this->name());
+
+        if (Helpers::documentsEqual($current, $desired)) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::s3()->putBucketCors([
+                'Bucket' => $this->name(),
+                'CORSConfiguration' => ['CORSRules' => $desired],
+            ]);
+        }
+
+        return [Change::make('cors', $current === null ? null : 'present', 'managed (origins *, GET/PUT/HEAD)')];
+    }
+
+    /**
+     * The managed CORS ruleset for direct browser uploads: permissive origins
+     * (the signed-storage endpoint is the real gate, not bucket CORS) and the
+     * methods a presigned PUT needs. ExposeHeaders is deliberately omitted — AWS
+     * drops empty optional fields on read, so an empty value would read back
+     * absent and drift forever; add ['ETag'] only when browser multipart uploads
+     * are introduced.
+     *
+     * @return array<string, mixed>
+     */
+    protected function desiredCors(): array
+    {
+        return [
+            'AllowedOrigins' => ['*'],
+            'AllowedMethods' => ['GET', 'PUT', 'HEAD'],
+            'AllowedHeaders' => ['*'],
+            'MaxAgeSeconds' => 3600,
+        ];
     }
 }

--- a/src/Steps/Sync/App/SyncS3BucketStep.php
+++ b/src/Steps/Sync/App/SyncS3BucketStep.php
@@ -2,14 +2,16 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\S3\S3Bucket;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
 
 class SyncS3BucketStep implements Step
 {
+    use SynchronisesResource;
+
     public function __invoke(array $options): StepResult
     {
         // The app data bucket is optional. Skip when the manifest doesn't define
@@ -19,20 +21,10 @@ class SyncS3BucketStep implements Step
             return StepResult::SKIPPED;
         }
 
-        $bucket = new S3Bucket();
-
-        // Existing app buckets are left untouched — BPA and tags are applied only
-        // at create, never reconciled (see S3Bucket).
-        if ($bucket->exists()) {
-            return StepResult::SYNCED;
-        }
-
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_CREATE;
-        }
-
-        $bucket->create();
-
-        return StepResult::CREATED;
+        // Create-or-sync: an existing bucket has its CORS (browser-upload ruleset)
+        // and tags reconciled; Block Public Access stays create-only (it lives in
+        // S3Bucket::create(), never in the sync path), so a live public bucket is
+        // never flipped under foot.
+        return $this->syncResource(new S3Bucket(), $options);
     }
 }

--- a/tests/Unit/Resources/S3/S3BucketTest.php
+++ b/tests/Unit/Resources/S3/S3BucketTest.php
@@ -1,0 +1,125 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\S3\S3Client;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Resources\S3\S3Bucket;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+
+/**
+ * Bind an S3 client whose calls are routed by command name and recorded (name +
+ * args) so tests can assert which writes fired and with what body. Returns the
+ * recorder for `$recorder->captured`.
+ *
+ * @param  array<string, Result>  $byCommand
+ */
+function bindRecordingAppBucketS3Client(array $byCommand): object
+{
+    $recorder = new class($byCommand) extends MockHandler
+    {
+        /** @var array<int, array{name: string, args: array<string, mixed>}> */
+        public array $captured = [];
+
+        public function __construct(public array $byCommand) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->captured[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            return Create::promiseFor($this->byCommand[$cmd->getName()] ?? new Result());
+        }
+    };
+
+    Helpers::app()->instance('s3', new S3Client([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $recorder,
+    ]));
+
+    return $recorder;
+}
+
+/**
+ * The managed CORS ruleset YOLO reconciles onto the app bucket — kept in lockstep
+ * with S3Bucket::desiredCors().
+ *
+ * @return array<int, array<string, mixed>>
+ */
+function managedAppBucketCors(): array
+{
+    return [[
+        'AllowedOrigins' => ['*'],
+        'AllowedMethods' => ['GET', 'PUT', 'HEAD'],
+        'AllowedHeaders' => ['*'],
+        'MaxAgeSeconds' => 3600,
+    ]];
+}
+
+beforeEach(function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket',
+    ]);
+});
+
+it('names the app bucket from the manifest bucket key', function () {
+    expect((new S3Bucket())->name())->toBe('my-app-bucket');
+});
+
+it('reconciles the bucket CORS through sync', function () {
+    expect(new S3Bucket())->toBeInstanceOf(SynchronisesConfiguration::class);
+});
+
+it('applies the managed CORS ruleset when the bucket has none', function () {
+    $recorder = bindRecordingAppBucketS3Client(['GetBucketCors' => new Result([])]);
+
+    $changes = (new S3Bucket())->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->attribute)->toBe('cors');
+    expect($changes[0]->from)->toBeNull();
+
+    $put = collect($recorder->captured)->firstWhere('name', 'PutBucketCors');
+    expect($put)->not->toBeNull();
+    expect($put['args']['CORSConfiguration']['CORSRules'])->toBe(managedAppBucketCors());
+});
+
+it('reports the CORS drift without writing under apply:false', function () {
+    $recorder = bindRecordingAppBucketS3Client(['GetBucketCors' => new Result([])]);
+
+    expect((new S3Bucket())->synchroniseConfiguration(apply: false))->toHaveCount(1);
+    expect(array_column($recorder->captured, 'name'))->not->toContain('PutBucketCors');
+});
+
+it('writes nothing when the live CORS already matches the managed ruleset', function () {
+    // Guards the ExposeHeaders-omission gotcha: the desired ruleset must round-trip
+    // through GetBucketCors with no phantom drift.
+    $recorder = bindRecordingAppBucketS3Client([
+        'GetBucketCors' => new Result(['CORSRules' => managedAppBucketCors()]),
+    ]);
+
+    expect((new S3Bucket())->synchroniseConfiguration())->toBe([]);
+    expect(array_column($recorder->captured, 'name'))->not->toContain('PutBucketCors');
+});
+
+it('overwrites a Vapor-style CORS config with the managed ruleset', function () {
+    // Vapor's default lacks HEAD and MaxAgeSeconds, so YOLO takes ownership.
+    $recorder = bindRecordingAppBucketS3Client([
+        'GetBucketCors' => new Result(['CORSRules' => [[
+            'AllowedOrigins' => ['*'],
+            'AllowedMethods' => ['GET', 'PUT'],
+            'AllowedHeaders' => ['*'],
+        ]]]),
+    ]);
+
+    $changes = (new S3Bucket())->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1);
+    expect($changes[0]->from)->toBe('present');
+
+    $put = collect($recorder->captured)->firstWhere('name', 'PutBucketCors');
+    expect($put['args']['CORSConfiguration']['CORSRules'])->toBe(managedAppBucketCors());
+});

--- a/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
+++ b/tests/Unit/Steps/Storage/SyncS3BucketHardeningTest.php
@@ -181,6 +181,85 @@ it('does not flip public access on an existing app bucket', function () {
     expect(array_column($captured, 'name'))->not->toContain('PutPublicAccessBlock');
 });
 
+it('applies the browser-upload CORS to a newly created app bucket', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket',
+    ]);
+
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => [s3NotFound(), new Result(['@metadata' => ['statusCode' => 200]])],
+        'CreateBucket' => new Result(),
+        'PutBucketTagging' => new Result(),
+        'PutPublicAccessBlock' => new Result(),
+        'PutBucketCors' => new Result(),
+    ], $captured);
+
+    expect((new SyncS3BucketStep())([]))->toBe(StepResult::CREATED);
+    expect(array_column($captured, 'name'))
+        ->toContain('PutPublicAccessBlock')   // BPA still applied at create
+        ->toContain('PutBucketCors');
+});
+
+it('reconciles CORS onto an existing app bucket without flipping public access', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket',
+    ]);
+
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => new Result(),       // exists
+        'GetBucketCors' => new Result([]),  // no CORS yet → drift
+    ], $captured);
+
+    expect((new SyncS3BucketStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))
+        ->toContain('PutBucketCors')
+        ->not->toContain('PutPublicAccessBlock');   // BPA stays create-only
+});
+
+it('reports CORS drift but writes nothing on a dry-run of an existing app bucket', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket',
+    ]);
+
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => new Result(),       // exists
+        'GetBucketCors' => new Result([]),  // drift
+    ], $captured);
+
+    expect((new SyncS3BucketStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect(array_column($captured, 'name'))
+        ->not->toContain('PutBucketCors')
+        ->not->toContain('PutPublicAccessBlock')
+        ->not->toContain('PutBucketTagging');
+});
+
+it('writes no CORS when an existing app bucket already matches the managed ruleset', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => 'my-app-bucket',
+    ]);
+
+    $captured = [];
+
+    bindMockS3Client([
+        'HeadBucket' => new Result(),   // exists
+        'GetBucketCors' => new Result(['CORSRules' => [[
+            'AllowedOrigins' => ['*'],
+            'AllowedMethods' => ['GET', 'PUT', 'HEAD'],
+            'AllowedHeaders' => ['*'],
+            'MaxAgeSeconds' => 3600,
+        ]]]),
+    ], $captured);
+
+    expect((new SyncS3BucketStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('PutBucketCors');
+});
+
 it('never puts a bucket policy on the artefact bucket (log-delivery moved to S3LoadBalancerLogs)', function () {
     // The artefacts bucket previously doubled as the ALB access-log destination,
     // which forced its policy to grant logdelivery.elasticloadbalancing.amazonaws.com


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**

The app data bucket (`bucket:`, injected as `AWS_BUCKET`) is the target for direct browser→S3 presigned-PUT uploads — the pattern replacing Vapor's `Vapor.store()` (a hand-rolled `SignedStorageUrlController` issues a presigned `putObject` URL; the browser PUTs straight to S3). That cross-origin PUT triggers a CORS preflight, so the bucket **must** carry a CORS config. YOLO never set it — working apps relied on Vapor having configured it at create. **convictrecords** is migrating off Vapor and serves its own presigned-upload controller against its adopted bucket, so YOLO now owns the CORS to keep the upload path self-contained and survive a freshly-created bucket.

- `S3Bucket` now `implements SynchronisesConfiguration` — `synchroniseConfiguration()` reconciles CORS to a permissive managed ruleset: origins `*`, methods `GET`/`PUT`/`HEAD`, `AllowedHeaders *`, `MaxAgeSeconds 3600`. `ExposeHeaders` is deliberately omitted (AWS drops empty optional fields on read, so an empty value would phantom-drift forever). `create()` applies CORS too.
- **BPA stays create-only** — flipping Block Public Access under a live public bucket can break it, so it's never reconciled onto an existing bucket. **Tags now reconcile on sync**, so `SyncS3BucketStep` drops its bespoke no-op early-return and delegates to the standard `syncResource()` create-or-sync path (reconciles tags + CORS, never touches BPA).
- Writes go direct via `Aws::s3()->putBucketCors(...)` — the S3 wrapper holds only read helpers, matching how `AssetBucket`/`S3LoadBalancerLogs` write.
- Docs: `manifest.md` `bucket` section documents the reconciled CORS + tags and the create-only BPA.

**Is there anything the reviewer needs to know to deploy this?**

- **Ownership = overwrite.** YOLO reconciles CORS on *every* sync. The permissive ruleset is close to Vapor's default, so the first sync on an adopted bucket (e.g. convictrecords) is a near-no-op — but any difference (the added `HEAD` / `MaxAgeSeconds`, or a hand-tuned config) is overwritten with the managed ruleset. The change is surfaced as a `cors` Change in the `yolo sync` plan / `--check` **before** apply.
- **CORS is not the access gate** — it grants no data access. The presigned URL (auth + same-origin) is the gate; `*` origins just let the preflight pass (and keep the cutover canary `fargate.<app>` + bare-ALB origin working).
- **Not validated against real AWS yet.** Unit fakes prove the `documentsEqual` drift logic but not S3's real CORS echo. Worth eyeballing the first `convictrecords` `sync:app production --check` when that cutover lands, to confirm the managed ruleset round-trips without perpetual drift.
- Scoped to the per-env (production) bucket only — local-dev buckets and their `*.test` CORS are set separately. No POST / multipart methods (single presigned PUT only).
- `pint` clean · **616 Pest pass** (1490 assertions) · `phpstan` no errors.

🤖 Generated with [Claude Code](https://claude.ai/code)
