### PR TITLE
fix(sync): coerce absent dry-run flag to bool in task SG ingress step

### DIFF
--- a/src/Steps/Sync/App/SyncTaskSecurityGroupStep.php
+++ b/src/Steps/Sync/App/SyncTaskSecurityGroupStep.php
@@ -28,7 +28,7 @@ class SyncTaskSecurityGroupStep implements Step
         $result = $this->syncResource($securityGroup, $options);
 
         if ($securityGroup->exists()) {
-            $this->ensureLoadBalancerIngressRule($securityGroup->arn(), Arr::get($options, 'dry-run'));
+            $this->ensureLoadBalancerIngressRule($securityGroup->arn(), (bool) Arr::get($options, 'dry-run'));
         }
 
         return $result;

--- a/tests/Unit/Steps/Network/SyncTaskSecurityGroupStepTest.php
+++ b/tests/Unit/Steps/Network/SyncTaskSecurityGroupStepTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\SyncTaskSecurityGroupStep;
+
+function describeTaskAndLoadBalancerGroups(): Result
+{
+    return new Result([
+        'SecurityGroups' => [
+            ['GroupName' => 'yolo-testing-my-app-ecs-task-security-group', 'GroupId' => 'sg-task456'],
+            ['GroupName' => 'yolo-testing-load-balancer-security-group', 'GroupId' => 'sg-lb789'],
+        ],
+    ]);
+}
+
+beforeEach(function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+    ]);
+});
+
+it('authorises the load-balancer ingress rule on the apply pass when the dry-run key is absent', function () {
+    // Regression: the apply pass flows the raw input options through, which no
+    // longer carry a `dry-run` key (the option was dropped). The step must coerce
+    // the absent flag to false rather than handing null to a bool-typed param.
+    $captured = [];
+
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => describeTaskAndLoadBalancerGroups(),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => []]),
+        'AuthorizeSecurityGroupIngress' => new Result(),
+    ], $captured);
+
+    expect((new SyncTaskSecurityGroupStep())([]))->toBe(StepResult::SYNCED);
+
+    $authorise = collect($captured)->firstWhere('name', 'AuthorizeSecurityGroupIngress');
+    expect($authorise)->not->toBeNull();
+
+    $permission = $authorise['args']['IpPermissions'][0];
+    expect($permission['FromPort'])->toBe(8000);
+    expect($permission['ToPort'])->toBe(8000);
+    expect($permission['UserIdGroupPairs'][0]['GroupId'])->toBe('sg-lb789');
+    expect($authorise['args']['GroupId'])->toBe('sg-task456');
+
+    // Purely additive — it must never revoke an existing rule.
+    expect(array_column($captured, 'name'))->not->toContain('RevokeSecurityGroupIngress');
+});
+
+it('does not authorise again when a matching load-balancer ingress rule already exists', function () {
+    $captured = [];
+
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => describeTaskAndLoadBalancerGroups(),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => [
+            [
+                'SecurityGroupRuleId' => 'sgr-existing',
+                'IsEgress' => false,
+                'IpProtocol' => 'tcp',
+                'FromPort' => 8000,
+                'ToPort' => 8000,
+                'ReferencedGroupInfo' => ['GroupId' => 'sg-lb789'],
+            ],
+        ]]),
+    ], $captured);
+
+    (new SyncTaskSecurityGroupStep())([]);
+
+    expect(array_column($captured, 'name'))
+        ->not->toContain('AuthorizeSecurityGroupIngress')
+        ->not->toContain('RevokeSecurityGroupIngress');
+});
+
+it('treats a manifest-specified task security group as custom-managed', function () {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'ecs' => ['security-group' => 'yolo-testing-my-app-ecs-task-security-group'],
+    ]);
+
+    $captured = [];
+
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => describeTaskAndLoadBalancerGroups(),
+    ], $captured);
+
+    expect((new SyncTaskSecurityGroupStep())([]))->toBe(StepResult::CUSTOM_MANAGED);
+    expect(array_column($captured, 'name'))->not->toContain('AuthorizeSecurityGroupIngress');
+});
+
+it('does not authorise during a dry-run', function () {
+    $captured = [];
+
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => describeTaskAndLoadBalancerGroups(),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => []]),
+    ], $captured);
+
+    (new SyncTaskSecurityGroupStep())(['dry-run' => true]);
+
+    expect(array_column($captured, 'name'))->not->toContain('AuthorizeSecurityGroupIngress');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- `yolo sync <env>` fatal'd mid-apply with a `TypeError` at the task security group step on a green-field app (hit on the convictrecords CON-538 cutover).
- Root cause: dropping the `--dry-run` CLI option (aafd817) removed the `dry-run` key from the options array entirely. The plan pass still injects `dry-run => true`, but the apply pass now carries no key at all, so `Arr::get($options, 'dry-run')` returns `null` instead of the old `false`. Every sibling step casts `(bool)`; `SyncTaskSecurityGroupStep` was the lone outlier feeding the raw nullable straight into a `bool`-typed param.
- Fix: `(bool)` cast at the call site — restores the `null → false` behaviour and matches the prevailing idiom across the sync steps.
- Added `SyncTaskSecurityGroupStepTest` covering the apply pass (no `dry-run` key — the regression), the already-authorised no-op, the manifest custom-managed branch, and the dry-run no-write.

**Is there anything the reviewer needs to know to deploy this?**
- Only the apply pass was affected (the plan pass injects `dry-run => true`, so previews always rendered fine) — which is why the crash hit *after* the confirm gate, not before. Nothing was written before the gate.
- Grepped every `dry-run` reference in `src/`: this was the only strict-typed site receiving the raw nullable, so there's no second landmine from aafd817.
- Resuming a partially-applied sync is safe: it's create-or-sync idempotent, so already-created resources sync and the rest create. The task SG that was created before the crash picks up its missing load-balancer ingress rule on the next run.
- 610 Pest green, pint clean. Pure bugfix — no command/manifest/scope-model surface change, so no docs update.

🤖 Generated with [Claude Code](https://claude.ai/code)