### PR TITLE
feat(build): hard-fail the build when laravel/octane is not installed

### DIFF
--- a/docs/guide/building-and-deploying.md
+++ b/docs/guide/building-and-deploying.md
@@ -30,7 +30,7 @@ To watch a rollout as it happens, or check what's running at any time, run [`yol
 1. Purge the build directory and stage a clean copy of your app.
 2. Pull `.env.<environment>` from S3 and stamp in `APP_VERSION` (and `ASSET_URL`, mirrored into `VITE_ASSET_URL` for Vite, if a CDN is configured).
 3. Run your manifest's `build` hooks (`composer install`, `npm run build`, …). With [Inertia SSR](/guide/images#inertia-ssr) enabled, this is also where `npm run build` produces the SSR bundle that gets baked into the image.
-4. Generate the entrypoint and supervisord config (see [The Container Image](/guide/images)). When `tasks.web.ssr` is on, this is where YOLO checks your Dockerfile for the Node runtime SSR needs.
+4. Generate the entrypoint and supervisord config (see [The Container Image](/guide/images)). Two preflight checks gate this step. First, YOLO **hard-fails the build** if `laravel/octane` isn't in your committed `composer.lock` production requirements — the web role runs `octane:start`, so a missing (or `require-dev`-only) octane would crash-loop the container on boot. Second, when `tasks.web.ssr` is on, it warns if your Dockerfile has no Node runtime for the SSR process.
 5. Log in to ECR, build the Docker image, and push it.
 
 The image-building steps (4–5) only run when your manifest declares `tasks` — a headless app with no web task still builds its source artefact.

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -23,6 +23,7 @@ class BuildCommand extends SteppedCommand
     ];
 
     protected array $fargateSteps = [
+        Steps\Build\Fargate\CheckOctaneInstalledStep::class,
         Steps\Build\Fargate\CheckSsrRuntimeStep::class,
         Steps\Build\Fargate\GenerateEntrypointScriptStep::class,
         Steps\Build\Fargate\GenerateSupervisorConfigStep::class,

--- a/src/Steps/Build/Fargate/CheckOctaneInstalledStep.php
+++ b/src/Steps/Build/Fargate/CheckOctaneInstalledStep.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Build\Fargate;
+
+use RuntimeException;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Illuminate\Filesystem\Filesystem;
+
+/**
+ * The web role runs `php artisan octane:start` (see ProcessCommands::octane) — a
+ * command that only exists when laravel/octane is installed. Without it the web
+ * container crash-loops on boot and the deploy circuit breaker rolls back ~20min
+ * later, so this preflight catches it before the image is even built.
+ *
+ * It reads composer.lock's `packages` array — the production dependency set, i.e.
+ * exactly what a `--no-dev` install ships into the image. That's deliberately not
+ * a composer.json `require` scan: octane sitting in `require-dev` would pass that
+ * check yet be stripped from the runtime image. Reading the lock also makes no
+ * assumption about *where* composer install runs — the committed lock is there
+ * whether the manifest builds host-side or an app-owned Dockerfile installs
+ * vendor itself, so inspecting the build dir's `vendor/` would false-fail the
+ * latter.
+ *
+ * Unlike the sibling SSR runtime check this is a hard fail, not a warn-and-confirm:
+ * the lock is authoritative (no heuristic that can false-negative), so a missing
+ * octane is a certainty rather than a guess — and a missing web server is fatal,
+ * where missing SSR merely degrades to client-side rendering.
+ */
+class CheckOctaneInstalledStep implements Step
+{
+    public function __construct(
+        protected string $environment,
+        protected Filesystem $filesystem = new Filesystem()
+    ) {}
+
+    public function __invoke(): StepResult
+    {
+        // Only the web role launches octane:start; a worker-only app never does.
+        if (! Manifest::has('tasks.web')) {
+            return StepResult::SKIPPED;
+        }
+
+        $lock = Paths::base('composer.lock');
+
+        if (! $this->filesystem->exists($lock)) {
+            throw new RuntimeException(
+                'Build aborted: composer.lock not found, so laravel/octane can\'t be verified. '
+                . 'Run `composer install` and commit composer.lock before deploying.'
+            );
+        }
+
+        if ($this->requiresOctane($this->filesystem->get($lock))) {
+            return StepResult::SUCCESS;
+        }
+
+        throw new RuntimeException(
+            'Build aborted: laravel/octane is not in composer.lock\'s production requirements. '
+            . 'The web container runs `octane:start` and will crash-loop without it. Run '
+            . '`composer require laravel/octane` (production, not --dev — the image installs '
+            . 'with --no-dev) and commit the updated composer.lock.'
+        );
+    }
+
+    protected function requiresOctane(string $lock): bool
+    {
+        $packages = json_decode($lock, true)['packages'] ?? [];
+
+        return collect($packages)->contains(fn (array $package) => ($package['name'] ?? null) === 'laravel/octane');
+    }
+}

--- a/tests/Unit/Steps/Build/Fargate/CheckOctaneInstalledStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckOctaneInstalledStepTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Build\Fargate\CheckOctaneInstalledStep;
+
+/**
+ * The guard reads the committed composer.lock and hard-fails when laravel/octane
+ * isn't in the production `packages` set — exactly what a `--no-dev` install ships
+ * into the image, and what the web role's `octane:start` needs to boot.
+ */
+function writeComposerLock(array $packages, array $devPackages = []): void
+{
+    file_put_contents(Paths::base('composer.lock'), json_encode([
+        'packages' => array_map(fn (string $name) => ['name' => $name], $packages),
+        'packages-dev' => array_map(fn (string $name) => ['name' => $name], $devPackages),
+    ]));
+}
+
+beforeEach(function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+});
+
+afterEach(function () {
+    is_file(Paths::base('composer.lock')) && unlink(Paths::base('composer.lock'));
+});
+
+it('skips without reading composer.lock for a worker-only app', function () {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['queue' => []],
+    ]);
+
+    // No composer.lock on disk — proof the step short-circuits before touching it.
+    expect((new CheckOctaneInstalledStep('testing'))())->toBe(StepResult::SKIPPED);
+});
+
+it('passes when laravel/octane is in the production packages', function () {
+    writeComposerLock(['laravel/framework', 'laravel/octane']);
+
+    expect((new CheckOctaneInstalledStep('testing'))())->toBe(StepResult::SUCCESS);
+});
+
+it('hard-fails when laravel/octane is absent', function () {
+    writeComposerLock(['laravel/framework', 'laravel/sanctum']);
+
+    expect(fn () => (new CheckOctaneInstalledStep('testing'))())
+        ->toThrow(RuntimeException::class, 'laravel/octane is not in composer.lock');
+});
+
+it('hard-fails when laravel/octane is only a dev dependency', function () {
+    // The footgun: octane in require-dev passes a composer.json scan but is stripped
+    // by the `--no-dev` production install, so the web container crash-loops.
+    writeComposerLock(['laravel/framework'], devPackages: ['laravel/octane']);
+
+    expect(fn () => (new CheckOctaneInstalledStep('testing'))())
+        ->toThrow(RuntimeException::class, 'laravel/octane is not in composer.lock');
+});
+
+it('hard-fails when composer.lock is missing', function () {
+    // No lock written; can't verify the requirement, so fail closed.
+    expect(fn () => (new CheckOctaneInstalledStep('testing'))())
+        ->toThrow(RuntimeException::class, 'composer.lock not found');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

- The web role runs `php artisan octane:start` (see `ProcessCommands::octane()`), which **only exists when `laravel/octane` is installed**. There was no check — an app reaching deploy without octane crash-loops the web container on boot, and the ECS deployment circuit breaker only rolls it back ~20 minutes later. Expensive, late, easy to miss.
- This adds a `CheckOctaneInstalledStep` build preflight, slotted **first** in `BuildCommand::$fargateSteps` (ahead of `CheckSsrRuntimeStep`, ECR login, and the image build/push), so a missing octane fails in milliseconds instead of after a full push + rollout. It gates on `tasks.web` (a worker-only app never runs octane → `SKIPPED`).

**Is there anything the reviewer needs to know to deploy this?**

- **It won't block existing apps' next deploy.** Every CL app on Fargate today is already running `octane:start`, so octane is in their `composer.lock` — the gate passes silently. It only fires on a genuinely-missing-octane misconfig (a new app, or octane demoted to `require-dev`).
- **Build-time only, no infra/AWS surface.** It reads the committed `composer.lock` from the repo root — no API calls, nothing provisioned. Rollback is a plain revert.
- On failure it aborts with a message naming the fix: `composer require laravel/octane`.

---

### The one decision worth flagging: check `composer.lock`, not `composer.json`

The production image installs with `--no-dev`, so `composer.lock`'s `packages` array (the prod set) is *exactly* what ships. Checking it instead of `composer.json`'s `require`:

| Source checked | octane in `require` | octane in `require-dev` |
|---|---|---|
| `composer.json` require | ✅ pass | ✅ pass — **but crash-loops in prod** |
| `composer.lock` `packages[]` | ✅ pass | ❌ **caught** |

Reading the lock also makes **no assumption about where `composer install` runs** — the committed lock is in the repo root whether the manifest builds host-side or an app-owned Dockerfile installs `vendor/` itself. (That's why I didn't inspect the build dir's `vendor/laravel/octane`: ground truth for a host-side build, but it would false-fail a legitimate Docker-side install.)

### Hard-fail, not warn-and-confirm

Unlike the sibling `CheckSsrRuntimeStep` (a Dockerfile-regex *heuristic* that can false-negative, so it warns + confirms), the lock is authoritative — a missing octane is a certainty. And a missing web server is fatal, where missing SSR merely degrades to client-side rendering.

### Tests & checks

5 new (`CheckOctaneInstalledStepTest`): skip for worker-only, pass when present, hard-fail when absent, **hard-fail when only a dev dependency** (the footgun), and hard-fail when `composer.lock` is missing.

- `./vendor/bin/pest` — **625 passed** (+5)
- `./vendor/bin/phpstan analyse` — no errors
- `./vendor/bin/pint` — pass
- Docs: build pipeline step 4 in `docs/guide/building-and-deploying.md` updated

🤖 Generated with [Claude Code](https://claude.ai/code)