### PR TITLE
fix(sync): self-heal absent task-SG load balancer ingress rule on sync

### DIFF
--- a/src/Steps/Sync/App/SyncTaskSecurityGroupStep.php
+++ b/src/Steps/Sync/App/SyncTaskSecurityGroupStep.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
@@ -38,11 +39,21 @@ class SyncTaskSecurityGroupStep implements Step
     {
         $rules = Ec2::securityGroupRules($groupId, SecurityGroupRule::ECS_TASK_LB_INGRESS_RULE->value);
 
-        if (! empty($rules) || $dryRun) {
+        if (! empty($rules)) {
             return;
         }
 
         $port = (int) Manifest::get('tasks.web.port', 8000);
+
+        // Record the missing rule before the dry-run guard (mirroring AuthorisesTaskIngress)
+        // so the plan pass flags this step pending. Without it a SG that exists but lacks
+        // the rule — e.g. a create interrupted mid-flight — records no change, gets pruned
+        // before apply, and can never be self-healed by a later sync.
+        $this->recordChange(Change::make("ingress {$port}/tcp from load balancer security group", null, 'authorised'));
+
+        if ($dryRun) {
+            return;
+        }
 
         Aws::ec2()->authorizeSecurityGroupIngress([
             'GroupId' => $groupId,

--- a/tests/Unit/Steps/Network/SyncTaskSecurityGroupStepTest.php
+++ b/tests/Unit/Steps/Network/SyncTaskSecurityGroupStepTest.php
@@ -64,11 +64,19 @@ it('does not authorise again when a matching load-balancer ingress rule already 
         ]]),
     ], $captured);
 
-    (new SyncTaskSecurityGroupStep())([]);
+    $step = new SyncTaskSecurityGroupStep();
+    $step([]);
 
     expect(array_column($captured, 'name'))
         ->not->toContain('AuthorizeSecurityGroupIngress')
         ->not->toContain('RevokeSecurityGroupIngress');
+
+    // The matching rule is already authorised, so the ingress reconcile records
+    // nothing — otherwise every sync would surface phantom ingress drift.
+    $ingressChanges = collect($step->changes())->filter(
+        fn ($change) => str_contains($change->attribute, 'ingress')
+    );
+    expect($ingressChanges)->toBeEmpty();
 });
 
 it('treats a manifest-specified task security group as custom-managed', function () {
@@ -99,4 +107,23 @@ it('does not authorise during a dry-run', function () {
     (new SyncTaskSecurityGroupStep())(['dry-run' => true]);
 
     expect(array_column($captured, 'name'))->not->toContain('AuthorizeSecurityGroupIngress');
+});
+
+it('records a pending change on the plan pass when the rule is absent so the step survives the prune', function () {
+    // Regression: the rule was written at create-time but recorded no Change on the
+    // plan (dry-run) pass, so the runner's pending filter pruned the step before apply.
+    // A task SG that exists without the rule (a create interrupted mid-flight) could
+    // therefore never be self-healed by a later sync. The change must be recorded
+    // regardless of --dry-run, mirroring AuthorisesTaskIngress.
+    $captured = [];
+
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => describeTaskAndLoadBalancerGroups(),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => []]),
+    ], $captured);
+
+    $step = new SyncTaskSecurityGroupStep();
+    $step(['dry-run' => true]);
+
+    expect($step->changes())->not->toBeEmpty();
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- `ensureLoadBalancerIngressRule` (in `SyncTaskSecurityGroupStep`) wrote the task-SG → load-balancer ingress rule but **recorded no `Change` on the plan (dry-run) pass**. The runner's `planEntryHasWork` filter only keeps a step for the apply pass if it returns a `WOULD_*` status or recorded a change — so this step got **pruned before apply**.
- Net effect: the rule was only ever authorised **at create-time**. A task SG that exists *without* the rule — e.g. a `sync` whose create was interrupted mid-flight — could never be self-healed by a later sync. `sync production` reported clean while the SG was silently missing its container-port ingress.
- This surfaced on **convict**: its task-SG create was interrupted by the [#93](https://github.com/codinglabsau/yolo/pull/93) crash, leaving it permanently stuck (CL got the rule at create-time, so it was unaffected).

**Fix:** move `recordChange()` to **before** the `$dryRun` guard (mirroring `AuthorisesTaskIngress`), so the plan flags the step pending → it survives the prune → apply self-heals any SG missing the rule. The reconcile stays purely additive — it never revokes an out-of-band rule, and records nothing when a matching rule already exists (no phantom drift).

**Is there anything the reviewer needs to know to deploy this?**
- Behaviour change is **plan-pass only**: an SG that already has the rule still records nothing and stays clean; an SG missing it now shows `ingress 8000/tcp from load balancer security group` as a pending change and authorises it on apply. No revokes, ever.
- Once merged, `yolo sync production` on **convict** will detect and add the missing rule — the permanent manual unblock is no longer required (a one-off manual rule-add was the only prior workaround).
- 621 Pest green; phpstan clean. Two regression tests added: the change is recorded under `--dry-run` (survives the prune), and an already-authorised SG records no ingress change.

🤖 Generated with [Claude Code](https://claude.ai/code)
