### PR TITLE
LPX-665: Surface global resources (IAM, CloudFront, Route 53) in yolo audit

### DIFF
--- a/src/Aws.php
+++ b/src/Aws.php
@@ -644,6 +644,15 @@ class Aws
         return Helpers::app('resourceGroupsTaggingApi');
     }
 
+    /**
+     * A Tagging API client pinned to us-east-1 — the only region that surfaces
+     * global-service resources (IAM, CloudFront, Route 53) to the audit.
+     */
+    public static function resourceGroupsTaggingApiGlobal(): ResourceGroupsTaggingAPIClient
+    {
+        return Helpers::app('resourceGroupsTaggingApiGlobal');
+    }
+
     public static function route53(): Route53Client
     {
         return Helpers::app('route53');

--- a/src/Aws/ResourceGroupsTaggingApi.php
+++ b/src/Aws/ResourceGroupsTaggingApi.php
@@ -3,26 +3,51 @@
 namespace Codinglabs\Yolo\Aws;
 
 use Codinglabs\Yolo\Aws;
+use Aws\ResourceGroupsTaggingAPI\ResourceGroupsTaggingAPIClient;
 
 class ResourceGroupsTaggingApi
 {
     /**
-     * Every resource carrying the given tag filters, across all pages.
+     * Every resource carrying the given tag filters across the account, deduped
+     * by ARN.
      *
-     * The Tagging API caps each page and hands back a PaginationToken until the
-     * last page returns an empty one — we follow it to the end so callers get the
-     * complete inventory in one list.
+     * The Tagging API is regional, and global-service resources — IAM roles and
+     * policies, CloudFront distributions, Route 53 hosted zones — are only ever
+     * returned by a us-east-1 query. So we run the filter twice: once against the
+     * environment's own region (regional services) and once against us-east-1
+     * (the global surface, plus any us-east-1-pinned resources like a CloudFront
+     * ACM certificate), then merge. Without the second pass the audit silently
+     * omits YOLO's entire global footprint. The two passes overlap only when the
+     * environment itself lives in us-east-1, where the ARN dedupe collapses them.
      *
      * @param  array<int, array{Key: string, Values?: array<int, string>}>  $tagFilters
      * @return array<int, array{ResourceARN: string, Tags: array<int, array{Key: string, Value: string}>}>
      */
     public static function getResources(array $tagFilters): array
     {
+        return collect([
+            ...static::paginate($tagFilters, Aws::resourceGroupsTaggingApi()),
+            ...static::paginate($tagFilters, Aws::resourceGroupsTaggingApiGlobal()),
+        ])
+            ->unique('ResourceARN')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Follow the Tagging API's PaginationToken to the end against a single
+     * client, so callers get the complete inventory for that region in one list.
+     *
+     * @param  array<int, array{Key: string, Values?: array<int, string>}>  $tagFilters
+     * @return array<int, array{ResourceARN: string, Tags: array<int, array{Key: string, Value: string}>}>
+     */
+    protected static function paginate(array $tagFilters, ResourceGroupsTaggingAPIClient $client): array
+    {
         $resources = [];
         $token = '';
 
         do {
-            $result = Aws::resourceGroupsTaggingApi()->getResources(array_filter([
+            $result = $client->getResources(array_filter([
                 'TagFilters' => $tagFilters,
                 'PaginationToken' => $token,
             ]));

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -59,6 +59,9 @@ trait RegistersAws
         Helpers::app()->singleton('iam', fn () => new IamClient($arguments));
         Helpers::app()->singleton('rds', fn () => new RdsClient($arguments));
         Helpers::app()->singleton('resourceGroupsTaggingApi', fn () => new ResourceGroupsTaggingAPIClient($arguments));
+        // The Tagging API is regional; global-service resources (IAM, CloudFront, Route 53) are only
+        // returned by a us-east-1 query, so the audit needs a second client pinned there to see them.
+        Helpers::app()->singleton('resourceGroupsTaggingApiGlobal', fn () => new ResourceGroupsTaggingAPIClient([...$arguments, 'region' => 'us-east-1']));
         Helpers::app()->singleton('route53', fn () => new Route53Client($arguments));
         Helpers::app()->singleton('s3', fn () => new S3Client($arguments));
         Helpers::app()->singleton('sns', fn () => new SnsClient($arguments));

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -14,6 +14,7 @@ use Aws\CloudWatch\CloudWatchClient;
 use Aws\ElastiCache\ElastiCacheClient;
 use Aws\ApplicationAutoScaling\ApplicationAutoScalingClient;
 use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
+use Aws\ResourceGroupsTaggingAPI\ResourceGroupsTaggingAPIClient;
 
 /*
 |--------------------------------------------------------------------------
@@ -430,6 +431,41 @@ function bindRoutedElbV2Client(array $byCommand, array &$captured): void
 
     Helpers::app()->instance('elasticLoadBalancingV2', new ElasticLoadBalancingV2Client([
         'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
+ * Bind a mock Tagging API client under the given container key — 'resourceGroupsTaggingApi'
+ * for the regional pass or 'resourceGroupsTaggingApiGlobal' for the us-east-1 pass. GetResources
+ * returns the supplied pages in order, the last repeating once the queue is exhausted, so a
+ * single-page array covers the common case and a multi-page array exercises PaginationToken
+ * following.
+ *
+ * @param  array<int, Result>  $pages
+ */
+function bindMockResourceGroupsTaggingApiClient(string $binding, array $pages): void
+{
+    $mock = new class($pages) extends MockHandler
+    {
+        private int $cursor = 0;
+
+        /** @param  array<int, Result>  $pages */
+        public function __construct(protected array $pages) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $index = min($this->cursor, count($this->pages) - 1);
+            $this->cursor++;
+
+            return Create::promiseFor($this->pages[$index]);
+        }
+    };
+
+    Helpers::app()->instance($binding, new ResourceGroupsTaggingAPIClient([
+        'region' => 'us-east-1',
         'version' => 'latest',
         'credentials' => false,
         'handler' => $mock,

--- a/tests/Unit/Aws/ResourceGroupsTaggingApiTest.php
+++ b/tests/Unit/Aws/ResourceGroupsTaggingApiTest.php
@@ -1,0 +1,102 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Audit\Audit;
+use Codinglabs\Yolo\Aws\ResourceGroupsTaggingApi;
+
+/**
+ * A tagged-resource mapping in the Tagging API's GetResources wire shape.
+ *
+ * @param  array<string, string>  $tags  associative key => value
+ */
+function rgtMapping(string $arn, array $tags = []): array
+{
+    return [
+        'ResourceARN' => $arn,
+        'Tags' => collect($tags)->map(fn ($value, $key) => ['Key' => $key, 'Value' => $value])->values()->all(),
+    ];
+}
+
+/**
+ * @param  array<int, array<string, mixed>>  $mappings
+ */
+function rgtPage(array $mappings, string $token = ''): Result
+{
+    return new Result(['ResourceTagMappingList' => $mappings, 'PaginationToken' => $token]);
+}
+
+it('merges the regional and us-east-1 passes so global resources appear', function () {
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [
+        rgtPage([rgtMapping('arn:aws:ecs:ap-southeast-2:111:service/yolo-production-codinglabs/web')]),
+    ]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [
+        rgtPage([rgtMapping('arn:aws:iam::111:role/yolo-production-codinglabs-task-role')]),
+    ]);
+
+    $arns = collect(ResourceGroupsTaggingApi::getResources([
+        ['Key' => 'yolo:environment', 'Values' => ['production']],
+    ]))->pluck('ResourceARN');
+
+    expect($arns)->toContain('arn:aws:ecs:ap-southeast-2:111:service/yolo-production-codinglabs/web')
+        ->and($arns)->toContain('arn:aws:iam::111:role/yolo-production-codinglabs-task-role');
+});
+
+it('dedupes by ARN when both passes return the same resource (us-east-1 environment)', function () {
+    $role = rgtMapping('arn:aws:iam::111:role/yolo-production-codinglabs-task-role', ['yolo:scope' => 'app']);
+
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [rgtPage([$role])]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [rgtPage([$role])]);
+
+    $resources = ResourceGroupsTaggingApi::getResources([
+        ['Key' => 'yolo:environment', 'Values' => ['production']],
+    ]);
+
+    expect($resources)->toHaveCount(1);
+});
+
+it('follows the PaginationToken to the end on each pass', function () {
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [
+        rgtPage([rgtMapping('arn:aws:s3:::yolo-production-a')], token: 'next'),
+        rgtPage([rgtMapping('arn:aws:s3:::yolo-production-b')]),
+    ]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [rgtPage([])]);
+
+    $arns = collect(ResourceGroupsTaggingApi::getResources([
+        ['Key' => 'yolo:environment', 'Values' => ['production']],
+    ]))->pluck('ResourceARN');
+
+    expect($arns->all())->toBe([
+        'arn:aws:s3:::yolo-production-a',
+        'arn:aws:s3:::yolo-production-b',
+    ]);
+});
+
+it('surfaces global resources through classification — IAM role ok, removed-service global resource unexpected', function () {
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [rgtPage([])]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [
+        rgtPage([
+            // An IAM role tagged for a live app — now visible to audit, classifies ok.
+            rgtMapping('arn:aws:iam::111:role/yolo-production-codinglabs-task-role', [
+                'yolo:app' => 'codinglabs', 'yolo:scope' => 'app', 'Name' => 'yolo-production-codinglabs-task-role',
+            ]),
+            // A YOLO-owned global resource of a service YOLO no longer provisions
+            // (a us-east-1 WAFv2 web ACL) — the global analogue of the DynamoDB
+            // sessions orphan: owned by a live app, but no Resources/ class, so a
+            // sync would never recreate it → unexpected, service no longer provisioned.
+            rgtMapping('arn:aws:wafv2:us-east-1:111:global/webacl/yolo-production-codinglabs/abc', [
+                'yolo:app' => 'codinglabs', 'yolo:scope' => 'app', 'Name' => 'yolo-production-codinglabs',
+            ]),
+        ]),
+    ]);
+
+    $tagged = ResourceGroupsTaggingApi::getResources([
+        ['Key' => 'yolo:environment', 'Values' => ['production']],
+    ]);
+    $report = Audit::classify($tagged, liveApps: ['codinglabs']);
+
+    $byArn = collect($report['resources'])->keyBy('arn');
+
+    expect($byArn['arn:aws:iam::111:role/yolo-production-codinglabs-task-role']['status'])->toBe('ok')
+        ->and($byArn['arn:aws:wafv2:us-east-1:111:global/webacl/yolo-production-codinglabs/abc']['status'])->toBe('unexpected')
+        ->and($byArn['arn:aws:wafv2:us-east-1:111:global/webacl/yolo-production-codinglabs/abc']['reason'])->toBe(Audit::REASON_UNMANAGED_SERVICE);
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

[LPX-665](https://linear.app/codinglabsau/issue/LPX-665/yolo-audit-is-blind-to-global-resources-iam-cloudfront-route-53)

**What problems are you solving?**
- `yolo audit <env>` advertises "every YOLO-tagged resource in an environment" but silently omitted **all global-service resources** — IAM (roles + policies), CloudFront distributions, and Route 53 hosted zones. They were never `ok` nor `unexpected`, just absent.
- Root cause: the Resource Groups Tagging API is **regional**, and global-service resources are only returned when the API is queried against **us-east-1**. The audit fetched only the environment's region (e.g. `ap-southeast-2`), so those ARNs never reached `Audit::classify()`.
- Concrete blind spot: the [yolo#89](https://github.com/codinglabsau/yolo/pull/89) orphaned shared `yolo-{env}-ecs-task-role`/`-ecs-task-policy` was invisible to audit (cleanup was manual `aws iam list-roles | grep` only). As the LP fleet grows, every deployer role, per-tenant Route 53 record and CloudFront distribution was outside audit's view.

**What changed**
- Register a second Tagging API client pinned to `us-east-1` (`resourceGroupsTaggingApiGlobal`), mirroring the existing CloudFront us-east-1 override.
- `ResourceGroupsTaggingApi::getResources()` now runs the same `yolo:environment` query against both the regional and the us-east-1 client and merges, **deduped by ARN** (the two passes overlap only when the env itself lives in us-east-1).
- Fetch-only fix: `Audit::SERVICE_BY_RESOURCE_GROUP` and `ConsoleUrl` already handle IAM/CloudFront/Route 53, so no classifier changes.
- Tests: merge + dedupe across the two passes, PaginationToken following per pass, and end-to-end through `classify` — a global IAM role for a live app is `ok`, while a global resource of an unmanaged service surfaces as `unexpected` (the IAM analogue of the DynamoDB-table case).

**Is there anything the reviewer needs to know to deploy this?**
- No infrastructure or behaviour change beyond the audit read path — it issues one extra `GetResources` call (against us-east-1) per audit run. No writes.
- Existing audit/classification behaviour is unchanged; this only adds the previously-missing global rows. Full suite green (629 passed), Pint + PHPStan clean.

🤖 Generated with [Claude Code](https://claude.ai/code)