### PR TITLE
LPX-646: diff-first sync reconcilers + IAM trust-policy self-heal

### DIFF
--- a/src/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrap.php
+++ b/src/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrap.php
@@ -105,8 +105,8 @@ class QueueScaleToZeroBootstrap
         ]);
 
         // PutMetricAlarm ignores Tags when updating an existing alarm, so reconcile
-        // the ownership markers explicitly (as QueueAlarm does) — so the alarm reads
-        // as `ok` in yolo audit rather than `rogue`.
+        // the ownership markers explicitly (TagResource works on an existing alarm) —
+        // so the alarm reads as `ok` in yolo audit rather than `rogue`.
         Aws::synchroniseCloudWatchTags(
             CloudWatch::alarm($this->alarmName())['AlarmArn'],
             $this->tags(),

--- a/src/Resources/ApplicationAutoScaling/ScalableTarget.php
+++ b/src/Resources/ApplicationAutoScaling/ScalableTarget.php
@@ -19,7 +19,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * target's from `tasks.queue.min/max` (a standalone queue is always autoscaled,
  * and its floor may be 0 — scale to zero).
  *
- * Like QueueAlarm / Dashboard this is a standalone reconciler, NOT a Resource:
+ * Like Dashboard this is a standalone reconciler, NOT a Resource:
  * App Auto Scaling targets aren't RGT-taggable (so they carry none of the
  * ownership tags the Resource contract reconciles, and stay invisible to
  * `yolo audit`) and RegisterScalableTarget is a pure upsert with no create/update

--- a/src/Resources/ApplicationAutoScaling/ScalingPolicy.php
+++ b/src/Resources/ApplicationAutoScaling/ScalingPolicy.php
@@ -10,11 +10,11 @@ use Codinglabs\Yolo\Aws\ApplicationAutoScaling;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
- * A target-tracking scaling policy on the web service's scalable target. Like
- * QueueAlarm this is a constructor-configured reconciler shared by the
- * request-count and CPU policies — PutScalingPolicy is a pure upsert, so there's
- * no create/update split. Dry-run honest: it reads the live policy, diffs the
- * comparable fields and only writes on drift.
+ * A target-tracking scaling policy on the web service's scalable target. A
+ * constructor-configured reconciler shared by the request-count and CPU policies —
+ * PutScalingPolicy is a pure upsert, so there's no create/update split. Dry-run
+ * honest: it reads the live policy, diffs the comparable fields and only writes on
+ * drift.
  *
  * Both policies attach to the same {@see ScalableTarget}. App Auto Scaling takes
  * the max desired count across every policy, so scale-out always wins and the two

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -28,12 +28,12 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * distribution, its S3 buckets and its log groups — plus the RDS database it
  * connects to (derived deterministically from DB_HOST in the app's env file).
  *
- * Like QueueAlarm this is a standalone reconciler, NOT a Resource: a dashboard
- * carries no meaningful tags (CloudWatch only tags alarms / Contributor Insights
- * rules) and PutDashboard is a pure upsert with no create/update split. Unlike
- * the blind QueueAlarm step it is dry-run honest — it reads the live body, diffs
- * it against the desired body (key-order-independent) and only writes on drift,
- * so `sync --dry-run` reports exactly when the dashboard would change.
+ * A standalone reconciler, NOT a Resource: a dashboard carries no meaningful tags
+ * (CloudWatch only tags alarms / Contributor Insights rules) and PutDashboard is a
+ * pure upsert with no create/update split. It is dry-run honest — it reads the
+ * live body, diffs it against the desired body (key-order-independent) and only
+ * writes on drift, so `sync --dry-run` reports exactly when the dashboard would
+ * change.
  *
  * The widget body is built from a resolved context: names are derived (ECS, SQS,
  * S3, log groups), the RDS identifier comes from the env file, and the three

--- a/src/Resources/CloudWatch/QueueAlarm.php
+++ b/src/Resources/CloudWatch/QueueAlarm.php
@@ -108,6 +108,10 @@ class QueueAlarm implements Resource, SynchronisesConfiguration
         $topicArn = (new SnsAlarmTopic())->arn();
 
         $attributes = [
+            // ActionsEnabled is reconciled so an alarm toggled off in the console heals
+            // back on; the alarm's metric/namespace/dimensions are hardcoded constants
+            // keyed to the queue, so they can't drift on a YOLO-managed alarm.
+            'actions-enabled' => [true, $live['ActionsEnabled'] ?? null],
             'comparison-operator' => ['GreaterThanThreshold', $live['ComparisonOperator'] ?? null],
             'evaluation-periods' => [(int) Manifest::get('sqs.depth-alarm-evaluation-periods', 3), isset($live['EvaluationPeriods']) ? (int) $live['EvaluationPeriods'] : null],
             'period' => [(int) Manifest::get('sqs.depth-alarm-period', 300), isset($live['Period']) ? (int) $live['Period'] : null],

--- a/src/Resources/CloudWatch/QueueAlarm.php
+++ b/src/Resources/CloudWatch/QueueAlarm.php
@@ -3,35 +3,133 @@
 namespace Codinglabs\Yolo\Resources\CloudWatch;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Aws\CloudWatch;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Resources\Sns\SnsAlarmTopic;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * A CloudWatch alarm that fires to the SNS alarm topic when an SQS queue gets
  * too deep, addressed by alarm + queue name so the solo, tenant and landlord
- * steps share it. putMetricAlarm is a pure upsert (no create/exists split), so
- * this doesn't implement the Resource contract — it just reconciles the desired
- * alarm on every sync.
+ * steps share it.
  *
- * Tags need their own reconcile: PutMetricAlarm only applies its Tags field when
- * it *creates* an alarm and silently ignores it on every later update, so an
- * alarm that was first put untagged (e.g. before tagging existed) would never
- * pick the tags up. TagResource works on an existing alarm, so after the upsert
- * we reconcile the app-scoped ownership tags onto it — the same yolo:scope /
- * yolo:app markers a Resource carries, so the alarm reads as `ok` in yolo audit
- * instead of `rogue`.
+ * A full Resource (+ SynchronisesConfiguration) so it rides the same create-or-sync
+ * path as every other resource. It used to be a bespoke reconciler whose step
+ * short-circuited to WOULD_SYNC on dry-run and re-put the alarm on every apply
+ * regardless of drift — invisible in the plan's "Pending changes" yet still
+ * tripping the confirm gate forever (so `yolo sync` on a clean account never
+ * reported "Already in sync"). Modelling it as a Resource makes its tag AND config
+ * drift surface symmetrically through syncResource(): a clean alarm records no
+ * change and is pruned before apply; a drifted one is listed current → desired.
+ *
+ * putMetricAlarm has no create/exists split (it's a pure upsert), which exists()
+ * = DescribeAlarms + create() = putMetricAlarm resolves cleanly. Tags need their
+ * own reconcile because PutMetricAlarm only applies its Tags field when it
+ * *creates* an alarm and silently ignores it on later updates — TagResource works
+ * on an existing alarm, so synchroniseTags() back-fills any alarm first put
+ * untagged.
  */
-class QueueAlarm
+class QueueAlarm implements Resource, SynchronisesConfiguration
 {
+    use ResolvesTags;
+
     public function __construct(
         protected string $alarmName,
         protected string $queueName,
         protected string $statistic = 'Average',
     ) {}
 
-    public function synchronise(): void
+    public function name(): string
+    {
+        return $this->alarmName;
+    }
+
+    public function scope(): Scope
+    {
+        return Scope::App;
+    }
+
+    public function exists(): bool
+    {
+        try {
+            CloudWatch::alarm($this->alarmName);
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    public function arn(): string
+    {
+        return CloudWatch::alarm($this->alarmName)['AlarmArn'];
+    }
+
+    public function create(): void
+    {
+        $this->putMetricAlarm();
+    }
+
+    public function synchroniseTags(bool $apply): array
+    {
+        return Aws::synchroniseCloudWatchTags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Diff the live alarm's reconciled attributes against the desired ones and,
+     * when any drift, re-put the whole desired alarm (putMetricAlarm is an upsert).
+     * Returns the drifted attributes as Change[] so the plan surfaces them and the
+     * apply pass isn't dropped by the only-pending-steps filter — empty when clean.
+     *
+     * @return array<int, Change>
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $changes = $this->configurationChanges(CloudWatch::alarm($this->alarmName));
+
+        if ($changes !== [] && $apply) {
+            $this->putMetricAlarm();
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @param  array<string, mixed>  $live
+     * @return array<int, Change>
+     */
+    protected function configurationChanges(array $live): array
+    {
+        $topicArn = (new SnsAlarmTopic())->arn();
+
+        $attributes = [
+            'comparison-operator' => ['GreaterThanThreshold', $live['ComparisonOperator'] ?? null],
+            'evaluation-periods' => [(int) Manifest::get('sqs.depth-alarm-evaluation-periods', 3), isset($live['EvaluationPeriods']) ? (int) $live['EvaluationPeriods'] : null],
+            'period' => [(int) Manifest::get('sqs.depth-alarm-period', 300), isset($live['Period']) ? (int) $live['Period'] : null],
+            'statistic' => [$this->statistic, $live['Statistic'] ?? null],
+            'threshold' => [(float) Manifest::get('sqs.depth-alarm-threshold', 100), isset($live['Threshold']) ? (float) $live['Threshold'] : null],
+            'treat-missing-data' => ['notBreaching', $live['TreatMissingData'] ?? null],
+            'alarm-actions' => [[$topicArn], $live['AlarmActions'] ?? []],
+            'ok-actions' => [[$topicArn], $live['OKActions'] ?? []],
+        ];
+
+        $changes = [];
+
+        foreach ($attributes as $label => [$desired, $current]) {
+            if ($desired !== $current) {
+                $changes[] = Change::make($label, $current, $desired);
+            }
+        }
+
+        return $changes;
+    }
+
+    protected function putMetricAlarm(): void
     {
         $topicArn = (new SnsAlarmTopic())->arn();
 
@@ -54,29 +152,5 @@ class QueueAlarm
             'OKActions' => [$topicArn],
             ...Aws::tags($this->tags()),
         ]);
-
-        // PutMetricAlarm ignores Tags when updating an existing alarm, so reconcile
-        // them explicitly (TagResource does work on an existing alarm) — this also
-        // back-fills any alarm that was first created untagged.
-        Aws::synchroniseCloudWatchTags(
-            CloudWatch::alarm($this->alarmName)['AlarmArn'],
-            $this->tags(),
-            apply: true,
-        );
-    }
-
-    /**
-     * App-scoped ownership tags, matching what a Resource's ResolvesTags would
-     * stamp. The yolo:environment baseline is added at write time by Aws::tags().
-     *
-     * @return array<string, string>
-     */
-    public function tags(): array
-    {
-        return [
-            'Name' => $this->alarmName,
-            'yolo:scope' => Scope::App->value,
-            'yolo:app' => Manifest::name(),
-        ];
     }
 }

--- a/src/Resources/Ecs/EcsService.php
+++ b/src/Resources/Ecs/EcsService.php
@@ -151,9 +151,9 @@ class EcsService implements Resource
             'cluster' => (new EcsCluster())->name(),
             'serviceName' => $this->name(),
             // The task definition family is the service name — SyncTaskDefinitionStep
-            // registers the family from this same value. TaskDef doesn't fit the Resource
-            // shape (re-registered every sync, no exists/create distinction), so the family
-            // is the service name rather than its own Resource.
+            // registers the family from this same value. TaskDef isn't modelled as a
+            // Resource (no taggable ARN to own; it's reconciled diff-first against the
+            // latest revision), so the family is the service name rather than its own Resource.
             'taskDefinition' => $this->name(),
             // Capacity isn't a manifest concern — start at the group's floor and let
             // ops scale it (console / `yolo scale` / autoscaling); never reconciled.

--- a/src/Resources/Iam/DeployerRole.php
+++ b/src/Resources/Iam/DeployerRole.php
@@ -11,6 +11,7 @@ use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -24,9 +25,10 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * repo + ref) and its permissions (the app's ECR repo, buckets, cluster, service)
  * are app-specific, so unlike the shared ECS execution role it can't be shared.
  */
-class DeployerRole implements Resource
+class DeployerRole implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
+    use SynchronisesAssumeRolePolicy;
 
     public function name(): string
     {
@@ -78,18 +80,6 @@ class DeployerRole implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseIamRoleTags($this->name(), $this->tags(), $apply);
-    }
-
-    /**
-     * Trust-policy drift (e.g. the manifest repository/branch changed) is
-     * reconciled by replacing the assume-role policy document.
-     */
-    public function synchroniseAssumeRolePolicy(): void
-    {
-        Aws::iam()->updateAssumeRolePolicy([
-            'RoleName' => $this->name(),
-            'PolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
-        ]);
     }
 
     public function assumeRolePolicyDocument(): array

--- a/src/Resources/Iam/EcsExecutionRole.php
+++ b/src/Resources/Iam/EcsExecutionRole.php
@@ -8,6 +8,7 @@ use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -20,9 +21,10 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * Replaces the previous reliance on the AWS-convention `ecsTaskExecutionRole`,
  * which AWS does not auto-create — green-field accounts never had it.
  */
-class EcsExecutionRole implements Resource
+class EcsExecutionRole implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
+    use SynchronisesAssumeRolePolicy;
 
     public function name(): string
     {
@@ -74,17 +76,6 @@ class EcsExecutionRole implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseIamRoleTags($this->name(), $this->tags(), $apply);
-    }
-
-    /**
-     * Trust-policy drift is reconciled by replacing the assume-role policy document.
-     */
-    public function synchroniseAssumeRolePolicy(): void
-    {
-        Aws::iam()->updateAssumeRolePolicy([
-            'RoleName' => $this->name(),
-            'PolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
-        ]);
     }
 
     public function assumeRolePolicyDocument(): array

--- a/src/Resources/Iam/EcsTaskRole.php
+++ b/src/Resources/Iam/EcsTaskRole.php
@@ -8,6 +8,7 @@ use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -19,9 +20,10 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * AttachEcsTaskRolePoliciesStep: the YOLO baseline task policy (ECS Exec + this
  * app's SQS/SES) plus any manifest-declared additions.
  */
-class EcsTaskRole implements Resource
+class EcsTaskRole implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
+    use SynchronisesAssumeRolePolicy;
 
     public function name(): string
     {
@@ -73,17 +75,6 @@ class EcsTaskRole implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseIamRoleTags($this->name(), $this->tags(), $apply);
-    }
-
-    /**
-     * Trust-policy drift is reconciled by replacing the assume-role policy document.
-     */
-    public function synchroniseAssumeRolePolicy(): void
-    {
-        Aws::iam()->updateAssumeRolePolicy([
-            'RoleName' => $this->name(),
-            'PolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
-        ]);
     }
 
     public function assumeRolePolicyDocument(): array

--- a/src/Resources/Iam/MediaConvertRole.php
+++ b/src/Resources/Iam/MediaConvertRole.php
@@ -8,6 +8,7 @@ use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
@@ -15,9 +16,10 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * EcsTaskRole, but app-exclusive (one per app) so it carries the yolo:app owner
  * tag. Permission policies are attached separately by AttachMediaConvertRolePoliciesStep.
  */
-class MediaConvertRole implements Resource
+class MediaConvertRole implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
+    use SynchronisesAssumeRolePolicy;
 
     public function name(): string
     {
@@ -67,14 +69,6 @@ class MediaConvertRole implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseIamRoleTags($this->name(), $this->tags(), $apply);
-    }
-
-    public function synchroniseAssumeRolePolicy(): void
-    {
-        Aws::iam()->updateAssumeRolePolicy([
-            'RoleName' => $this->name(),
-            'PolicyDocument' => json_encode($this->assumeRolePolicyDocument()),
-        ]);
     }
 
     public function assumeRolePolicyDocument(): array

--- a/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
+++ b/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
@@ -57,7 +57,7 @@ trait SynchronisesAssumeRolePolicy
      */
     protected function liveAssumeRolePolicyDocument(): array
     {
-        return json_decode(urldecode(IamClient::role($this->name())['AssumeRolePolicyDocument']), associative: true);
+        return json_decode(rawurldecode(IamClient::role($this->name())['AssumeRolePolicyDocument']), associative: true);
     }
 
     /**
@@ -77,7 +77,7 @@ trait SynchronisesAssumeRolePolicy
             return Change::make('trust sub', $liveSubject, $desiredSubject);
         }
 
-        return new Change('trust-policy', 'drifted', 'reconciled');
+        return Change::make('trust-policy', 'drifted', 'reconciled');
     }
 
     /**

--- a/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
+++ b/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\Iam;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Aws\Iam as IamClient;
+
+/**
+ * Shared trust-policy drift reconciliation for the YOLO-managed IAM roles
+ * (DeployerRole, EcsTaskRole, MediaConvertRole, EcsExecutionRole). A role's
+ * assume-role (trust) policy can drift after creation — most consequentially the
+ * deployer role's `sub` condition when an environment switches from a branch to a
+ * tag — and IAM replaces it in place via UpdateAssumeRolePolicy.
+ *
+ * This is wired through SynchronisesConfiguration — NOT a bespoke side-effect the
+ * sync step calls under `! dry-run` — on purpose. SyncSteppedCommand computes a
+ * plan pass (compute-only, apply=false) and then applies only the steps the plan
+ * flagged as having work. A trust rewrite computed only at apply time is invisible
+ * to that plan, so the step reports clean, gets dropped before apply, and the
+ * drifted trust never heals — exactly the bug that left a `tag: true` deployer
+ * role stuck trusting `refs/heads/main` so its OIDC deploy could never assume it.
+ * Returning the drift as a plan-time Change keeps the step on the apply side of
+ * the "only-pending-steps" filter (same shape as SynchronisesPolicyDocument).
+ *
+ * Requires the using Resource to provide name() and assumeRolePolicyDocument().
+ */
+trait SynchronisesAssumeRolePolicy
+{
+    /**
+     * @return array<int, Change>
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $live = $this->liveAssumeRolePolicyDocument();
+        $desired = $this->assumeRolePolicyDocument();
+
+        if ($this->policyDocumentsMatch($live, $desired)) {
+            return [];
+        }
+
+        if ($apply) {
+            Aws::iam()->updateAssumeRolePolicy([
+                'RoleName' => $this->name(),
+                'PolicyDocument' => json_encode($desired),
+            ]);
+        }
+
+        return [$this->trustPolicyChange($live, $desired)];
+    }
+
+    /**
+     * The role's live trust document. IAM returns it URL-encoded on the role
+     * record; decode to the same array shape as assumeRolePolicyDocument().
+     *
+     * @return array<string, mixed>
+     */
+    protected function liveAssumeRolePolicyDocument(): array
+    {
+        return json_decode(urldecode(IamClient::role($this->name())['AssumeRolePolicyDocument']), associative: true);
+    }
+
+    /**
+     * Render the drift as a single Change. The `sub` claim is the human-meaningful,
+     * security-relevant attribute (branch vs tag ref), so surface it directly when
+     * present; otherwise report the document drift generically.
+     *
+     * @param  array<string, mixed>  $live
+     * @param  array<string, mixed>  $desired
+     */
+    protected function trustPolicyChange(array $live, array $desired): Change
+    {
+        $liveSubject = $this->subjectClaimFrom($live);
+        $desiredSubject = $this->subjectClaimFrom($desired);
+
+        if ($liveSubject !== null || $desiredSubject !== null) {
+            return Change::make('trust sub', $liveSubject, $desiredSubject);
+        }
+
+        return new Change('trust-policy', 'drifted', 'reconciled');
+    }
+
+    /**
+     * The OIDC `sub` condition value (which ref may assume the role) from a given
+     * document, or null for a service-principal trust that carries no such
+     * condition. Named distinctly from DeployerRole::subjectClaim() (which renders
+     * the *desired* sub from the manifest) so the trait isn't shadowed when a role
+     * defines its own.
+     *
+     * @param  array<string, mixed>  $document
+     */
+    protected function subjectClaimFrom(array $document): ?string
+    {
+        foreach ($document['Statement'] ?? [] as $statement) {
+            foreach ($statement['Condition']['StringLike'] ?? [] as $key => $value) {
+                if (str_ends_with($key, ':sub')) {
+                    return is_array($value) ? implode(',', $value) : $value;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Order- and shape-independent comparison of two IAM policy documents. AWS may
+     * reorder keys, reorder statements, and collapse a single-element Action or
+     * Condition list to a bare scalar — a naive json_encode compare would read all
+     * of that as phantom drift and re-stamp the trust on every sync. Canonicalise
+     * both sides (sort keys, sort lists, unwrap single-element lists) first.
+     *
+     * @param  array<string, mixed>  $live
+     * @param  array<string, mixed>  $desired
+     */
+    protected function policyDocumentsMatch(array $live, array $desired): bool
+    {
+        return $this->canonicalisePolicyDocument($live) === $this->canonicalisePolicyDocument($desired);
+    }
+
+    protected function canonicalisePolicyDocument(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        // Associative (string-keyed) → sort keys for order-independence, recurse.
+        if (array_keys($value) !== range(0, count($value) - 1)) {
+            ksort($value);
+
+            return array_map($this->canonicalisePolicyDocument(...), $value);
+        }
+
+        // Sequential list → canonicalise each element and sort, then unwrap a
+        // single-element list to its scalar so IAM's "x" and ["x"] forms compare
+        // equal (Action, single-value Conditions).
+        $items = array_map($this->canonicalisePolicyDocument(...), $value);
+
+        usort($items, fn (mixed $a, mixed $b): int => json_encode($a) <=> json_encode($b));
+
+        return count($items) === 1 ? $items[0] : $items;
+    }
+}

--- a/src/Steps/Sync/App/Landlord/SyncQueueAlarmStep.php
+++ b/src/Steps/Sync/App/Landlord/SyncQueueAlarmStep.php
@@ -2,26 +2,22 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Landlord;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\CloudWatch\QueueAlarm;
 use Codinglabs\Yolo\Contracts\ExecutesMultitenancyStep;
 
 class SyncQueueAlarmStep implements ExecutesMultitenancyStep
 {
+    use SynchronisesResource;
+
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        (new QueueAlarm(
+        return $this->syncResource(new QueueAlarm(
             alarmName: Helpers::keyedResourceName('landlord-queue-depth-alarm'),
             queueName: Helpers::keyedResourceName('landlord'),
             statistic: 'Sum',
-        ))->synchronise();
-
-        return StepResult::SYNCED;
+        ), $options);
     }
 }

--- a/src/Steps/Sync/App/Solo/SyncQueueAlarmStep.php
+++ b/src/Steps/Sync/App/Solo/SyncQueueAlarmStep.php
@@ -2,25 +2,21 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Solo;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\CloudWatch\QueueAlarm;
 
 class SyncQueueAlarmStep implements Step
 {
+    use SynchronisesResource;
+
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        (new QueueAlarm(
+        return $this->syncResource(new QueueAlarm(
             alarmName: Helpers::keyedResourceName('queue-depth-alarm'),
             queueName: Helpers::keyedResourceName(),
-        ))->synchronise();
-
-        return StepResult::SYNCED;
+        ), $options);
     }
 }

--- a/src/Steps/Sync/App/SyncDeployerRoleStep.php
+++ b/src/Steps/Sync/App/SyncDeployerRoleStep.php
@@ -2,7 +2,6 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -19,14 +18,9 @@ class SyncDeployerRoleStep implements Step
             return StepResult::SKIPPED;
         }
 
-        $role = new DeployerRole();
-
-        // Trust-policy drift (the manifest repository/branch changed) reconciled
-        // by replacing the assume-role policy.
-        if ($role->exists() && ! Arr::get($options, 'dry-run')) {
-            $role->synchroniseAssumeRolePolicy();
-        }
-
-        return $this->syncResource($role, $options);
+        // Trust-policy drift (the manifest repository/branch/tag changed) rides
+        // through SynchronisesConfiguration on the role, so it's recorded in the
+        // plan pass and survives the only-pending-steps filter into apply.
+        return $this->syncResource(new DeployerRole(), $options);
     }
 }

--- a/src/Steps/Sync/App/SyncEcsTaskRoleStep.php
+++ b/src/Steps/Sync/App/SyncEcsTaskRoleStep.php
@@ -2,7 +2,6 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
@@ -14,13 +13,7 @@ class SyncEcsTaskRoleStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        $role = new EcsTaskRole();
-
-        // Trust-policy drift reconciled by replacing the assume-role policy.
-        if ($role->exists() && ! Arr::get($options, 'dry-run')) {
-            $role->synchroniseAssumeRolePolicy();
-        }
-
-        return $this->syncResource($role, $options);
+        // Trust-policy drift rides through SynchronisesConfiguration on the role.
+        return $this->syncResource(new EcsTaskRole(), $options);
     }
 }

--- a/src/Steps/Sync/App/SyncMediaConvertRoleStep.php
+++ b/src/Steps/Sync/App/SyncMediaConvertRoleStep.php
@@ -2,7 +2,6 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -19,13 +18,7 @@ class SyncMediaConvertRoleStep implements Step
             return StepResult::SKIPPED;
         }
 
-        $role = new MediaConvertRole();
-
-        // Trust-policy drift reconciled by replacing the assume-role policy.
-        if ($role->exists() && ! Arr::get($options, 'dry-run')) {
-            $role->synchroniseAssumeRolePolicy();
-        }
-
-        return $this->syncResource($role, $options);
+        // Trust-policy drift rides through SynchronisesConfiguration on the role.
+        return $this->syncResource(new MediaConvertRole(), $options);
     }
 }

--- a/src/Steps/Sync/App/SyncTaskDefinitionStep.php
+++ b/src/Steps/Sync/App/SyncTaskDefinitionStep.php
@@ -3,17 +3,21 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Aws\Ecs;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\ShutdownTimings;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Codinglabs\Yolo\Resources\Ecs\EcsService;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
 use Codinglabs\Yolo\Resources\Ecr\EcrRepository;
 use Codinglabs\Yolo\Resources\Iam\EcsExecutionRole;
 use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * Registers the web service's task definition. Standalone queue/scheduler
@@ -25,15 +29,94 @@ use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
  */
 class SyncTaskDefinitionStep implements Step
 {
+    use RecordsChanges;
+
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
+        $dryRun = (bool) Arr::get($options, 'dry-run');
+
+        try {
+            $desired = static::payload($this->group());
+        } catch (ResourceDoesNotExistException $e) {
+            // The roles / ECR the payload resolves aren't provisioned yet (a
+            // greenfield plan pass) — so the task definition can't exist either.
+            // Report it pending on the plan; on apply the deps exist (registered
+            // earlier in scope order) so a genuine miss is a hard fail.
+            if ($dryRun) {
+                $this->recordChange(Change::make('task definition', 'absent', 'new revision'));
+
+                return StepResult::WOULD_SYNC;
+            }
+
+            throw $e;
+        }
+
+        $live = $this->liveTaskDefinition($desired['family']);
+
+        // The registered revision already renders the desired payload — nothing to
+        // do, so the step is pruned before apply and a clean app reports "Already
+        // in sync" instead of registering a no-op revision every time (LPX-646).
+        if ($live !== null && $this->matchesDesired(Arr::except($desired, ['tags']), $live)) {
+            return StepResult::SYNCED;
+        }
+
+        $this->recordChange(Change::make(
+            'task definition',
+            $live === null ? 'absent' : 'revision ' . ($live['revision'] ?? '?'),
+            'new revision',
+        ));
+
+        if ($dryRun) {
             return StepResult::WOULD_SYNC;
         }
 
-        Aws::ecs()->registerTaskDefinition(static::payload($this->group()));
+        Aws::ecs()->registerTaskDefinition($desired);
 
         return StepResult::SYNCED;
+    }
+
+    /**
+     * The latest active revision of the family, or null when none is registered
+     * yet (a first sync).
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function liveTaskDefinition(string $family): ?array
+    {
+        try {
+            return Ecs::taskDefinition($family);
+        } catch (ResourceDoesNotExistException) {
+            return null;
+        }
+    }
+
+    /**
+     * Whether every attribute YOLO sets in the desired payload is present and equal
+     * in the live revision. A subset check (not equality) because AWS enriches a
+     * registered task definition with derived fields (revision, status, ARNs,
+     * container defaults) we don't manage — comparing the whole document would read
+     * all of that as phantom drift and re-register on every sync.
+     *
+     * @param  array<string, mixed>  $desired
+     * @param  array<string, mixed>  $live
+     */
+    protected function matchesDesired(array $desired, array $live): bool
+    {
+        foreach ($desired as $key => $value) {
+            if (! array_key_exists($key, $live)) {
+                return false;
+            }
+
+            if (is_array($value)) {
+                if (! is_array($live[$key]) || ! $this->matchesDesired($value, $live[$key])) {
+                    return false;
+                }
+            } elseif ((string) $value !== (string) $live[$key]) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/src/Steps/Sync/App/SyncTaskDefinitionStep.php
+++ b/src/Steps/Sync/App/SyncTaskDefinitionStep.php
@@ -138,8 +138,9 @@ class SyncTaskDefinitionStep implements Step
         $image = (new EcrRepository())->uri() . ':' . ($imageTag ?? 'latest');
 
         // The family is the service name — EcsService points its `taskDefinition`
-        // at the same value, so they stay in lockstep. The task definition isn't its
-        // own Resource (re-registered every sync — no exists/create distinction).
+        // at the same value, so they stay in lockstep. The task definition isn't
+        // modelled as a Resource (no taggable ARN to own); SyncTaskDefinitionStep
+        // reconciles it diff-first against the latest registered revision.
         $family = (new EcsService($group))->name();
 
         // ECS's SIGTERM-to-SIGKILL ceiling. Derived from the same source as the

--- a/src/Steps/Sync/App/Tenant/SyncQueueAlarmStep.php
+++ b/src/Steps/Sync/App/Tenant/SyncQueueAlarmStep.php
@@ -2,25 +2,21 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Tenant;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Steps\TenantStep;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\CloudWatch\QueueAlarm;
 
 class SyncQueueAlarmStep extends TenantStep
 {
+    use SynchronisesResource;
+
     public function __invoke(array $options): StepResult
     {
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_SYNC;
-        }
-
-        (new QueueAlarm(
+        return $this->syncResource(new QueueAlarm(
             alarmName: Helpers::keyedResourceName(sprintf('%s-queue-depth-alarm', $this->tenantId())),
             queueName: Helpers::keyedResourceName($this->tenantId()),
-        ))->synchronise();
-
-        return StepResult::SYNCED;
+        ), $options);
     }
 }

--- a/src/Steps/Sync/Environment/SyncDefaultRouteStep.php
+++ b/src/Steps/Sync/Environment/SyncDefaultRouteStep.php
@@ -3,29 +3,73 @@
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Codinglabs\Yolo\Resources\Ec2\RouteTable;
 use Codinglabs\Yolo\Resources\Ec2\InternetGateway;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
+/**
+ * The 0.0.0.0/0 → internet gateway default route on the public route table.
+ * AWS exposes no direct lookup for a single route, but the route table's `Routes`
+ * block lists them, so we diff against that and only call createRoute when the
+ * default route is absent — instead of re-stamping it (idempotently) on every
+ * sync, which recorded no Change and so kept tripping the confirm gate even on a
+ * clean account (LPX-646).
+ */
 class SyncDefaultRouteStep implements Step
 {
+    use RecordsChanges;
+
     public function __invoke(array $options): StepResult
     {
-        // note: there does not appear to be a way to retrieve this resource directly, and
-        // calling createRoute() multiple times does not create additional resources. This
-        // resource is visible in the AWS console under VPC -> Route Tables -> $route > Routes.
-        if (! Arr::get($options, 'dry-run')) {
-            Aws::ec2()->createRoute([
-                'DestinationCidrBlock' => '0.0.0.0/0',
-                'GatewayId' => (new InternetGateway())->arn(),
-                'RouteTableId' => (new RouteTable())->arn(),
-            ]);
+        $dryRun = (bool) Arr::get($options, 'dry-run');
 
+        // Already routed → nothing to do, so the step is pruned before apply and a
+        // clean environment reports "Already in sync".
+        if ($this->hasDefaultRoute()) {
             return StepResult::SYNCED;
         }
 
-        return StepResult::WOULD_SYNC;
+        $this->recordChange(Change::make('default route 0.0.0.0/0', null, 'internet gateway'));
+
+        if ($dryRun) {
+            return StepResult::WOULD_SYNC;
+        }
+
+        Aws::ec2()->createRoute([
+            'DestinationCidrBlock' => '0.0.0.0/0',
+            'GatewayId' => (new InternetGateway())->arn(),
+            'RouteTableId' => (new RouteTable())->arn(),
+        ]);
+
+        return StepResult::SYNCED;
+    }
+
+    /**
+     * Whether the public route table already carries a 0.0.0.0/0 route to an
+     * internet gateway. False when the route table isn't provisioned yet (a
+     * greenfield plan pass), so the missing route is reported as pending.
+     */
+    protected function hasDefaultRoute(): bool
+    {
+        try {
+            $routeTable = Ec2::routeTable((new RouteTable())->name());
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+
+        foreach ($routeTable['Routes'] ?? [] as $route) {
+            if (($route['DestinationCidrBlock'] ?? null) === '0.0.0.0/0'
+                && str_starts_with($route['GatewayId'] ?? '', 'igw-')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Steps/Sync/Environment/SyncEcsExecutionRoleStep.php
+++ b/src/Steps/Sync/Environment/SyncEcsExecutionRoleStep.php
@@ -2,7 +2,6 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
-use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
@@ -14,13 +13,7 @@ class SyncEcsExecutionRoleStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        $role = new EcsExecutionRole();
-
-        // Trust-policy drift reconciled by replacing the assume-role policy.
-        if ($role->exists() && ! Arr::get($options, 'dry-run')) {
-            $role->synchroniseAssumeRolePolicy();
-        }
-
-        return $this->syncResource($role, $options);
+        // Trust-policy drift rides through SynchronisesConfiguration on the role.
+        return $this->syncResource(new EcsExecutionRole(), $options);
     }
 }

--- a/src/Steps/Sync/Environment/SyncPublicSubnetsAssociationToRouteTableStep.php
+++ b/src/Steps/Sync/Environment/SyncPublicSubnetsAssociationToRouteTableStep.php
@@ -3,33 +3,99 @@
 namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Enums\PublicSubnets;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Codinglabs\Yolo\Resources\Ec2\RouteTable;
 use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
+/**
+ * Associates the public subnets with the public route table. AWS exposes no direct
+ * lookup for an association, but the route table's `Associations` block lists them,
+ * so we diff against that and only associate the subnets that aren't already
+ * attached — instead of re-associating all three on every sync, which recorded no
+ * Change and so kept tripping the confirm gate even on a clean account (LPX-646).
+ */
 class SyncPublicSubnetsAssociationToRouteTableStep implements Step
 {
+    use RecordsChanges;
+
     public function __invoke(array $options): StepResult
     {
-        // note: there does not appear to be a way to retrieve this resource directly, and
-        // calling associateRouteTable() multiple times does not create additional associations. This
-        // resource is visible in the AWS console under VPC -> Route Tables -> Subnet associations.
-        if (! Arr::get($options, 'dry-run')) {
-            $routeTableId = (new RouteTable())->arn();
+        $dryRun = (bool) Arr::get($options, 'dry-run');
 
-            foreach (array_keys(PublicSubnets::cases()) as $index) {
-                Aws::ec2()->associateRouteTable([
-                    'RouteTableId' => $routeTableId,
-                    'SubnetId' => (new PublicSubnet($index))->arn(),
-                ]);
+        $associatedSubnetIds = $this->associatedSubnetIds();
+
+        // Subnets not associated yet, keyed by index → [label, resolved id].
+        // An unresolved subnet (a greenfield plan pass) counts as missing so it's
+        // reported as pending; resolving it here also avoids a second lookup on apply.
+        $missing = [];
+
+        foreach (PublicSubnets::cases() as $index => $case) {
+            $subnetId = $this->subnetIdOrNull($index);
+
+            if ($subnetId === null || ! in_array($subnetId, $associatedSubnetIds, true)) {
+                $missing[$index] = ['label' => $case->value, 'subnetId' => $subnetId];
             }
+        }
 
+        if ($missing === []) {
             return StepResult::SYNCED;
         }
 
-        return StepResult::WOULD_SYNC;
+        foreach ($missing as $entry) {
+            $this->recordChange(Change::make("route table association ({$entry['label']})", null, 'associated'));
+        }
+
+        if ($dryRun) {
+            return StepResult::WOULD_SYNC;
+        }
+
+        $routeTableId = (new RouteTable())->arn();
+
+        foreach ($missing as $index => $entry) {
+            Aws::ec2()->associateRouteTable([
+                'RouteTableId' => $routeTableId,
+                'SubnetId' => $entry['subnetId'] ?? (new PublicSubnet($index))->arn(),
+            ]);
+        }
+
+        return StepResult::SYNCED;
+    }
+
+    /**
+     * The subnet ids already associated with the public route table (the main
+     * association carries no SubnetId and is skipped). Empty when the route table
+     * isn't provisioned yet (a greenfield plan pass).
+     *
+     * @return array<int, string>
+     */
+    protected function associatedSubnetIds(): array
+    {
+        try {
+            $routeTable = Ec2::routeTable((new RouteTable())->name());
+        } catch (ResourceDoesNotExistException) {
+            return [];
+        }
+
+        return collect($routeTable['Associations'] ?? [])
+            ->pluck('SubnetId')
+            ->filter()
+            ->values()
+            ->all();
+    }
+
+    protected function subnetIdOrNull(int $index): ?string
+    {
+        try {
+            return (new PublicSubnet($index))->arn();
+        } catch (ResourceDoesNotExistException) {
+            return null;
+        }
     }
 }

--- a/tests/Arch/SyncStepReconcilerTest.php
+++ b/tests/Arch/SyncStepReconcilerTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use Codinglabs\Yolo\Steps\Sync\App\SyncIvsEventBridgeTargetStep;
+use Codinglabs\Yolo\Steps\Sync\Account\SyncGithubOidcProviderStep;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncInternetGatewayAttachmentStep;
+use Codinglabs\Yolo\Steps\Sync\App\Solo\SyncSslCertificateStep as SoloSslCertificateStep;
+use Codinglabs\Yolo\Steps\Sync\App\Tenant\AttachSslCertificateToLoadBalancerListenerStep;
+use Codinglabs\Yolo\Steps\Sync\App\Tenant\SyncSslCertificateStep as TenantSslCertificateStep;
+
+/**
+ * Every sync step that mutates AWS must be able to record drift into the plan: a
+ * write that records no Change is invisible to the plan pass and pruned before
+ * apply — the LPX-646 / #95 class of bug. The structural floor is that every
+ * concrete `Steps\Sync` step exposes `changes()` (via RecordsChanges, directly or
+ * through SynchronisesResource / inheritance).
+ *
+ * Steps that gate every write on a live existence/state check — and so return
+ * SYNCED without writing when already provisioned — never write invisibly and are
+ * exempted below. Each exemption is a deliberate decision: a new step that
+ * bypasses the change machinery fails this test until it's either fixed or
+ * consciously added here with a justification.
+ */
+it('every sync step can record drift into the plan, or is an explicit exemption', function () {
+    // Existence/state-diff steps: they check live state first and return SYNCED
+    // (without writing) when already provisioned, so a clean sync stays quiet.
+    $existenceDiff = [
+        SyncGithubOidcProviderStep::class,        // account-level singleton: exists ⇒ done
+        SoloSslCertificateStep::class,            // ACM cert lifecycle (request/validate by state)
+        TenantSslCertificateStep::class,          // same, per tenant
+        SyncIvsEventBridgeTargetStep::class,      // compares the live target ARN before putTargets
+        SyncInternetGatewayAttachmentStep::class, // checks the attachment state before attaching
+    ];
+
+    // Known debt — does NOT belong here long-term. Tracked in LPX-669: it returns
+    // WOULD_SYNC on every plan pass regardless of drift, so a multi-tenant sync
+    // never reaches "Already in sync". Remove once it's made diff-first.
+    $knownOverReporters = [
+        AttachSslCertificateToLoadBalancerListenerStep::class,
+    ];
+
+    $exempt = [...$existenceDiff, ...$knownOverReporters];
+
+    $root = dirname(__DIR__, 2) . '/src';
+    $syncRoot = $root . '/Steps/Sync';
+
+    $offenders = [];
+    $examined = 0;
+
+    $files = new RecursiveIteratorIterator(
+        new RecursiveDirectoryIterator($syncRoot, FilesystemIterator::SKIP_DOTS)
+    );
+
+    foreach ($files as $file) {
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+
+        $relative = substr($file->getPathname(), strlen($root) + 1);
+        $class = 'Codinglabs\\Yolo\\' . str_replace(['/', '.php'], ['\\', ''], $relative);
+
+        if (! class_exists($class)) {
+            continue;
+        }
+
+        $reflection = new ReflectionClass($class);
+
+        if ($reflection->isAbstract() || in_array($class, $exempt, true)) {
+            continue;
+        }
+
+        $examined++;
+
+        if (! method_exists($class, 'changes')) {
+            $offenders[] = $class;
+        }
+    }
+
+    // Guard against a vacuous pass: if the path resolution ever breaks, the loop
+    // examines nothing and offenders is trivially empty. There are dozens of sync steps.
+    expect($examined)->toBeGreaterThan(40);
+
+    // A non-empty list means a sync step mutates AWS but can't surface that work in
+    // the plan — use RecordsChanges (directly or via SynchronisesResource), or add
+    // it to the exemption list above with a justification.
+    expect($offenders)->toBe([]);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -11,6 +11,7 @@ use GuzzleHttp\Promise\Create;
 use Symfony\Component\Yaml\Yaml;
 use Aws\CloudFront\CloudFrontClient;
 use Aws\CloudWatch\CloudWatchClient;
+use Codinglabs\Yolo\Enums\StepResult;
 use Aws\ElastiCache\ElastiCacheClient;
 use Aws\ApplicationAutoScaling\ApplicationAutoScalingClient;
 use Aws\ElasticLoadBalancingV2\ElasticLoadBalancingV2Client;
@@ -78,6 +79,47 @@ function writeManifest(array $config, string $environment = 'testing'): void
     ], 10, 2));
 
     Helpers::app()->instance('environment', $environment);
+}
+
+/**
+ * Assert a sync step honours the reconciler contract that the LPX-646 / #95 class
+ * of bug violated: its plan-pass status and recorded changes must reflect ACTUAL
+ * drift, and it must never write on the plan pass. This is the shared standard —
+ * every sync step that mutates AWS should carry one of these:
+ *
+ *   in-sync ⇒ SYNCED, no recorded Change, and no $writeCommand on either pass
+ *   drifted ⇒ WOULD_SYNC + a recorded Change on the plan (no write), $writeCommand on apply
+ *
+ * $makeStep returns a fresh step instance; $bindInSync / $bindDrifted bind the AWS
+ * mocks for each state (each receives the &$captured call log by reference).
+ */
+function assertSyncStepReconciles(Closure $makeStep, Closure $bindInSync, Closure $bindDrifted, string $writeCommand): void
+{
+    // In sync: the plan is clean (status + changes), and neither pass writes.
+    $captured = [];
+    $bindInSync($captured);
+    $planned = $makeStep();
+    expect($planned(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect($planned->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain($writeCommand);
+
+    $captured = [];
+    $bindInSync($captured);
+    expect($makeStep()([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain($writeCommand);
+
+    // Drifted: the plan records the drift but writes nothing; apply writes.
+    $captured = [];
+    $bindDrifted($captured);
+    $planned = $makeStep();
+    expect($planned(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($planned->changes())->not->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain($writeCommand);
+
+    $captured = [];
+    $bindDrifted($captured);
+    $makeStep()([]);
+    expect(array_column($captured, 'name'))->toContain($writeCommand);
 }
 
 /**

--- a/tests/Unit/Resources/CloudWatch/QueueAlarmTest.php
+++ b/tests/Unit/Resources/CloudWatch/QueueAlarmTest.php
@@ -6,7 +6,8 @@ use Aws\Sns\SnsClient;
 use Aws\CommandInterface;
 use Codinglabs\Yolo\Helpers;
 use GuzzleHttp\Promise\Create;
-use Codinglabs\Yolo\Resources\CloudWatch\QueueAlarm;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\Solo\SyncQueueAlarmStep;
 
 /** Bind an SNS client whose ListTopics always returns the alarm topic. */
 function bindAlarmTopic(): void
@@ -35,61 +36,120 @@ function bindAlarmTopic(): void
     ]));
 }
 
+/** A live alarm whose attributes match the solo step's desired state. */
+function inSyncQueueAlarm(array $overrides = []): array
+{
+    return array_merge([
+        'AlarmName' => 'yolo-testing-my-app-queue-depth-alarm',
+        'AlarmArn' => 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-depth-alarm',
+        'ComparisonOperator' => 'GreaterThanThreshold',
+        'EvaluationPeriods' => 3,
+        'Period' => 300,
+        'Statistic' => 'Average',
+        'Threshold' => 100.0,
+        'TreatMissingData' => 'notBreaching',
+        'AlarmActions' => ['arn:aws:sns:ap-southeast-2:111111111111:yolo-testing'],
+        'OKActions' => ['arn:aws:sns:ap-southeast-2:111111111111:yolo-testing'],
+    ], $overrides);
+}
+
+/** The ownership tags a synced alarm carries. */
+function syncedAlarmTags(): array
+{
+    return [
+        ['Key' => 'yolo:environment', 'Value' => 'testing'],
+        ['Key' => 'yolo:scope', 'Value' => 'app'],
+        ['Key' => 'yolo:app', 'Value' => 'my-app'],
+        ['Key' => 'Name', 'Value' => 'yolo-testing-my-app-queue-depth-alarm'],
+    ];
+}
+
 beforeEach(function () {
     writeManifest(['region' => 'ap-southeast-2', 'account-id' => '111111111111']);
     bindAlarmTopic();
 });
 
-it('reconciles the app-scoped ownership tags onto the alarm (PutMetricAlarm cannot tag an existing one)', function () {
-    $arn = 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-depth-alarm';
-
+it('creates the alarm when it does not yet exist', function () {
     $captured = [];
     bindMockCloudWatchClient([
-        'DescribeAlarms' => new Result(['MetricAlarms' => [
-            ['AlarmName' => 'yolo-testing-my-app-queue-depth-alarm', 'AlarmArn' => $arn],
-        ]]),
+        'DescribeAlarms' => new Result(['MetricAlarms' => []]),
+    ], $captured);
+
+    expect((new SyncQueueAlarmStep())([]))->toBe(StepResult::CREATED);
+
+    $put = collect($captured)->firstWhere('name', 'PutMetricAlarm');
+    expect($put)->not->toBeNull();
+    expect($put['args']['AlarmName'])->toBe('yolo-testing-my-app-queue-depth-alarm');
+    // Tags ride along on the create (PutMetricAlarm only honours them on create).
+    expect($put['args'])->toHaveKey('Tags');
+});
+
+it('records config drift on the plan pass and re-puts the alarm on apply', function () {
+    $captured = [];
+    bindMockCloudWatchClient([
+        // Live threshold has drifted from the desired 100.
+        'DescribeAlarms' => new Result(['MetricAlarms' => [inSyncQueueAlarm(['Threshold' => 999.0])]]),
+        'ListTagsForResource' => new Result(['Tags' => syncedAlarmTags()]),
+    ], $captured);
+
+    // Plan (dry-run) pass: drift is surfaced as a recorded change without writing.
+    $plan = new SyncQueueAlarmStep();
+    expect($plan(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect(collect($plan->changes())->pluck('attribute'))->toContain('threshold');
+    expect(array_column($captured, 'name'))->not->toContain('PutMetricAlarm');
+
+    // Apply pass: the alarm is re-put.
+    $captured = [];
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => [inSyncQueueAlarm(['Threshold' => 999.0])]]),
+        'ListTagsForResource' => new Result(['Tags' => syncedAlarmTags()]),
+    ], $captured);
+
+    expect((new SyncQueueAlarmStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->toContain('PutMetricAlarm');
+});
+
+it('records no change and never re-puts when the alarm is already in sync', function () {
+    // The acceptance criterion: a clean alarm produces no pending entry, so a
+    // no-op `yolo sync` can short-circuit to "Already in sync" instead of forever
+    // tripping the confirm gate.
+    $captured = [];
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => [inSyncQueueAlarm()]]),
+        'ListTagsForResource' => new Result(['Tags' => syncedAlarmTags()]),
+    ], $captured);
+
+    $step = new SyncQueueAlarmStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))
+        ->not->toContain('PutMetricAlarm')
+        ->not->toContain('TagResource');
+});
+
+it('back-fills missing ownership tags without re-putting an in-sync alarm', function () {
+    // PutMetricAlarm can't tag an existing alarm, so tag drift is healed via
+    // TagResource — and an alarm whose config is in sync is not needlessly re-put.
+    $captured = [];
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => [inSyncQueueAlarm()]]),
         'ListTagsForResource' => new Result(['Tags' => []]),
     ], $captured);
 
-    (new QueueAlarm(
-        alarmName: 'yolo-testing-my-app-queue-depth-alarm',
-        queueName: 'yolo-testing-my-app',
-    ))->synchronise();
+    expect((new SyncQueueAlarmStep())([]))->toBe(StepResult::SYNCED);
 
-    expect(collect($captured)->pluck('name'))->toContain('PutMetricAlarm', 'TagResource');
+    $tag = collect($captured)->firstWhere('name', 'TagResource');
+    expect($tag)->not->toBeNull();
+    expect($tag['args']['ResourceARN'])->toBe('arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-depth-alarm');
 
-    $tagCall = collect($captured)->firstWhere('name', 'TagResource');
-    expect($tagCall['args']['ResourceARN'])->toBe($arn);
-
-    $tags = collect($tagCall['args']['Tags'])->mapWithKeys(fn ($t) => [$t['Key'] => $t['Value']]);
+    $tags = collect($tag['args']['Tags'])->mapWithKeys(fn ($t) => [$t['Key'] => $t['Value']]);
     expect($tags)->toMatchArray([
         'yolo:environment' => 'testing',
         'yolo:scope' => 'app',
         'yolo:app' => 'my-app',
         'Name' => 'yolo-testing-my-app-queue-depth-alarm',
     ]);
-});
 
-it('makes no tag write when the alarm already carries the expected tags', function () {
-    $arn = 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-depth-alarm';
-
-    $captured = [];
-    bindMockCloudWatchClient([
-        'DescribeAlarms' => new Result(['MetricAlarms' => [
-            ['AlarmName' => 'yolo-testing-my-app-queue-depth-alarm', 'AlarmArn' => $arn],
-        ]]),
-        'ListTagsForResource' => new Result(['Tags' => [
-            ['Key' => 'yolo:environment', 'Value' => 'testing'],
-            ['Key' => 'yolo:scope', 'Value' => 'app'],
-            ['Key' => 'yolo:app', 'Value' => 'my-app'],
-            ['Key' => 'Name', 'Value' => 'yolo-testing-my-app-queue-depth-alarm'],
-        ]]),
-    ], $captured);
-
-    (new QueueAlarm(
-        alarmName: 'yolo-testing-my-app-queue-depth-alarm',
-        queueName: 'yolo-testing-my-app',
-    ))->synchronise();
-
-    expect(collect($captured)->pluck('name'))->not->toContain('TagResource');
+    // Config is in sync, so the alarm itself is not re-put.
+    expect(array_column($captured, 'name'))->not->toContain('PutMetricAlarm');
 });

--- a/tests/Unit/Resources/CloudWatch/QueueAlarmTest.php
+++ b/tests/Unit/Resources/CloudWatch/QueueAlarmTest.php
@@ -42,6 +42,7 @@ function inSyncQueueAlarm(array $overrides = []): array
     return array_merge([
         'AlarmName' => 'yolo-testing-my-app-queue-depth-alarm',
         'AlarmArn' => 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-depth-alarm',
+        'ActionsEnabled' => true,
         'ComparisonOperator' => 'GreaterThanThreshold',
         'EvaluationPeriods' => 3,
         'Period' => 300,
@@ -107,6 +108,19 @@ it('records config drift on the plan pass and re-puts the alarm on apply', funct
 
     expect((new SyncQueueAlarmStep())([]))->toBe(StepResult::SYNCED);
     expect(array_column($captured, 'name'))->toContain('PutMetricAlarm');
+});
+
+it('heals an alarm that was disabled in the console', function () {
+    $captured = [];
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => [inSyncQueueAlarm(['ActionsEnabled' => false])]]),
+        'ListTagsForResource' => new Result(['Tags' => syncedAlarmTags()]),
+    ], $captured);
+
+    $plan = new SyncQueueAlarmStep();
+    expect($plan(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect(collect($plan->changes())->pluck('attribute'))->toContain('actions-enabled');
+    expect(array_column($captured, 'name'))->not->toContain('PutMetricAlarm');
 });
 
 it('records no change and never re-puts when the alarm is already in sync', function () {

--- a/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
@@ -1,6 +1,9 @@
 <?php
 
+use Aws\Result;
+use Illuminate\Support\Arr;
 use Codinglabs\Yolo\ShutdownTimings;
+use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Steps\Sync\App\SyncTaskDefinitionStep;
 
@@ -128,4 +131,70 @@ it('tags the task definition with the environment', function () {
     $payload = SyncTaskDefinitionStep::payload();
 
     expect($payload['tags'])->toContain(['key' => 'yolo:environment', 'value' => 'testing']);
+});
+
+/** A live revision rendering the desired payload, plus AWS-derived enrichment. */
+function liveTaskDefinition(array $overrides = []): array
+{
+    return array_merge(
+        Arr::except(SyncTaskDefinitionStep::payload(), ['tags']),
+        ['revision' => 7, 'status' => 'ACTIVE', 'taskDefinitionArn' => 'arn:aws:ecs:ap-southeast-2:111111111111:task-definition/yolo-testing-my-app-web:7'],
+        $overrides,
+    );
+}
+
+it('is in sync when the registered revision already renders the desired payload', function () {
+    // The acceptance criterion: a no-op sync must not register a fresh revision —
+    // it records no change, gets pruned before apply, and lets the sync report
+    // "Already in sync".
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => liveTaskDefinition()]),
+    ], $captured);
+
+    $step = new SyncTaskDefinitionStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('RegisterTaskDefinition');
+});
+
+it('records drift on the plan pass and registers a new revision on apply', function () {
+    // A drifted attribute (here the CPU sizing) the live revision no longer matches.
+    $drifted = liveTaskDefinition(['cpu' => '9999']);
+
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => $drifted]),
+    ], $captured);
+
+    $plan = new SyncTaskDefinitionStep();
+    expect($plan(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($plan->changes())->not->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('RegisterTaskDefinition');
+
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => $drifted]),
+    ], $captured);
+
+    expect((new SyncTaskDefinitionStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->toContain('RegisterTaskDefinition');
+});
+
+it('ignores AWS-derived enrichment fields when diffing (no phantom drift)', function () {
+    // The live revision carries fields YOLO never sets (revision, status, ARN, and
+    // container-level defaults). These must not read as drift.
+    $live = liveTaskDefinition();
+    $live['containerDefinitions'][0]['mountPoints'] = [];
+    $live['containerDefinitions'][0]['volumesFrom'] = [];
+    $live['containerDefinitions'][0]['environment'] = [];
+    $live['requiresAttributes'] = [['name' => 'ecs.capability.execution-role-awslogs']];
+
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => $live]),
+    ], $captured);
+
+    expect((new SyncTaskDefinitionStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('RegisterTaskDefinition');
 });

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -24,12 +24,35 @@ function existingDeployerPolicy(): array
     ];
 }
 
-function existingDeployerRole(): array
+function existingDeployerRole(?string $trustSubject = null): array
 {
     return [
         'RoleName' => 'yolo-testing-my-app-deployer',
         'Arn' => 'arn:aws:iam::111111111111:role/yolo-testing-my-app-deployer',
+        // IAM returns the live trust URL-encoded on the role record. Default to the
+        // main-branch trust so a default (main) manifest reads as in-sync and a
+        // branch/tag manifest reads as drifted.
+        'AssumeRolePolicyDocument' => deployerTrustDocument($trustSubject ?? 'repo:my-org/my-repo:ref:refs/heads/main'),
     ];
+}
+
+/** A URL-encoded OIDC trust document scoped to the given `sub` claim. */
+function deployerTrustDocument(string $subject): string
+{
+    return rawurlencode(json_encode([
+        'Version' => '2012-10-17',
+        'Statement' => [
+            [
+                'Effect' => 'Allow',
+                'Principal' => ['Federated' => 'arn:aws:iam::111111111111:oidc-provider/token.actions.githubusercontent.com'],
+                'Action' => 'sts:AssumeRoleWithWebIdentity',
+                'Condition' => [
+                    'StringEquals' => ['token.actions.githubusercontent.com:aud' => 'sts.amazonaws.com'],
+                    'StringLike' => ['token.actions.githubusercontent.com:sub' => $subject],
+                ],
+            ],
+        ],
+    ]));
 }
 
 /** A manifest with a resolvable GitHub repository — the deployer provisions. */
@@ -229,6 +252,60 @@ it('reconciles the deployer role trust policy when the env ref changes', functio
 
     $sub = json_decode($update['args']['PolicyDocument'], true)['Statement'][0]['Condition']['StringLike']['token.actions.githubusercontent.com:sub'];
     expect($sub)->toBe('repo:my-org/my-repo:ref:refs/heads/release');
+});
+
+it('records deployer trust drift on the plan pass so the step survives the prune', function () {
+    // Regression (the convict `tag: true` OIDC failure): the trust rewrite used to
+    // happen only under `! dry-run` and recorded no Change, so the plan pass saw a
+    // clean step, the only-pending-steps filter pruned it before apply, and a
+    // role created on `main` could never be self-healed to `refs/tags/*`. The drift
+    // must be recorded on the plan (dry-run) pass — without writing — so the step
+    // survives the prune.
+    manifestWithDeployer(['tag' => true]);
+
+    $captured = [];
+    bindRoutedIamClient([
+        // Live trust still pinned to the old main-branch ref.
+        'ListRoles' => new Result(['Roles' => [existingDeployerRole('repo:my-org/my-repo:ref:refs/heads/main')]]),
+    ], $captured);
+
+    $step = new SyncDeployerRoleStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+
+    $trustChange = collect($step->changes())->first(fn ($change) => str_contains($change->attribute, 'trust'));
+    expect($trustChange)->not->toBeNull();
+    // The diff must read live → desired, not desired → desired (guards the trait
+    // method being shadowed by DeployerRole's own subjectClaim()).
+    expect($trustChange->from)->toBe('repo:my-org/my-repo:ref:refs/heads/main');
+    expect($trustChange->to)->toBe('repo:my-org/my-repo:ref:refs/tags/*');
+
+    // Plan pass computes only — it must never rewrite the trust.
+    expect(array_column($captured, 'name'))->not->toContain('UpdateAssumeRolePolicy');
+});
+
+it('records no trust change when the deployer trust already matches', function () {
+    // The other half of the regression: an in-sync trust must produce no pending
+    // entry, otherwise every sync re-stamps it and the confirm gate never clears.
+    manifestWithDeployer();
+
+    $captured = [];
+    bindRoutedIamClient([
+        // Live trust already on the default main ref — matches the rendered desired.
+        'ListRoles' => new Result(['Roles' => [existingDeployerRole()]]),
+        'ListRoleTags' => new Result(['Tags' => [
+            ['Key' => 'Name', 'Value' => 'yolo-testing-my-app-deployer'],
+            ['Key' => 'yolo:scope', 'Value' => 'app'],
+            ['Key' => 'yolo:app', 'Value' => 'my-app'],
+            ['Key' => 'yolo:environment', 'Value' => 'testing'],
+        ]]),
+    ], $captured);
+
+    $step = new SyncDeployerRoleStep();
+    expect($step([]))->toBe(StepResult::SYNCED);
+
+    $trustChanges = collect($step->changes())->filter(fn ($change) => str_contains($change->attribute, 'trust'));
+    expect($trustChanges)->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('UpdateAssumeRolePolicy');
 });
 
 it('never mutates IAM on a dry-run against existing deployer resources', function () {

--- a/tests/Unit/Steps/Iam/RoleTrustPolicySelfHealTest.php
+++ b/tests/Unit/Steps/Iam/RoleTrustPolicySelfHealTest.php
@@ -1,0 +1,85 @@
+<?php
+
+use Aws\Result;
+use Illuminate\Support\Collection;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
+use Codinglabs\Yolo\Resources\Iam\EcsExecutionRole;
+use Codinglabs\Yolo\Resources\Iam\MediaConvertRole;
+use Codinglabs\Yolo\Steps\Sync\App\SyncEcsTaskRoleStep;
+use Codinglabs\Yolo\Steps\Sync\App\SyncMediaConvertRoleStep;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncEcsExecutionRoleStep;
+
+/**
+ * The service-principal roles (ECS task, ECS execution, MediaConvert) reconcile
+ * their trust the same way the deployer role does, through
+ * SynchronisesConfiguration. These guard the generic (sub-less) drift branch and
+ * confirm each step records drift on the plan pass — so the only-pending-steps
+ * filter can't prune the self-heal — and stays quiet when the trust is in sync.
+ */
+dataset('serviceRoles', [
+    'ecs task role' => [EcsTaskRole::class, SyncEcsTaskRoleStep::class, []],
+    'ecs execution role' => [EcsExecutionRole::class, SyncEcsExecutionRoleStep::class, []],
+    'mediaconvert role' => [MediaConvertRole::class, SyncMediaConvertRoleStep::class, ['mediaconvert' => true]],
+]);
+
+function bindServiceRoleTrust(string $roleName, array $liveTrust, array &$captured): void
+{
+    bindRoutedIamClient([
+        'ListRoles' => new Result(['Roles' => [[
+            'RoleName' => $roleName,
+            'Arn' => 'arn:aws:iam::111111111111:role/' . $roleName,
+            // IAM returns the live trust URL-encoded on the role record.
+            'AssumeRolePolicyDocument' => rawurlencode(json_encode($liveTrust)),
+        ]]]),
+    ], $captured);
+}
+
+function trustChangesFor(object $step): Collection
+{
+    return collect($step->changes())->filter(fn ($change) => str_contains($change->attribute, 'trust'));
+}
+
+it('records trust drift on the plan pass and rewrites it on apply', function (string $resourceClass, string $stepClass, array $manifestExtra) {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', ...$manifestExtra]);
+
+    $resource = new $resourceClass();
+
+    // Drift the live trust's principal away from the rendered desired.
+    $drifted = $resource->assumeRolePolicyDocument();
+    $drifted['Statement'][0]['Principal']['Service'] = 'stale.amazonaws.com';
+
+    // Plan (dry-run) pass: the drift is recorded so the step survives the prune,
+    // but the trust is never rewritten.
+    $captured = [];
+    bindServiceRoleTrust($resource->name(), $drifted, $captured);
+
+    $planStep = new $stepClass();
+    expect($planStep(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect(trustChangesFor($planStep))->not->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('UpdateAssumeRolePolicy');
+
+    // Apply pass: the trust is reconciled in place.
+    $captured = [];
+    bindServiceRoleTrust($resource->name(), $drifted, $captured);
+
+    (new $stepClass())([]);
+    expect(array_column($captured, 'name'))->toContain('UpdateAssumeRolePolicy');
+})->with('serviceRoles');
+
+it('records no trust change and never rewrites when the trust already matches', function (string $resourceClass, string $stepClass, array $manifestExtra) {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', ...$manifestExtra]);
+
+    $resource = new $resourceClass();
+
+    $captured = [];
+    bindServiceRoleTrust($resource->name(), $resource->assumeRolePolicyDocument(), $captured);
+
+    $step = new $stepClass();
+    $step([]);
+
+    // An in-sync trust produces no pending entry, so a no-op sync stays quiet and
+    // the confirm gate can clear.
+    expect(trustChangesFor($step))->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('UpdateAssumeRolePolicy');
+})->with('serviceRoles');

--- a/tests/Unit/Steps/Network/RouteTableReconcileTest.php
+++ b/tests/Unit/Steps/Network/RouteTableReconcileTest.php
@@ -1,0 +1,136 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncDefaultRouteStep;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncPublicSubnetsAssociationToRouteTableStep;
+
+beforeEach(function () {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+});
+
+function routeTableResult(array $routes = [], array $associations = []): Result
+{
+    return new Result(['RouteTables' => [[
+        'RouteTableId' => 'rtb-1',
+        'Routes' => $routes,
+        'Associations' => $associations,
+    ]]]);
+}
+
+// ── Default route ────────────────────────────────────────────────────────────
+
+it('creates the default route when the route table lacks one', function () {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => routeTableResult(routes: [
+            ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
+        ]),
+        'DescribeInternetGateways' => new Result(['InternetGateways' => [['InternetGatewayId' => 'igw-123']]]),
+    ], $captured);
+
+    expect((new SyncDefaultRouteStep())([]))->toBe(StepResult::SYNCED);
+
+    $create = collect($captured)->firstWhere('name', 'CreateRoute');
+    expect($create)->not->toBeNull();
+    expect($create['args'])->toMatchArray([
+        'DestinationCidrBlock' => '0.0.0.0/0',
+        'GatewayId' => 'igw-123',
+        'RouteTableId' => 'rtb-1',
+    ]);
+});
+
+it('is in sync when the default route already exists', function () {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => routeTableResult(routes: [
+            ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
+            ['DestinationCidrBlock' => '0.0.0.0/0', 'GatewayId' => 'igw-123'],
+        ]),
+    ], $captured);
+
+    $step = new SyncDefaultRouteStep();
+    expect($step([]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('CreateRoute');
+});
+
+it('records the missing default route on the plan pass without creating it', function () {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => routeTableResult(routes: [
+            ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
+        ]),
+    ], $captured);
+
+    $step = new SyncDefaultRouteStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($step->changes())->not->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('CreateRoute');
+});
+
+// ── Public subnet associations ───────────────────────────────────────────────
+
+it('associates only the public subnets that are not yet attached', function () {
+    $captured = [];
+    bindMockEc2Client([
+        // subnet-a is already associated (plus the main association); b and c are not.
+        'DescribeRouteTables' => routeTableResult(associations: [
+            ['Main' => true],
+            ['SubnetId' => 'subnet-a'],
+        ]),
+        'DescribeSubnets' => [
+            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
+        ],
+    ], $captured);
+
+    expect((new SyncPublicSubnetsAssociationToRouteTableStep())([]))->toBe(StepResult::SYNCED);
+
+    $associated = collect($captured)
+        ->where('name', 'AssociateRouteTable')
+        ->pluck('args.SubnetId');
+
+    expect($associated)->toContain('subnet-b', 'subnet-c');
+    expect($associated)->not->toContain('subnet-a');
+});
+
+it('is in sync when every public subnet is already associated', function () {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => routeTableResult(associations: [
+            ['Main' => true],
+            ['SubnetId' => 'subnet-a'],
+            ['SubnetId' => 'subnet-b'],
+            ['SubnetId' => 'subnet-c'],
+        ]),
+        'DescribeSubnets' => [
+            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
+        ],
+    ], $captured);
+
+    $step = new SyncPublicSubnetsAssociationToRouteTableStep();
+    expect($step([]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('AssociateRouteTable');
+});
+
+it('records the missing associations on the plan pass without associating', function () {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => routeTableResult(associations: [['Main' => true]]),
+        'DescribeSubnets' => [
+            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
+            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
+        ],
+    ], $captured);
+
+    $step = new SyncPublicSubnetsAssociationToRouteTableStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($step->changes())->toHaveCount(3);
+    expect(array_column($captured, 'name'))->not->toContain('AssociateRouteTable');
+});

--- a/tests/Unit/Steps/Network/RouteTableReconcileTest.php
+++ b/tests/Unit/Steps/Network/RouteTableReconcileTest.php
@@ -18,9 +18,41 @@ function routeTableResult(array $routes = [], array $associations = []): Result
     ]]]);
 }
 
+/** The three public subnets, resolved in index order off the DescribeSubnets queue. */
+function publicSubnetResults(): array
+{
+    return [
+        new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
+        new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
+        new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
+    ];
+}
+
 // ── Default route ────────────────────────────────────────────────────────────
 
-it('creates the default route when the route table lacks one', function () {
+it('honours the reconciler contract for the default route', function () {
+    assertSyncStepReconciles(
+        makeStep: fn () => new SyncDefaultRouteStep(),
+        bindInSync: function (array &$captured) {
+            bindMockEc2Client([
+                'DescribeRouteTables' => routeTableResult(routes: [
+                    ['DestinationCidrBlock' => '0.0.0.0/0', 'GatewayId' => 'igw-123'],
+                ]),
+            ], $captured);
+        },
+        bindDrifted: function (array &$captured) {
+            bindMockEc2Client([
+                'DescribeRouteTables' => routeTableResult(routes: [
+                    ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
+                ]),
+                'DescribeInternetGateways' => new Result(['InternetGateways' => [['InternetGatewayId' => 'igw-123']]]),
+            ], $captured);
+        },
+        writeCommand: 'CreateRoute',
+    );
+});
+
+it('creates the default route pointed at the internet gateway and route table', function () {
     $captured = [];
     bindMockEc2Client([
         'DescribeRouteTables' => routeTableResult(routes: [
@@ -32,7 +64,6 @@ it('creates the default route when the route table lacks one', function () {
     expect((new SyncDefaultRouteStep())([]))->toBe(StepResult::SYNCED);
 
     $create = collect($captured)->firstWhere('name', 'CreateRoute');
-    expect($create)->not->toBeNull();
     expect($create['args'])->toMatchArray([
         'DestinationCidrBlock' => '0.0.0.0/0',
         'GatewayId' => 'igw-123',
@@ -40,36 +71,31 @@ it('creates the default route when the route table lacks one', function () {
     ]);
 });
 
-it('is in sync when the default route already exists', function () {
-    $captured = [];
-    bindMockEc2Client([
-        'DescribeRouteTables' => routeTableResult(routes: [
-            ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
-            ['DestinationCidrBlock' => '0.0.0.0/0', 'GatewayId' => 'igw-123'],
-        ]),
-    ], $captured);
-
-    $step = new SyncDefaultRouteStep();
-    expect($step([]))->toBe(StepResult::SYNCED);
-    expect($step->changes())->toBeEmpty();
-    expect(array_column($captured, 'name'))->not->toContain('CreateRoute');
-});
-
-it('records the missing default route on the plan pass without creating it', function () {
-    $captured = [];
-    bindMockEc2Client([
-        'DescribeRouteTables' => routeTableResult(routes: [
-            ['DestinationCidrBlock' => '10.0.0.0/16', 'GatewayId' => 'local'],
-        ]),
-    ], $captured);
-
-    $step = new SyncDefaultRouteStep();
-    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
-    expect($step->changes())->not->toBeEmpty();
-    expect(array_column($captured, 'name'))->not->toContain('CreateRoute');
-});
-
 // ── Public subnet associations ───────────────────────────────────────────────
+
+it('honours the reconciler contract for the public subnet associations', function () {
+    assertSyncStepReconciles(
+        makeStep: fn () => new SyncPublicSubnetsAssociationToRouteTableStep(),
+        bindInSync: function (array &$captured) {
+            bindMockEc2Client([
+                'DescribeRouteTables' => routeTableResult(associations: [
+                    ['Main' => true],
+                    ['SubnetId' => 'subnet-a'],
+                    ['SubnetId' => 'subnet-b'],
+                    ['SubnetId' => 'subnet-c'],
+                ]),
+                'DescribeSubnets' => publicSubnetResults(),
+            ], $captured);
+        },
+        bindDrifted: function (array &$captured) {
+            bindMockEc2Client([
+                'DescribeRouteTables' => routeTableResult(associations: [['Main' => true]]),
+                'DescribeSubnets' => publicSubnetResults(),
+            ], $captured);
+        },
+        writeCommand: 'AssociateRouteTable',
+    );
+});
 
 it('associates only the public subnets that are not yet attached', function () {
     $captured = [];
@@ -79,11 +105,7 @@ it('associates only the public subnets that are not yet attached', function () {
             ['Main' => true],
             ['SubnetId' => 'subnet-a'],
         ]),
-        'DescribeSubnets' => [
-            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
-        ],
+        'DescribeSubnets' => publicSubnetResults(),
     ], $captured);
 
     expect((new SyncPublicSubnetsAssociationToRouteTableStep())([]))->toBe(StepResult::SYNCED);
@@ -94,43 +116,4 @@ it('associates only the public subnets that are not yet attached', function () {
 
     expect($associated)->toContain('subnet-b', 'subnet-c');
     expect($associated)->not->toContain('subnet-a');
-});
-
-it('is in sync when every public subnet is already associated', function () {
-    $captured = [];
-    bindMockEc2Client([
-        'DescribeRouteTables' => routeTableResult(associations: [
-            ['Main' => true],
-            ['SubnetId' => 'subnet-a'],
-            ['SubnetId' => 'subnet-b'],
-            ['SubnetId' => 'subnet-c'],
-        ]),
-        'DescribeSubnets' => [
-            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
-        ],
-    ], $captured);
-
-    $step = new SyncPublicSubnetsAssociationToRouteTableStep();
-    expect($step([]))->toBe(StepResult::SYNCED);
-    expect($step->changes())->toBeEmpty();
-    expect(array_column($captured, 'name'))->not->toContain('AssociateRouteTable');
-});
-
-it('records the missing associations on the plan pass without associating', function () {
-    $captured = [];
-    bindMockEc2Client([
-        'DescribeRouteTables' => routeTableResult(associations: [['Main' => true]]),
-        'DescribeSubnets' => [
-            new Result(['Subnets' => [['SubnetId' => 'subnet-a']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-b']]]),
-            new Result(['Subnets' => [['SubnetId' => 'subnet-c']]]),
-        ],
-    ], $captured);
-
-    $step = new SyncPublicSubnetsAssociationToRouteTableStep();
-    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
-    expect($step->changes())->toHaveCount(3);
-    expect(array_column($captured, 'name'))->not->toContain('AssociateRouteTable');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Closes [LPX-646](https://linear.app/codinglabsau/issue/LPX-646). Two related bug fixes plus a guardrail so they can't recur — all the same class as #95: a write gated on `! dry-run` that records no `Change` is invisible to the plan pass and pruned before apply.

**What problems are you solving?**

- **LPX-646 — `yolo sync` never reached "Already in sync".** Four idempotent re-stamper steps emitted `WOULD_SYNC` / re-wrote on every apply without recording a `Change`, so a clean account showed no "Pending changes" yet still tripped the confirm gate forever. All four are now **diff-first** (record a `Change` only on real drift, pruned when clean):
  - `QueueAlarm` → full `Resource` + `SynchronisesConfiguration`; the Solo/Tenant/Landlord steps collapse to one-line `syncResource()`.
  - `SyncDefaultRouteStep` + `SyncPublicSubnetsAssociationToRouteTableStep` diff `DescribeRouteTables` (Routes / Associations) and only write what's missing.
  - `SyncTaskDefinitionStep` subset-diffs the latest revision (a subset, since AWS enriches the live payload) and only registers on real drift.
- **IAM role trust-policy drift never self-healed.** `yolo sync` silently left assume-role trust drift unreconciled when the role existed with in-sync tags (the convict `tag: true` OIDC failure — the deployer role still trusted `refs/heads/main`). Folded trust drift into the role Resource via a new **`SynchronisesAssumeRolePolicy`** trait (canonicalised, order-independent document diff) implementing `SynchronisesConfiguration`. Applied to the deployer / task / execution / mediaconvert roles; the four role steps collapse to plain `syncResource()`.
- **Locked it in.** A reconciler-contract test helper (`assertSyncStepReconciles`) + an arch test (`tests/Arch/SyncStepReconcilerTest`) requiring every concrete `Steps\Sync` step to record drift into the plan (or be an explicit, justified exemption) — so the bypass class fails CI in future.

**Is there anything the reviewer needs to know to deploy this?**

- **Behavioural change to `sync`, not a surface change** — no manifest keys, command args or scope model changed. It makes the already-documented "Already in sync" short-circuit actually hold, so docs needed no edits.
- The immediate convict prod unblock is still a manual `aws iam update-assume-role-policy` to `refs/tags/*` (out of scope here); after this lands, `yolo sync production` heals that drift on its own.
- **Diff fidelity is the risk surface.** Task-def uses a *subset* compare (`desired ⊆ live`) so AWS-derived enrichment isn't read as phantom drift; trust uses canonicalisation (sorted keys/lists, single-element-vs-array) to avoid re-stamping every sync. Both have explicit no-phantom-drift regression tests.
- **Deploy path is untouched** — `RegisterTaskDefinitionRevisionStep` still always registers (with the versioned tag); only the *sync* path is now no-op-aware. The ECS service pins the family name, so a clean sync skipping a re-register can't leave a stale pointer.
- Independently risk-reviewed on safety / breaking-changes / consistency — **no blockers** (IAM canonicaliser verified no false-match/false-drift; zero dangling callers of the removed `synchroniseAssumeRolePolicy()`; per-tenant fan-out isolated).
- **+22 regression tests.** Full suite **649 green**, pint + phpstan clean.

**Follow-ups surfaced (filed, not in this PR):**

- [LPX-669](https://linear.app/codinglabsau/issue/LPX-669) — the new arch test's audit found one more over-reporter: `App\Tenant\AttachSslCertificateToLoadBalancerListenerStep` returns `WOULD_SYNC` on every plan (multi-tenant only → **LP**). Tracked as known debt in the arch test's exemption list.
- [LPX-670](https://linear.app/codinglabsau/issue/LPX-670) — sibling-trait consistency: `SynchronisesPolicyDocument` still does a naive string compare while the new trait canonicalises; converge both onto a shared canonicalisation helper.

🤖 Generated with [Claude Code](https://claude.ai/code)
