### PR TITLE
fix(sync): two phantom-drift fixes — :443 listener cert + IAM policy-doc compare

### DIFF
--- a/src/Resources/Iam/CanonicalisesPolicyDocuments.php
+++ b/src/Resources/Iam/CanonicalisesPolicyDocuments.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\Iam;
+
+/**
+ * Order- and shape-independent comparison of two IAM policy documents. AWS may
+ * reorder keys, reorder statements, and collapse a single-element Action or
+ * Condition list to a bare scalar — a naive json_encode/string compare reads all
+ * of that as phantom drift and re-stamps the document (a new managed-policy
+ * version, or a role-trust rewrite) on every sync. Canonicalise both sides (sort
+ * keys, sort lists, unwrap single-element lists) before comparing.
+ *
+ * Shared by SynchronisesPolicyDocument (customer-managed policy versions) and
+ * SynchronisesAssumeRolePolicy (role trust documents) so the two compare
+ * identically — canonicalisation is strictly more lenient than a string compare,
+ * collapsing only AWS's legitimate equivalences, so it never false-matches two
+ * semantically-distinct documents.
+ */
+trait CanonicalisesPolicyDocuments
+{
+    /**
+     * @param  array<string, mixed>  $live
+     * @param  array<string, mixed>  $desired
+     */
+    protected function policyDocumentsMatch(array $live, array $desired): bool
+    {
+        return $this->canonicalisePolicyDocument($live) === $this->canonicalisePolicyDocument($desired);
+    }
+
+    protected function canonicalisePolicyDocument(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        // Associative (string-keyed) → sort keys for order-independence, recurse.
+        if (array_keys($value) !== range(0, count($value) - 1)) {
+            ksort($value);
+
+            return array_map($this->canonicalisePolicyDocument(...), $value);
+        }
+
+        // Sequential list → canonicalise each element and sort, then unwrap a
+        // single-element list to its scalar so IAM's "x" and ["x"] forms compare
+        // equal (Action, single-value Conditions).
+        $items = array_map($this->canonicalisePolicyDocument(...), $value);
+
+        usort($items, fn (mixed $a, mixed $b): int => json_encode($a) <=> json_encode($b));
+
+        return count($items) === 1 ? $items[0] : $items;
+    }
+}

--- a/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
+++ b/src/Resources/Iam/SynchronisesAssumeRolePolicy.php
@@ -27,6 +27,8 @@ use Codinglabs\Yolo\Aws\Iam as IamClient;
  */
 trait SynchronisesAssumeRolePolicy
 {
+    use CanonicalisesPolicyDocuments;
+
     /**
      * @return array<int, Change>
      */
@@ -100,43 +102,5 @@ trait SynchronisesAssumeRolePolicy
         }
 
         return null;
-    }
-
-    /**
-     * Order- and shape-independent comparison of two IAM policy documents. AWS may
-     * reorder keys, reorder statements, and collapse a single-element Action or
-     * Condition list to a bare scalar — a naive json_encode compare would read all
-     * of that as phantom drift and re-stamp the trust on every sync. Canonicalise
-     * both sides (sort keys, sort lists, unwrap single-element lists) first.
-     *
-     * @param  array<string, mixed>  $live
-     * @param  array<string, mixed>  $desired
-     */
-    protected function policyDocumentsMatch(array $live, array $desired): bool
-    {
-        return $this->canonicalisePolicyDocument($live) === $this->canonicalisePolicyDocument($desired);
-    }
-
-    protected function canonicalisePolicyDocument(mixed $value): mixed
-    {
-        if (! is_array($value)) {
-            return $value;
-        }
-
-        // Associative (string-keyed) → sort keys for order-independence, recurse.
-        if (array_keys($value) !== range(0, count($value) - 1)) {
-            ksort($value);
-
-            return array_map($this->canonicalisePolicyDocument(...), $value);
-        }
-
-        // Sequential list → canonicalise each element and sort, then unwrap a
-        // single-element list to its scalar so IAM's "x" and ["x"] forms compare
-        // equal (Action, single-value Conditions).
-        $items = array_map($this->canonicalisePolicyDocument(...), $value);
-
-        usort($items, fn (mixed $a, mixed $b): int => json_encode($a) <=> json_encode($b));
-
-        return count($items) === 1 ? $items[0] : $items;
     }
 }

--- a/src/Resources/Iam/SynchronisesPolicyDocument.php
+++ b/src/Resources/Iam/SynchronisesPolicyDocument.php
@@ -25,17 +25,25 @@ use Codinglabs\Yolo\Aws\Iam as IamClient;
  */
 trait SynchronisesPolicyDocument
 {
+    use CanonicalisesPolicyDocuments;
+
     /**
      * @return array<int, Change>
      */
     public function synchroniseConfiguration(bool $apply = true): array
     {
         $policy = IamClient::policy($this->name());
-        $desired = json_encode($this->document());
+        $desired = $this->document();
 
         $currentVersion = IamClient::policyVersion($policy['Arn'], $policy['DefaultVersionId']);
+        $live = json_decode(urldecode((string) $currentVersion['Document']), associative: true);
 
-        if (urldecode((string) $currentVersion['Document']) === $desired) {
+        // Canonical compare, not a naive json_encode string match: IAM round-trips
+        // the document with reordered keys/statements and collapses single-element
+        // Action/Condition lists to scalars, which a string compare reads as drift —
+        // re-versioning on every sync and burning the 5-version cap (LPX-670). Shared
+        // with SynchronisesAssumeRolePolicy via CanonicalisesPolicyDocuments.
+        if ($this->policyDocumentsMatch($live, $desired)) {
             return [];
         }
 
@@ -44,7 +52,7 @@ trait SynchronisesPolicyDocument
 
             Aws::iam()->createPolicyVersion([
                 'PolicyArn' => $policy['Arn'],
-                'PolicyDocument' => $desired,
+                'PolicyDocument' => json_encode($desired),
                 'SetAsDefault' => true,
             ]);
         }

--- a/src/Steps/Sync/App/SyncHttpsListenerStep.php
+++ b/src/Steps/Sync/App/SyncHttpsListenerStep.php
@@ -3,13 +3,13 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Aws\Acm;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
-use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\ElbV2\HttpsListener;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -37,7 +37,14 @@ class SyncHttpsListenerStep implements ExecutesWebStep
         $listener = new HttpsListener($certificate);
 
         // Cert-attachment is orchestration, not part of the resource's identity.
+        // The app's SNI cert lives in the listener's certificate list
+        // (DescribeListenerCertificates), not its single default cert — so checking
+        // the default-only list read this as missing on every sync for any app that
+        // wasn't the listener's creator. Record the change before the dry-run guard
+        // so it shows in the plan and survives to apply.
         if ($listener->exists() && ! static::hasCertificate($listener->arn(), $certificate)) {
+            $this->recordChange(Change::make('listener certificate', 'absent', 'attached'));
+
             if (Arr::get($options, 'dry-run')) {
                 return StepResult::WOULD_SYNC;
             }
@@ -55,9 +62,12 @@ class SyncHttpsListenerStep implements ExecutesWebStep
 
     protected static function hasCertificate(string $listenerArn, array $certificate): bool
     {
-        $listener = ElbV2::listenerOnPort((new LoadBalancer())->arn(), 443);
+        try {
+            ElbV2::listenerCertificate($listenerArn, $certificate['CertificateArn']);
 
-        return collect($listener['Certificates'] ?? [])
-            ->contains(fn (array $cert): bool => $cert['CertificateArn'] === $certificate['CertificateArn']);
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
     }
 }

--- a/tests/Unit/Steps/Fargate/SyncHttpsListenerStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncHttpsListenerStepTest.php
@@ -1,0 +1,139 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\Acm\AcmClient;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\SyncHttpsListenerStep;
+
+const HTTPS_APEX = 'codinglabs.com.au';
+const HTTPS_APP_CERT = 'arn:aws:acm:ap-southeast-2:111111111111:certificate/app-cert';
+const HTTPS_DEFAULT_CERT = 'arn:aws:acm:ap-southeast-2:111111111111:certificate/default-cert';
+
+beforeEach(function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'apex' => HTTPS_APEX,
+        'domain' => HTTPS_APEX,
+    ]);
+
+    bindIssuedAcmCertificate(HTTPS_APEX, HTTPS_APP_CERT);
+});
+
+it('is in sync when the cert is attached as an SNI cert, even though it is not the listener default', function (): void {
+    // The acceptance criterion: the cert lives in the listener's SNI certificate
+    // list (DescribeListenerCertificates), NOT its single default cert
+    // (DescribeListeners). Checking only the default read this as missing on every
+    // sync for any app that wasn't the listener's creator — the "always syncs" bug.
+    $captured = [];
+    bindRoutedElbV2Client(
+        httpsListenerElbV2(attached: [HTTPS_DEFAULT_CERT, HTTPS_APP_CERT]),
+        $captured,
+    );
+
+    $step = new SyncHttpsListenerStep();
+
+    expect($step(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('AddListenerCertificates');
+});
+
+it('records drift on the plan pass and attaches the cert on apply', function (): void {
+    $captured = [];
+    bindRoutedElbV2Client(
+        httpsListenerElbV2(attached: [HTTPS_DEFAULT_CERT]),
+        $captured,
+    );
+
+    $plan = new SyncHttpsListenerStep();
+    expect($plan(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+    expect($plan->changes())->not->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('AddListenerCertificates');
+
+    $captured = [];
+    bindRoutedElbV2Client(
+        httpsListenerElbV2(attached: [HTTPS_DEFAULT_CERT]),
+        $captured,
+    );
+
+    expect((new SyncHttpsListenerStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->toContain('AddListenerCertificates');
+});
+
+it('skips when no apex or domain is configured', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+
+    $captured = [];
+    bindRoutedElbV2Client(httpsListenerElbV2(attached: [HTTPS_APP_CERT]), $captured);
+
+    expect((new SyncHttpsListenerStep())(['dry-run' => true]))->toBe(StepResult::SKIPPED);
+});
+
+/**
+ * A routed ELBv2 mock for the shared env :443 listener. The listener's default
+ * cert is deliberately NOT the app cert, so a step that only inspects the default
+ * (DescribeListeners) would always miss an attached SNI cert; the attached SNI
+ * list (DescribeListenerCertificates) is driven by $attached.
+ *
+ * @param  array<int, string>  $attached  cert ARNs in the listener's SNI list
+ * @return array<string, Result>
+ */
+function httpsListenerElbV2(array $attached): array
+{
+    return [
+        'DescribeLoadBalancers' => new Result(['LoadBalancers' => [
+            ['LoadBalancerName' => 'yolo-testing', 'LoadBalancerArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/app/yolo-testing/abc'],
+        ]]),
+        'DescribeListeners' => new Result(['Listeners' => [
+            [
+                'Port' => 443,
+                'ListenerArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:listener/app/yolo-testing/abc/443',
+                'Certificates' => [['CertificateArn' => HTTPS_DEFAULT_CERT]],
+            ],
+        ]]),
+        'DescribeListenerCertificates' => new Result(['Certificates' => array_map(
+            fn (string $arn): array => ['CertificateArn' => $arn],
+            $attached,
+        )]),
+        'DescribeTags' => new Result(['TagDescriptions' => [['Tags' => [
+            ['Key' => 'Name', 'Value' => 'yolo-testing-https'],
+            ['Key' => 'yolo:scope', 'Value' => 'env'],
+            ['Key' => 'yolo:environment', 'Value' => 'testing'],
+        ]]]]),
+    ];
+}
+
+function bindIssuedAcmCertificate(string $domain, string $certificateArn, string $status = 'ISSUED'): void
+{
+    $mock = new class($domain, $certificateArn, $status) extends MockHandler
+    {
+        public function __construct(
+            private string $domain,
+            private string $certificateArn,
+            private string $status,
+        ) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            return Create::promiseFor(new Result([
+                'CertificateSummaryList' => [[
+                    'DomainName' => $this->domain,
+                    'CertificateArn' => $this->certificateArn,
+                    'Status' => $this->status,
+                ]],
+            ]));
+        }
+    };
+
+    Helpers::app()->instance('acm', new AcmClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}

--- a/tests/Unit/Steps/Fargate/SyncHttpsListenerStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncHttpsListenerStepTest.php
@@ -113,9 +113,9 @@ function bindIssuedAcmCertificate(string $domain, string $certificateArn, string
     $mock = new class($domain, $certificateArn, $status) extends MockHandler
     {
         public function __construct(
-            private string $domain,
-            private string $certificateArn,
-            private string $status,
+            private readonly string $domain,
+            private readonly string $certificateArn,
+            private readonly string $status,
         ) {}
 
         public function __invoke(CommandInterface $cmd, $request)

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -220,6 +220,42 @@ it('does not create a new policy version when the deployer document is unchanged
     expect(array_column($captured, 'name'))->not->toContain('CreatePolicyVersion');
 });
 
+it('does not re-version the deployer policy when IAM returns the same document reordered (canonical compare)', function (): void {
+    // IAM round-trips a managed policy with reordered top-level keys, reordered
+    // statements, and single-element Action lists collapsed to bare scalars. The
+    // old naive json_encode string compare read all of that as drift and created a
+    // fresh version on every sync (LPX-670); the canonical compare must see it as
+    // in-sync and write nothing.
+    manifestWithDeployer();
+
+    $desired = (new DeployerPolicy())->document();
+
+    $reordered = [
+        // Top-level key order flipped (Statement before Version) and the statement
+        // list reversed — both order-only changes IAM is free to make on read-back.
+        'Statement' => collect(array_reverse($desired['Statement']))
+            ->map(function (array $statement): array {
+                // Collapse any single-element Action list to a scalar, as IAM does.
+                if (is_array($statement['Action']) && count($statement['Action']) === 1) {
+                    $statement['Action'] = $statement['Action'][0];
+                }
+
+                return $statement;
+            })
+            ->all(),
+        'Version' => $desired['Version'],
+    ];
+
+    $captured = [];
+    bindRoutedIamClient([
+        'ListPolicies' => new Result(['Policies' => [existingDeployerPolicy()]]),
+        'GetPolicyVersion' => new Result(['PolicyVersion' => ['Document' => rawurlencode(json_encode($reordered))]]),
+    ], $captured);
+
+    expect((new SyncDeployerPolicyStep())([]))->toBe(StepResult::SYNCED);
+    expect(array_column($captured, 'name'))->not->toContain('CreatePolicyVersion');
+});
+
 it('reconciles the deployer policy by creating a new default version when it drifts', function (): void {
     manifestWithDeployer();
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Two related fixes that stop a `sync` step from reporting drift forever when nothing changed (the LPX-646 symptom class), in two different resources. Both ride on this one PR.

**What problems are you solving?**

- **`:443` listener always-syncs (solo path).** `SyncHttpsListenerStep::hasCertificate()` checked whether the app's cert was attached by reading `DescribeListeners.Certificates` — which only ever returns the listener's single **default** cert. The app's cert is attached as an **SNI** cert (`DescribeListenerCertificates`), so for any app that wasn't the listener's creator the check read it as missing on every sync: `WOULD_SYNC` forever in the plan (trips the confirm gate), and an idempotent `addListenerCertificates` on apply that never changes the default → a closed loop. Fixed by routing through `ElbV2::listenerCertificate()` (the `DescribeListenerCertificates` helper the tenant path already uses), and recording the change before the dry-run guard so a genuinely-missing cert survives the apply-prune. Distinct from [LPX-669](https://linear.app/codinglabsau/issue/LPX-669) (the multi-tenant cert-attach), still open.
- **[LPX-670](https://linear.app/codinglabsau/issue/LPX-670): managed IAM policy-doc compare.** `SynchronisesPolicyDocument` (DeployerPolicy, EcsTaskPolicy) compared live vs desired with a naive string match, while its sibling `SynchronisesAssumeRolePolicy` already canonicalises first — because IAM reorders keys/statements and collapses single-element `Action`/`Condition` lists to scalars. The first reordered read-back would create a new policy version on every sync, burning the 5-version cap. Fixed by extracting a shared `CanonicalisesPolicyDocuments` trait and switching the managed-policy path onto it.

**Is there anything the reviewer needs to know to deploy this?**

- No infra is mutated by the change itself and there's no migration — it only changes what `sync` reports and writes. After merge, the next `yolo sync` on a deployed app stops re-reporting the `:443` listener cert; the IAM change is latent (prevents future version-churn, no behavioural change on an already-clean policy).
- Canonicalisation is strictly more lenient than a string compare (collapses only AWS's legitimate equivalences), so it can only reduce spurious re-versioning, never miss real drift.
- New tests: `SyncHttpsListenerStepTest` (in-sync when the cert is SNI even though the listener default differs — the regression-locking case; drift → write on apply; skip with no domain) and a `DeployerStepsTest` reordered/collapsed-but-equal fixture. Full suite green (678), Pint · Rector · PHPStan (L5) clean. No public surface change, so no docs update.

🤖 Generated with [Claude Code](https://claude.ai/code)