### PR TITLE
fix(sync): preserve the deployed image in task-def reconcile (stop :latest churn)

### DIFF
--- a/src/Steps/Sync/App/SyncTaskDefinitionStep.php
+++ b/src/Steps/Sync/App/SyncTaskDefinitionStep.php
@@ -34,6 +34,7 @@ class SyncTaskDefinitionStep implements Step
     public function __invoke(array $options): StepResult
     {
         $dryRun = (bool) Arr::get($options, 'dry-run');
+        $live = $this->liveTaskDefinition((new EcsService($this->group()))->name());
 
         try {
             $desired = static::payload($this->group());
@@ -51,7 +52,16 @@ class SyncTaskDefinitionStep implements Step
             throw $e;
         }
 
-        $live = $this->liveTaskDefinition($desired['family']);
+        // Which image runs is `yolo deploy`'s call, not sync's. Deploy pins the app
+        // version (repo:<version>); sync would otherwise render repo:latest and so
+        // re-register a throwaway revision on every run after a deploy (the image
+        // tag is the only field that differs) — and that revision, if ever adopted,
+        // would swap the running image to :latest. So preserve the live revision's
+        // image: a no-op deploy→sync renders an identical document, and a genuine
+        // infra-field change still re-registers carrying the deployed image.
+        if ($live !== null && isset($live['containerDefinitions'][0]['image'])) {
+            $desired['containerDefinitions'][0]['image'] = $live['containerDefinitions'][0]['image'];
+        }
 
         // The registered revision already renders the desired payload — nothing to
         // do, so the step is pruned before apply and a clean app reports "Already

--- a/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
@@ -198,3 +198,41 @@ it('ignores AWS-derived enrichment fields when diffing (no phantom drift)', func
     expect((new SyncTaskDefinitionStep())([]))->toBe(StepResult::SYNCED);
     expect(array_column($captured, 'name'))->not->toContain('RegisterTaskDefinition');
 });
+
+it('does not re-register when only the image tag differs (deploy pinned a version)', function (): void {
+    // deploy registers the revision with a versioned image (repo:<version>); sync
+    // must reuse that image instead of rendering repo:latest, so a no-op deploy→sync
+    // is in sync rather than churning a throwaway revision on every run.
+    $live = liveTaskDefinition();
+    $live['containerDefinitions'][0]['image'] = '111111111111.dkr.ecr.ap-southeast-2.amazonaws.com/my-app:26.21.2.1500';
+
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => $live]),
+    ], $captured);
+
+    $step = new SyncTaskDefinitionStep();
+    expect($step(['dry-run' => true]))->toBe(StepResult::SYNCED);
+    expect($step->changes())->toBeEmpty();
+    expect(array_column($captured, 'name'))->not->toContain('RegisterTaskDefinition');
+});
+
+it('preserves the deployed image when re-registering for a genuine infra change', function (): void {
+    // A real field drifted (cpu) AND the live revision runs a deployed version — the
+    // new revision must carry that deployed image, never silently swap to :latest.
+    $live = liveTaskDefinition(['cpu' => '9999']);
+    $live['containerDefinitions'][0]['image'] = '111111111111.dkr.ecr.ap-southeast-2.amazonaws.com/my-app:26.21.2.1500';
+
+    $captured = [];
+    bindRoutedEcsClient([
+        'DescribeTaskDefinition' => new Result(['taskDefinition' => $live]),
+    ], $captured);
+
+    expect((new SyncTaskDefinitionStep())([]))->toBe(StepResult::SYNCED);
+
+    $register = collect($captured)->firstWhere('name', 'RegisterTaskDefinition');
+    expect($register)->not->toBeNull()
+        ->and($register['args']['cpu'])->toBe('1024')
+        ->and($register['args']['containerDefinitions'][0]['image'])
+        ->toBe('111111111111.dkr.ecr.ap-southeast-2.amazonaws.com/my-app:26.21.2.1500');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

`yolo sync` wanted to register a new task-definition revision on **every run after a deploy**, even with zero real changes — the `app · Sync task definition: revision N → new revision` line that shows up on every plan.

Root cause: `yolo deploy` pins the deployed app version into the task def (`repo:<version>`), but the sync reconcile rendered `repo:latest`. The image tag was then the *only* field that differed from the live revision, so `matchesDesired()` always saw drift. The churn was:

- **inert but noisy** — sync never re-points the running service (task-def adoption is deploy's job; `EcsService::updatePayload()` doesn't send `taskDefinition`), so it never changed what's running, but it masked genuine drift in `--check`
- **litter** — a throwaway revision per sync, and `:latest` becoming the *latest active* revision, diverging from the deployed version actually running (a latent foot-gun if anything ever adopted "latest revision of the family")

**Summary of changes**

- `SyncTaskDefinitionStep` now **preserves the live revision's image** when reconciling, instead of rendering `repo:latest`. Deploy stays the sole owner of which image runs.
- A no-op `deploy → sync` now renders an identical document → `SYNCED`, no new revision.
- A genuine infra-field change (cpu / memory / role / logging / command / stopTimeout) still re-registers — and the new revision carries the **deployed** image, never silently `:latest`.
- Greenfield (no live revision yet) keeps the `repo:latest` fallback.
- Covers web, queue and scheduler families (they share the base step).
- 2 new tests; 690 Pest green, PHPStan L5 / Rector / Pint clean.

**Is there anything the reviewer needs to know to deploy this?**

- **No behaviour change to `yolo deploy`** — it still pins `repo:<app-version>` and owns image adoption. This only changes what `sync` *renders* and *compares*.
- **Self-converging on existing apps:** the first sync after this lands reuses whatever image the latest live revision already runs (including a `:latest` revision left by a pre-fix sync), so the churn simply stops — no manual cleanup of old throwaway revisions required (they age out as ECS prunes inactive revisions).
- Purely a `sync`-plan/reconcile change — no manifest keys, command args, or runtime/container changes.

🤖 Generated with [Claude Code](https://claude.ai/code)
