### PR TITLE
chore: reword test comments to drop internal identifiers

### DIFF
--- a/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
+++ b/tests/Unit/Resources/CloudFront/AssetDistributionTest.php
@@ -109,7 +109,7 @@ it('sees no drift when the live behaviour already carries the managed fields', f
 });
 
 it('sees drift on a distribution still using the Origin-keyed cache policy', function (): void {
-    // Shape of the live CL distribution before the fix: custom Origin-in-key
+    // Shape of a live distribution from before the fix: custom Origin-in-key
     // cache policy, CORS-S3Origin origin-request policy forwarding Origin, no
     // response-headers policy. Reconciling must flip all three.
     $preFix = [

--- a/tests/Unit/Resources/Fargate/TargetGroupTest.php
+++ b/tests/Unit/Resources/Fargate/TargetGroupTest.php
@@ -102,8 +102,8 @@ it('lets the manifest override each health-check field', function (): void {
 });
 
 it('reconciles a target group still on the old aggressive health-check defaults to the tolerant ones', function (): void {
-    // CL's live target group sits on the pre-tolerance values (5s timeout, 3
-    // unhealthy). A plain `yolo sync` must drag it onto the new defaults via
+    // A live target group from before the tolerance change sits on the old
+    // values (5s timeout, 3 unhealthy). A plain `yolo sync` must drag it onto the new defaults via
     // ModifyTargetGroup — the health check is reconciled, not create-only.
     $recorder = bindRecordingElbV2Client(
         liveTargetGroup(['HealthCheckTimeoutSeconds' => 5, 'UnhealthyThresholdCount' => 3]),

--- a/tests/Unit/Resources/Iam/IamDescriptionsAreSafeTest.php
+++ b/tests/Unit/Resources/Iam/IamDescriptionsAreSafeTest.php
@@ -14,7 +14,7 @@ use Codinglabs\Yolo\Resources\Iam\MediaConvertRole;
  * with `ValidationError` at the API.
  *
  * Caught in the wild: a stray em dash in EcsTaskRole::description() killed a
- * green-field CL canary at sync:iam. This test guards every YOLO-authored IAM
+ * green-field sync on a fresh account at sync:iam. This test guards every YOLO-authored IAM
  * description against the same class of bug.
  */
 const IAM_DESCRIPTION_PATTERN = '/^[\x{0009}\x{000A}\x{000D}\x{0020}-\x{007E}\x{00A1}-\x{00FF}]*$/u';

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -291,7 +291,7 @@ it('reconciles the deployer role trust policy when the env ref changes', functio
 });
 
 it('records deployer trust drift on the plan pass so the step survives the prune', function (): void {
-    // Regression (the convict `tag: true` OIDC failure): the trust rewrite used to
+    // Regression (a real `tag: true` OIDC failure): the trust rewrite used to
     // happen only under `! dry-run` and recorded no Change, so the plan pass saw a
     // clean step, the only-pending-steps filter pruned it before apply, and a
     // role created on `main` could never be self-healed to `refs/tags/*`. The drift


### PR DESCRIPTION
## Summary
Rewords four test comments that referenced specific live deployments, replacing them with generic descriptions of the same scenario. No behaviour or assertion changes — comments only.

- `tests/Unit/Resources/Fargate/TargetGroupTest.php` — "a live target group from before the tolerance change"
- `tests/Unit/Steps/Iam/DeployerStepsTest.php` — "a real `tag: true` OIDC failure"
- `tests/Unit/Resources/Iam/IamDescriptionsAreSafeTest.php` — "a green-field sync on a fresh account"
- `tests/Unit/Resources/CloudFront/AssetDistributionTest.php` — "a live distribution from before the fix"

## Anything the reviewer needs to know
Zero production impact — test comments only, no code or assertion changes. Deliberately left alone: "web ACL's" (Access Control List), the package namespace, example domains, bare ticket IDs, and Laravel Vapor interop references.

## Test plan
- [x] `./vendor/bin/pint` clean
- [x] `./vendor/bin/pest` — 720 passed (1844 assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)