### PR TITLE
refactor: drop two dead methods left after the bucket rework

### DIFF
--- a/src/Aws.php
+++ b/src/Aws.php
@@ -304,24 +304,6 @@ class Aws
     }
 
     /**
-     * Synchronise tags on an ACM certificate, addressed by its ARN.
-     *
-     * @return array<string, string>
-     */
-    public static function synchroniseAcmTags(string $arn, array $tags, bool $apply): array
-    {
-        return static::reconcileTags(
-            $tags,
-            fn () => static::acm()->listTagsForCertificate(['CertificateArn' => $arn])['Tags'] ?? [],
-            fn (array $missing) => static::acm()->addTagsToCertificate([
-                'CertificateArn' => $arn,
-                'Tags' => static::keyValueTags($missing),
-            ]),
-            $apply,
-        );
-    }
-
-    /**
      * Synchronise tags on a Route 53 hosted zone. The zone Id comes back from
      * listHostedZones prefixed (`/hostedzone/Z123`); the tagging API wants the
      * bare id, and adds tags under `AddTags` rather than `Tags`.

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -161,11 +161,6 @@ class Manifest
         return Arr::has(static::current()['environments'][Helpers::environment()], $key);
     }
 
-    public static function doesntHave(string $key): bool
-    {
-        return ! static::has($key);
-    }
-
     public static function get(string $key, $default = null): mixed
     {
         if (! static::has($key)) {

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -17,7 +17,6 @@ describe('has and get', function (): void {
         writeManifest([]);
 
         expect(Manifest::has('region'))->toBeFalse();
-        expect(Manifest::doesntHave('region'))->toBeTrue();
     });
 
     it('gets values with defaults', function (): void {


### PR DESCRIPTION
Pure deletion — the last two zero-caller methods found in a dead-code audit against `main`:

- **`Aws::synchroniseAcmTags()`** — no callers in src or tests. `SslCertificate` sets its tags at request time and never reconciles them, so the ACM tag-sync helper was orphaned.
- **`Manifest::doesntHave()`** — its only caller was its own test, which kept it green; the test assertion goes with it.

Rector clean, Pint passed, PHPStan level 5 clean, 730 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)