### PR TITLE
fix: SyncTypesenseKeyStep broke the new-step-with-environment contract

### DIFF
--- a/src/Steps/Sync/App/SyncTypesenseKeyStep.php
+++ b/src/Steps/Sync/App/SyncTypesenseKeyStep.php
@@ -41,7 +41,7 @@ class SyncTypesenseKeyStep implements Step
 {
     use RecordsChanges;
 
-    public function __construct(protected ?Client $http = null) {}
+    public function __construct(protected string $environment, protected ?Client $http = null) {}
 
     public function __invoke(array $options): StepResult
     {

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -69,7 +69,9 @@ it('constructs every declared step with just the environment string', function (
         ->merge((new ReflectionProperty(BuildCommand::class, 'fargateSteps'))->getValue($build))
         ->merge((new DeployCommand())->steps())
         ->unique()
-        ->each(fn (string $stepName) => expect(new $stepName('testing'))->toBeInstanceOf(Step::class));
+        ->each(function (string $stepName): void {
+            expect(new $stepName('testing'))->toBeInstanceOf(Step::class);
+        });
 })->with([
     'solo web app' => [['domain' => 'codinglabs.com.au', 'tasks' => ['web' => []]]],
     'multi-tenant app' => [['tenants' => ['alpha' => []]]],

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -3,9 +3,12 @@
 use Codinglabs\Yolo\Steps;
 use Codinglabs\Yolo\Helpers;
 use Illuminate\Support\Collection;
+use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Steps\TenantStep;
 use Codinglabs\Yolo\Commands\SyncCommand;
+use Codinglabs\Yolo\Commands\BuildCommand;
+use Codinglabs\Yolo\Commands\DeployCommand;
 use Codinglabs\Yolo\Commands\SyncAppCommand;
 use Symfony\Component\Console\Input\ArrayInput;
 use Codinglabs\Yolo\Commands\SyncSteppedCommand;
@@ -50,6 +53,27 @@ class CollationFakeTenantStep extends TenantStep
         return StepResult::CREATED;
     }
 }
+
+it('constructs every declared step with just the environment string', function (array $manifest): void {
+    // Step collation instantiates every declared step as `new $step($environment)`
+    // (collateSteps / extractSteps), so a step constructor must take the environment
+    // first with everything after it optional. A step taking a different first
+    // parameter fatals on the very first run of its command before the plan starts.
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2'] + $manifest);
+
+    $build = new BuildCommand();
+
+    collect((new SyncCommand())->scopes())
+        ->flatten()
+        ->merge($build->steps())
+        ->merge((new ReflectionProperty(BuildCommand::class, 'fargateSteps'))->getValue($build))
+        ->merge((new DeployCommand())->steps())
+        ->unique()
+        ->each(fn (string $stepName) => expect(new $stepName('testing'))->toBeInstanceOf(Step::class));
+})->with([
+    'solo web app' => [['domain' => 'codinglabs.com.au', 'tasks' => ['web' => []]]],
+    'multi-tenant app' => [['tenants' => ['alpha' => []]]],
+]);
 
 it('orchestrates the three scopes in order — account → environment → app', function (): void {
     writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);

--- a/tests/Unit/Steps/Environment/TypesenseEdgesTest.php
+++ b/tests/Unit/Steps/Environment/TypesenseEdgesTest.php
@@ -82,7 +82,7 @@ it('leaves an already-minted app key alone', function (): void {
         'GetObject' => new Result(['Body' => "TYPESENSE_API_KEY=already-minted\n"]),
     ], $captured);
 
-    expect((new SyncTypesenseKeyStep())([]))->toBe(StepResult::SYNCED);
+    expect((new SyncTypesenseKeyStep('testing'))([]))->toBe(StepResult::SYNCED);
     expect(array_column($captured, 'name'))->not->toContain('PutObject');
 });
 
@@ -101,12 +101,12 @@ it('plans the mint without any HTTP call, and mints + persists on apply', functi
         new Response(201, [], (string) json_encode(['value' => 'scoped-key'])),
     ]);
 
-    $planned = new SyncTypesenseKeyStep(new Client(['handler' => HandlerStack::create($guzzle)]));
+    $planned = new SyncTypesenseKeyStep('testing', new Client(['handler' => HandlerStack::create($guzzle)]));
     expect($planned(['dry-run' => true]))->toBe(StepResult::WOULD_CREATE);
     expect($planned->changes())->not->toBeEmpty();
     expect($guzzle->count())->toBe(1); // nothing consumed on the plan
 
-    $step = new SyncTypesenseKeyStep(new Client(['handler' => HandlerStack::create($guzzle)]));
+    $step = new SyncTypesenseKeyStep('testing', new Client(['handler' => HandlerStack::create($guzzle)]));
     expect($step([]))->toBe(StepResult::CREATED);
 
     $put = collect($captured)->firstWhere('name', 'PutObject');
@@ -125,6 +125,6 @@ it('skips the mint with instructions while the cluster is not provisioned yet', 
 
     Prompt::fake();
 
-    expect((new SyncTypesenseKeyStep())([]))->toBe(StepResult::SKIPPED);
+    expect((new SyncTypesenseKeyStep('testing'))([]))->toBe(StepResult::SKIPPED);
     expect(Prompt::content())->toContain('not provisioned yet');
 });


### PR DESCRIPTION
## The bug

`yolo sync <env>` fatals immediately on any install carrying #114:

```
TypeError: SyncTypesenseKeyStep::__construct(): Argument #1 ($http) must be of type ?GuzzleHttp\Client, string given
```

Step collation (`collateSteps()` / `extractSteps()`) instantiates every declared step as `new $step($environment)`. The convention everywhere else is `__construct(protected string $environment, ...optionals)` — or no constructor at all, where PHP silently absorbs the extra arg. `SyncTypesenseKeyStep` shipped with the test-injectable Guzzle client as its **first** argument, so the environment string landed on a `?Client` parameter.

## The fix

- Environment first, client second: `__construct(protected string $environment, protected ?Client $http = null)`
- Updated the step's tests to pass the environment through

## The pin

Nothing enforced the constructor contract, so this could ship again with the next injectable collaborator. New collation test constructs **every** step reachable from `SyncCommand::scopes()`, `BuildCommand` (base + fargate lists) and `DeployCommand` with just the environment string, in both solo and multi-tenant modes — the old signature fails it.

## Validation

- 889 tests green, PHPStan L5 clean, Pint clean
- The new test fails against the pre-fix constructor

🤖 Generated with [Claude Code](https://claude.com/claude-code)