### PR TITLE
fix: scaffold redis + excimer from pinned GitHub tags, not PECL aliases

### DIFF
--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -13,8 +13,14 @@ FROM dunglas/frankenphp:1-php8.4-alpine
 
 # supercronic runs the scheduler's cron as a non-root user (busybox crond can't);
 # nodejs is the runtime for Inertia SSR (tasks.web.ssr) — drop it if you don't use SSR.
+# redis and excimer install from pinned GitHub tags rather than their PECL aliases —
+# pecl.php.net (the aliases' source) times out routinely. ADD clones the phpredis
+# tag with submodules (the tag tarball is missing liblzf), and the installer
+# accepts the clone as a source path.
+ADD https://github.com/phpredis/phpredis.git#6.3.0 /usr/src/phpredis
 RUN apk add --no-cache git supervisor supercronic nodejs \
-    && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache excimer
+    && install-php-extensions intl pcntl bcmath /usr/src/phpredis pdo_mysql opcache wikimedia/php-excimer@1.2.6 \
+    && rm -rf /usr/src/phpredis
 
 WORKDIR /app
 

--- a/stubs/Dockerfile.stub
+++ b/stubs/Dockerfile.stub
@@ -9,8 +9,14 @@ FROM dunglas/frankenphp:1-php8.4-alpine
 
 # supercronic runs the scheduler's cron as a non-root user (busybox crond can't);
 # nodejs is the runtime for Inertia SSR (tasks.web.ssr) — drop it if you don't use SSR.
+# redis and excimer install from pinned GitHub tags rather than their PECL aliases —
+# pecl.php.net (the aliases' source) times out routinely. ADD clones the phpredis
+# tag with submodules (the tag tarball is missing liblzf), and the installer
+# accepts the clone as a source path.
+ADD https://github.com/phpredis/phpredis.git#6.3.0 /usr/src/phpredis
 RUN apk add --no-cache git supervisor supercronic nodejs \
-    && install-php-extensions intl pcntl bcmath redis pdo_mysql opcache excimer
+    && install-php-extensions intl pcntl bcmath /usr/src/phpredis pdo_mysql opcache wikimedia/php-excimer@1.2.6 \
+    && rm -rf /usr/src/phpredis
 
 WORKDIR /app
 


### PR DESCRIPTION
## Why

`pecl.php.net` (both the REST resolver and the `/get` download endpoint) times out routinely — tonight it 504'd for over an hour, failing image builds at `install-php-extensions` for any app whose apk layer wasn't cached. PECL is also mid-sunset upstream, so this gets worse, not better.

## What

The scaffolded Dockerfile pins the two PECL-alias extensions to GitHub sources:

- **redis** — BuildKit `ADD https://github.com/phpredis/phpredis.git#6.3.0` (a git clone **with submodules** — the codeload tag tarball is missing `liblzf/`, so the plain `owner/repo@tag` short form fails the installer's packaging validation), then handed to `install-php-extensions` as a source path.
- **excimer** — `wikimedia/php-excimer@1.2.6` short form (no submodules, `package.xml` at root).

Both pins are deterministic: same input, same image, every build — no dependency on what PECL calls "latest stable" on the day.

`docs/guide/images.md` updated to match (it quotes the scaffolded Dockerfile verbatim).

## Validation

- The exact pattern deployed green to production end-to-end (build → gate → rollout) after the PECL alias and the tag-tarball variants both failed.
- BuildKit `ADD git#tag` submodule behaviour verified directly: the resulting context contains `liblzf/`.
- 895 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)