### PR TITLE
feat: --json machine-readable read surface (status + audit)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -212,7 +212,7 @@ Once the rollout settles, `deploy` prints a recap — the same per-group summary
 Show a live dashboard of the app's running state for an environment — what each service group is running, its current load, scaling configuration, and any deploy in progress.
 
 ```bash
-yolo status <environment> [--snapshot]
+yolo status <environment> [--snapshot] [--json]
 ```
 
 | Argument | Required | Description |
@@ -222,6 +222,7 @@ yolo status <environment> [--snapshot]
 | Option | Value | Default | Description |
 |---|---|---|---|
 | `--snapshot` | flag | off | Render one frame and exit instead of running the live dashboard. |
+| `--json` | flag | off | Emit the status as JSON (`{app, environment, groups}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if a deployment is currently failed. |
 
 The dashboard has three panels, read live from ECS, Application Auto Scaling and CloudWatch:
 
@@ -231,7 +232,7 @@ The dashboard has three panels, read live from ECS, Application Auto Scaling and
 
 Below the panels is a clickable deep link to the app's CloudWatch dashboard for the full metrics view.
 
-By default it **polls and redraws until you quit** (Ctrl-C), picking up any deploy that starts while it's open — so it doubles as a live deploy watch. `--snapshot` (and any non-interactive shell) renders a single frame and exits instead, returning a non-zero exit code if a deployment is currently failed.
+By default it **polls and redraws until you quit** (Ctrl-C), picking up any deploy that starts while it's open — so it doubles as a live deploy watch. `--snapshot` (and any non-interactive shell) renders a single frame and exits instead, returning a non-zero exit code if a deployment is currently failed. `--json` emits the same live state as a structured payload rather than the dashboard — the machine-readable contract the `/yolo` skill (and any script) consumes.
 
 ---
 
@@ -387,7 +388,7 @@ When a [`tasks.web.autoscaling`](/reference/manifest#tasks-web-autoscaling) bloc
 Audit YOLO-tagged resources for an environment (account → environment → app) and flag anything not accounted for. Read-only.
 
 ```bash
-yolo audit <environment> [--unexpected]
+yolo audit <environment> [--unexpected] [--json]
 ```
 
 | Argument | Required | Description |
@@ -397,6 +398,7 @@ yolo audit <environment> [--unexpected]
 | Option | Value | Description |
 |---|---|---|
 | `--unexpected` | flag | Only show unexpected resources — anything not accounted for by YOLO. |
+| `--json` | flag | Emit the audit as JSON (`{environment, liveApps, okCount, unexpectedCount, resources}`) and exit — machine-readable for the `/yolo` skill and scripts. Honours the same scope and `--unexpected` filtering as the table. |
 
 Queries the Resource Groups Tagging API for everything tagged `yolo:environment=<env>` and classifies each resource as **`ok`** or **`unexpected`**, with a **Reason** explaining each unexpected row — `no ownership tag`, `service no longer provisioned`, or `app cluster gone` (see [Provisioning › Auditing](/guide/provisioning#auditing-what-s-deployed)). Audit is an ownership/inventory check; it does not inspect a resource's configuration (that's `sync`'s job). Results are grouped by scope, unexpected-first within a scope, with clickable AWS Console links where the terminal supports them.
 

--- a/src/Commands/AbstractAuditCommand.php
+++ b/src/Commands/AbstractAuditCommand.php
@@ -30,7 +30,8 @@ abstract class AbstractAuditCommand extends Command
     {
         $this
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
-            ->addOption('unexpected', null, InputOption::VALUE_NONE, 'Only show unexpected resources (anything not accounted for by YOLO)');
+            ->addOption('unexpected', null, InputOption::VALUE_NONE, 'Only show unexpected resources (anything not accounted for by YOLO)')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit the audit as JSON and exit (machine-readable; for the /yolo skill and scripts)');
     }
 
     public function handle(): int
@@ -42,6 +43,10 @@ abstract class AbstractAuditCommand extends Command
         ]);
 
         $report = Audit::classify($tagged, $this->liveApps($environment));
+
+        if ($this->option('json')) {
+            return $this->renderJson($report, $environment);
+        }
 
         return $this->render($report, $environment);
     }
@@ -120,6 +125,51 @@ abstract class AbstractAuditCommand extends Command
         ));
 
         return self::SUCCESS;
+    }
+
+    /**
+     * The machine-readable form for `--json` consumers (the `/yolo` skill,
+     * scripts): the same scope-filtered + `--unexpected`-filtered rows the table
+     * would show, plus the environment, live apps and counts derived from those
+     * rows — so the payload is internally consistent (unlike the human note,
+     * which prints the env-wide totals alongside a filtered table).
+     *
+     * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, unexpectedCount: int}  $report
+     */
+    protected function renderJson(array $report, string $environment): int
+    {
+        $rows = $this->filtered($report['resources']);
+
+        $this->output->writeln((string) json_encode([
+            'environment' => $environment,
+            'liveApps' => array_values($report['liveApps']),
+            'okCount' => $rows->where('status', Audit::STATUS_OK)->count(),
+            'unexpectedCount' => $rows->where('status', Audit::STATUS_UNEXPECTED)->count(),
+            'resources' => static::auditJsonRows($rows->all()),
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Flatten audit resource rows to the clean machine shape (a stable subset of
+     * keys, `app`/`reason`/`arn` defaulting to null). Pure — unit-tested directly
+     * with hand-built rows, no AWS.
+     *
+     * @param  array<int, array<string, mixed>>  $resources
+     * @return array<int, array<string, mixed>>
+     */
+    public static function auditJsonRows(array $resources): array
+    {
+        return array_map(static fn (array $resource): array => [
+            'scope' => $resource['scope'],
+            'status' => $resource['status'],
+            'type' => $resource['type'],
+            'name' => $resource['name'],
+            'app' => $resource['app'] ?? null,
+            'reason' => $resource['reason'] ?? null,
+            'arn' => $resource['arn'] ?? null,
+        ], $resources);
     }
 
     /**

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -17,11 +17,27 @@ class StatusCommand extends Command
             ->setName('status')
             ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
             ->addOption('snapshot', null, InputOption::VALUE_NONE, 'Render once and exit instead of running the live dashboard')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit the status as JSON and exit (machine-readable; for the /yolo skill and scripts)')
             ->setDescription("Show a live dashboard of the app's services, load, scaling and any in-progress deploy");
     }
 
     public function handle(): int
     {
+        // `--json` is the machine-readable contract the /yolo skill consumes: gather
+        // once, emit the structured payload, and exit non-zero if a deploy is failed
+        // so it stays scriptable. No dashboard, regardless of interactivity.
+        if ($this->option('json')) {
+            $statuses = static::gatherServiceStatuses();
+
+            $this->output->writeln((string) json_encode([
+                'app' => Manifest::current()['name'] ?? null,
+                'environment' => $this->argument('environment'),
+                'groups' => static::jsonStatuses($statuses),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return static::anyDeploymentFailed($statuses) ? 1 : 0;
+        }
+
         // A snapshot (or a non-interactive shell, where a redraw loop is pointless)
         // renders one frame and exits non-zero if a deployment is currently failed.
         if ($this->option('snapshot') || ! $this->input->isInteractive()) {

--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -225,6 +225,52 @@ trait RendersServiceStatus
     // --- Pure formatters (unit-tested directly) -----------------------------
 
     /**
+     * The machine-readable form of the gathered status rows — a clean,
+     * JSON-serialisable shape for `--json` consumers (the `/yolo` skill and
+     * scripts). Pure: it flattens the gathered rows (a `ServerGroup` enum plus
+     * nested arrays) and drops the raw `primary` deployment blob, which carries
+     * DateTimeInterface timestamps that don't belong in the contract.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     * @return array<int, array<string, mixed>>
+     */
+    public static function jsonStatuses(array $statuses): array
+    {
+        return array_map(static::jsonStatus(...), $statuses);
+    }
+
+    /**
+     * @param  array<string, mixed>  $status
+     * @return array<string, mixed>
+     */
+    public static function jsonStatus(array $status): array
+    {
+        return [
+            'group' => $status['group']->value,
+            'exists' => (bool) $status['exists'],
+            'tasks' => [
+                'running' => (int) $status['running'],
+                'desired' => (int) $status['desired'],
+                'pending' => (int) $status['pending'],
+            ],
+            'spec' => [
+                'cpu' => $status['cpu'],
+                'memory' => $status['memory'],
+                'launch' => $status['launch'],
+            ],
+            'revision' => $status['revision'],
+            'version' => $status['version'],
+            'rollout' => [
+                'state' => $status['rolloutState'],
+                'reason' => $status['rolloutReason'],
+            ],
+            'scaling' => $status['scaling'],
+            'cpuTarget' => $status['cpuTarget'],
+            'load' => $status['load'],
+        ];
+    }
+
+    /**
      * FARGATE / SPOT from a service's launch type or capacity-provider strategy.
      *
      * @param  array<string, mixed>  $service

--- a/tests/Unit/Commands/AuditJsonTest.php
+++ b/tests/Unit/Commands/AuditJsonTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Audit\Audit;
+use Codinglabs\Yolo\Commands\AuditCommand;
+
+// The `--json` audit output is built by a pure row-flattener on
+// AbstractAuditCommand (reached here through AuditCommand). It takes the
+// already-classified + scope-filtered rows, so it can be pinned with plain
+// arrays — no Resource Groups Tagging API or ECS mocking.
+
+it('flattens audit resource rows into a clean, encodable machine shape', function (): void {
+    $rows = [
+        [
+            'scope' => Audit::SCOPE_APP,
+            'status' => Audit::STATUS_OK,
+            'type' => 'ecs',
+            'name' => 'yolo-prod-app-web',
+            'app' => 'app',
+            'reason' => null,
+            'arn' => 'arn:aws:ecs:ap-southeast-2:111111111111:service/yolo-prod/yolo-prod-app-web',
+        ],
+        // A shared resource with no `yolo:app` owner (no 'app' key) and a reason.
+        [
+            'scope' => Audit::SCOPE_ENV,
+            'status' => Audit::STATUS_UNEXPECTED,
+            'type' => 'dynamodb',
+            'name' => 'sessions',
+            'reason' => Audit::REASON_UNMANAGED_SERVICE,
+            'arn' => 'arn:aws:dynamodb:ap-southeast-2:111111111111:table/sessions',
+        ],
+    ];
+
+    $json = AuditCommand::auditJsonRows($rows);
+
+    expect($json)->toBe([
+        [
+            'scope' => 'app',
+            'status' => 'ok',
+            'type' => 'ecs',
+            'name' => 'yolo-prod-app-web',
+            'app' => 'app',
+            'reason' => null,
+            'arn' => 'arn:aws:ecs:ap-southeast-2:111111111111:service/yolo-prod/yolo-prod-app-web',
+        ],
+        [
+            'scope' => 'env',
+            'status' => 'unexpected',
+            'type' => 'dynamodb',
+            'name' => 'sessions',
+            'app' => null,
+            'reason' => 'service no longer provisioned',
+            'arn' => 'arn:aws:dynamodb:ap-southeast-2:111111111111:table/sessions',
+        ],
+    ]);
+
+    expect(json_encode($json))->toBeJson();
+});
+
+it('returns an empty list when there are no resources', function (): void {
+    expect(AuditCommand::auditJsonRows([]))->toBe([]);
+});

--- a/tests/Unit/Commands/StatusCommandTest.php
+++ b/tests/Unit/Commands/StatusCommandTest.php
@@ -129,3 +129,78 @@ it('reads the launch type, defaulting to FARGATE and detecting Spot', function (
     ]))->toBe('SPOT');
     expect(StatusCommand::launchType([]))->toBe('FARGATE');
 });
+
+it('serialises gathered status rows into a clean, encodable json shape', function (): void {
+    $statuses = [
+        [
+            'group' => ServerGroup::WEB,
+            'exists' => true,
+            'running' => 2,
+            'desired' => 2,
+            'pending' => 0,
+            'launch' => 'FARGATE',
+            'cpu' => '512',
+            'memory' => '1024',
+            'revision' => 'web:42',
+            'version' => '20260605-1',
+            // The raw primary deployment blob carries DateTimeInterface timestamps;
+            // it must be dropped from the machine contract.
+            'primary' => ['createdAt' => new DateTimeImmutable('@1000')],
+            'rolloutState' => 'COMPLETED',
+            'rolloutReason' => null,
+            'scaling' => ['min' => 1, 'max' => 4, 'policies' => [['metric' => 'ECSServiceAverageCPUUtilization', 'target' => 65.0]]],
+            'cpuTarget' => 65.0,
+            'load' => ['cpu' => 43.2, 'memory' => 38.0, 'requests' => 410.0, 'response' => 0.126],
+        ],
+    ];
+
+    $json = StatusCommand::jsonStatuses($statuses);
+
+    expect($json)->toBe([
+        [
+            'group' => 'web',
+            'exists' => true,
+            'tasks' => ['running' => 2, 'desired' => 2, 'pending' => 0],
+            'spec' => ['cpu' => '512', 'memory' => '1024', 'launch' => 'FARGATE'],
+            'revision' => 'web:42',
+            'version' => '20260605-1',
+            'rollout' => ['state' => 'COMPLETED', 'reason' => null],
+            'scaling' => ['min' => 1, 'max' => 4, 'policies' => [['metric' => 'ECSServiceAverageCPUUtilization', 'target' => 65.0]]],
+            'cpuTarget' => 65.0,
+            'load' => ['cpu' => 43.2, 'memory' => 38.0, 'requests' => 410.0, 'response' => 0.126],
+        ],
+    ]);
+
+    // No raw deployment blob, and the payload encodes to valid JSON cleanly.
+    expect($json[0])->not->toHaveKey('primary');
+    expect(json_encode($json))->toBeJson();
+});
+
+it('serialises a not-yet-deployed group without choking on null spec', function (): void {
+    $statuses = [[
+        'group' => ServerGroup::QUEUE,
+        'exists' => false,
+        'running' => 0,
+        'desired' => 0,
+        'pending' => 0,
+        'launch' => 'FARGATE',
+        'cpu' => null,
+        'memory' => null,
+        'revision' => null,
+        'version' => null,
+        'primary' => null,
+        'rolloutState' => null,
+        'rolloutReason' => null,
+        'scaling' => null,
+        'cpuTarget' => null,
+        'load' => ['cpu' => null, 'memory' => null, 'requests' => null, 'response' => null],
+    ]];
+
+    expect(StatusCommand::jsonStatuses($statuses)[0])->toMatchArray([
+        'group' => 'queue',
+        'exists' => false,
+        'spec' => ['cpu' => null, 'memory' => null, 'launch' => 'FARGATE'],
+        'scaling' => null,
+        'rollout' => ['state' => null, 'reason' => null],
+    ]);
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- YOLO's read commands (`status`, `audit`) only render human ANSI tables — there's no machine-readable output, so anything programmatic (an agent/skill, or a script) has to screen-scrape. This adds a uniform `--json` flag across the read surface so YOLO state can be consumed as structured data.

**Is there anything the reviewer needs to know to deploy this?**
- **Read-only, additive, zero production impact.** It adds an output *flag*; existing human output and exit codes are unchanged when `--json` is absent.
- `status --json` emits `{app, environment, groups[]}` and stays scriptable (non-zero exit if a deploy is currently failed). `audit --json` (inherited by `audit:environment` / `audit:app`) emits `{environment, liveApps, okCount, unexpectedCount, resources[]}`, honouring the same scope + `--unexpected` filtering as the table.
- The serialisers are **pure static methods** (`RendersServiceStatus::jsonStatuses`, `AbstractAuditCommand::auditJsonRows`), unit-tested directly with hand-built rows — **no new AWS calls**. The raw primary-deployment blob (DateTimeInterface timestamps) is dropped from the contract.
- Gates: Pest (full suite green), Pint, PHPStan L5, Rector — all clean. CLI reference updated.

First slice of a broader direction — making the CLI a machine-readable read surface a Claude skill can consume. Follow-ups (scoped `status:*` namespace, `status:budget`, incident reads, `yolo rollback`) will land on this branch.

🤖 Generated with [Claude Code](https://claude.ai/code)
