### PR TITLE
yolo tui — interactive dashboard + yolo services surface (Outrun theme)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -47,6 +47,7 @@ export default defineConfig({
           { text: 'Domains', link: '/guide/domains' },
           { text: 'Multi-Tenancy', link: '/guide/multi-tenancy' },
           { text: 'Scaling', link: '/guide/scaling' },
+          { text: 'Interactive Dashboard', link: '/guide/tui' },
           { text: 'CI/CD', link: '/guide/ci-cd' },
         ],
       },

--- a/docs/guide/tui.md
+++ b/docs/guide/tui.md
@@ -1,0 +1,37 @@
+# Interactive Dashboard
+
+`yolo tui` opens a tabbed terminal UI over an environment — live status, the service gate, deployments and rollback, logs, and the manifest, all in one place. It adds no new powers: every action routes through the same commands you'd run by hand ([`status`](/reference/commands#yolo-status), [`services`](/reference/commands#yolo-services), [`rollback`](/reference/commands#yolo-rollback)). Think of it as the live cockpit on top of them.
+
+```bash
+yolo tui                # prompt for the environment
+yolo tui production     # straight in
+```
+
+With no argument it prompts for the environment (auto-selecting the only one when a manifest declares just one). It's interactive only — for a single frame in a script, use [`yolo status --snapshot`](/reference/commands#yolo-status).
+
+## The tabs
+
+| Tab | What it shows | Actions |
+|---|---|---|
+| **Status** | Per-group vitals, load, scaling, and any in-flight rollout — the same view [`status`](/reference/commands#yolo-status) renders | — |
+| **Services** | The two-key [service gate](/guide/provisioning#the-service-lifecycle): what's offered, which apps claim it, and its lifecycle state | <kbd>⏎</kbd> manage (add / edit / remove) |
+| **Deployments** | Recent deployments from ECR, the running version marked; live progress while a rollout is in flight | <kbd>⏎</kbd> roll back |
+| **Logs** | Recent CloudWatch logs for one service group | <kbd>g</kbd> cycle group |
+| **Manifest** | A read view of the environment manifest and the app's `yolo.yml` | — |
+
+A **global health bar** stays pinned at the top on every tab — one dot per group (web / queue / scheduler), green when healthy, red when down. When a deploy is in flight it flips to a rollout banner, **whoever triggered it** — your `yolo deploy` in another shell, CI, or the Deployments tab's own rollback. The dashboard reads that straight from ECS, so it's never out of step with what's actually rolling.
+
+## Navigating
+
+| Key | Does |
+|---|---|
+| <kbd>◂</kbd> <kbd>▸</kbd> / <kbd>Tab</kbd> | Previous / next tab |
+| <kbd>1</kbd>…<kbd>5</kbd> | Jump to a tab by number |
+| a tab's letter (`s` `v` `d` `l` `m`) | Jump straight to it |
+| <kbd>q</kbd> | Quit |
+
+When you trigger an action — managing a service, rolling back — the dashboard hands the screen to the prompt, you complete it, and the live view resumes.
+
+## Editing safely
+
+The dashboard never hides the destructive surface. Withdrawing a service offer is refused while a running app still claims it; a rollback warns that the database is not rolled back and defaults to *no*; both run the exact same guards as their standalone commands. Read-heavy tabs (Status, Logs, Manifest) make no changes at all.

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,6 +25,8 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`status <env>`](#yolo-status) | Live dashboard of services, load, scaling and any in-progress deploy |
 | [`run <env>`](#yolo-run) | Open a shell / run a command in a running container |
 | [`scale <env> [count]`](#yolo-scale) | Adjust the web service's task count out of band |
+| [`services <env>`](#yolo-services) | View and manage the services an environment offers |
+| [`tui [env]`](#yolo-tui) | Open the interactive dashboard |
 | [`sync <env>`](#yolo-sync) | Provision all resources (account → environment → app) |
 | [`sync:account <env>`](#yolo-sync-account) | Provision account-global resources |
 | [`sync:environment <env>`](#yolo-sync-environment) | Provision environment-shared resources |
@@ -334,6 +336,52 @@ yolo scale production                            # prompt for a fixed count
 ```
 
 **Reducing capacity** (a bound below the live value) is confirm-gated and defaults to *no*. See [Scaling](/guide/scaling).
+
+---
+
+## `yolo services`
+
+View and manage the [services](/guide/provisioning#the-service-lifecycle) an environment offers — the two-key gate (the env manifest offers a service, an app claims it) made visible and editable.
+
+```bash
+yolo services <environment> [--json] [--add=<service>] [--set key=value] [--remove=<service>]
+```
+
+| Option | Value | Description |
+|---|---|---|
+| `--json` | flag | Print the service state as JSON and exit — no prompts (for agents/CI). |
+| `--add` | service | Offer a service non-interactively (pair with `--set`). |
+| `--set` | `key=value` | An offer field for `--add`, repeatable (e.g. `--set version=29.0 --set nodes=3`). |
+| `--remove` | service | Withdraw a service offer non-interactively. |
+
+Run with no options for an interactive table — each service's offer, the running apps that claim it, and its lifecycle state — with add / edit / remove. The add/edit prompts are generated from each service's offer fields, so a new service needs no command changes. App-side-only services (`rekognition`, `mediaconvert`) are listed but not offerable at the environment tier.
+
+Editing writes and uploads the [environment manifest](/reference/manifest); the next [`sync:environment`](#yolo-sync-environment) reconciles AWS to it. A service can't be withdrawn while a running app still claims it (the same guard as [`environment:manifest:push`](#yolo-environment-manifest-push)).
+
+```bash
+yolo services production                                          # interactive
+yolo services production --json                                   # read state
+yolo services production --add=typesense --set version=29.0 --set nodes=3
+yolo services production --remove=typesense
+```
+
+---
+
+## `yolo tui`
+
+Open the [interactive dashboard](/guide/tui) — a tabbed terminal UI over the environment.
+
+```bash
+yolo tui [environment]
+```
+
+| Argument | Required | Description |
+|---|---|---|
+| `environment` | no | The environment name. Prompts when omitted (auto-selects the only one). |
+
+Tabs: **Status** (live vitals, reusing [`status`](#yolo-status)), **Services** (the [`services`](#yolo-services) gate, ⏎ to manage), **Deployments** (ECR history + interactive [`rollback`](#yolo-rollback), and live rollout progress when one's in flight), **Logs** (tail CloudWatch per group), and **Manifest** (a read view of the env + app manifests). A global health bar stays on top and flags any in-progress deploy whoever triggered it. `tui` adds no new powers — it's the live cockpit over the existing commands.
+
+Navigate with `◂ ▸` / `Tab` / number keys / a tab's hotkey; `q` quits. It's interactive only — for a one-off frame in a script use [`status --snapshot`](#yolo-status).
 
 ---
 

--- a/src/Aws/CloudWatchLogs.php
+++ b/src/Aws/CloudWatchLogs.php
@@ -28,6 +28,30 @@ class CloudWatchLogs
     }
 
     /**
+     * Recent log events for a group's stream prefix (web/queue/scheduler). A
+     * missing group reads as no events rather than throwing — the Logs tab shows
+     * an empty state until the first task logs.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function recent(string $logGroup, string $streamPrefix, int $limit = 60): array
+    {
+        try {
+            return Aws::cloudWatchLogs()->filterLogEvents([
+                'logGroupName' => $logGroup,
+                'logStreamNamePrefix' => $streamPrefix,
+                'limit' => $limit,
+            ])['events'] ?? [];
+        } catch (AwsException $e) {
+            if ($e->getAwsErrorCode() === 'ResourceNotFoundException') {
+                return [];
+            }
+
+            throw $e;
+        }
+    }
+
+    /**
      * The account-level resource policy with the given name decoded to an array,
      * or null when no such policy exists. Used to diff the EventBridge log-delivery
      * grant before re-putting it.

--- a/src/Commands/ServicesCommand.php
+++ b/src/Commands/ServicesCommand.php
@@ -1,0 +1,336 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\EnvManifest;
+use Symfony\Component\Yaml\Yaml;
+use Codinglabs\Yolo\Enums\Service;
+use Codinglabs\Yolo\Services\Lifecycle;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+use Codinglabs\Yolo\Concerns\ManagesEnvironmentFiles;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\text;
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\table;
+use function Laravel\Prompts\select;
+use function Laravel\Prompts\confirm;
+
+/**
+ * The two-key service gate, made visible and editable. A table of every service
+ * — whether the environment offers it (`services.{name}` in the env manifest),
+ * which running apps claim it, and the resulting lifecycle state — with add /
+ * edit / remove driven generically off each service's offerKeys()/validateOffer()
+ * (no per-service code here). Editing writes the env manifest and uploads it; the
+ * next `yolo sync:environment` reconciles AWS to it.
+ *
+ * Add/edit/remove guard the same invariant `environment:manifest:push` does — a
+ * service can't be withdrawn while a running app still claims it. App-side-only
+ * services (rekognition, mediaconvert) are listed but not offerable.
+ *
+ *   yolo services production                                   # interactive
+ *   yolo services production --json                            # read state (agents/CI)
+ *   yolo services production --add=typesense --set version=29.0 --set nodes=3
+ *   yolo services production --remove=typesense
+ */
+class ServicesCommand extends Command
+{
+    use ManagesEnvironmentFiles;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('services')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Print the service state as JSON and exit (no prompts)')
+            ->addOption('add', null, InputOption::VALUE_REQUIRED, 'Offer a service non-interactively (pair with --set)')
+            ->addOption('remove', null, InputOption::VALUE_REQUIRED, 'Withdraw a service offer non-interactively')
+            ->addOption('set', null, InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY, 'key=value offer field for --add (repeatable)')
+            ->setDescription('View and manage the services an environment offers');
+    }
+
+    public function handle(): int
+    {
+        if ($this->option('add') !== null) {
+            return $this->applyAdd((string) $this->option('add'));
+        }
+
+        if ($this->option('remove') !== null) {
+            return $this->applyRemove((string) $this->option('remove'), interactive: false);
+        }
+
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode(static::rows(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        return $this->interactive();
+    }
+
+    /**
+     * The full service state — the data behind both the table and `--json`, and
+     * reused by the TUI Services panel. Reads the env manifest (offered) and the
+     * published-claim registry (used by); the display state is derived so the
+     * manual-edit "conflict" case surfaces as a row rather than throwing.
+     *
+     * @return array<int, array{service: string, envBacked: bool, offered: bool, offer: array<string, mixed>|null, offerKeys: array<int, string>, usedBy: array<int, string>, state: string}>
+     */
+    public static function rows(): array
+    {
+        $unpublished = Lifecycle::unpublishedLiveApps() !== [];
+
+        return array_map(function (Service $service) use ($unpublished): array {
+            $definition = $service->definition();
+            $envBacked = $definition->envBacked();
+            $offered = $envBacked && EnvManifest::has($service->envManifestKey());
+            $usedBy = Lifecycle::liveAppsUsing($service);
+
+            return [
+                'service' => $service->value,
+                'envBacked' => $envBacked,
+                'offered' => $offered,
+                'offer' => $offered ? (array) EnvManifest::get($service->envManifestKey(), []) : null,
+                'offerKeys' => $definition->offerKeys(),
+                'usedBy' => $usedBy,
+                'state' => self::displayState($envBacked, $offered, $usedBy !== [], $unpublished),
+            ];
+        }, Service::cases());
+    }
+
+    /**
+     * The lifecycle verdict for the table: the two-key gate, plus the safe-to-show
+     * variants for app-side-only services and the offer-removed-while-used conflict
+     * (which Lifecycle::state() throws on — here it's just a flag).
+     */
+    public static function displayState(bool $envBacked, bool $offered, bool $used, bool $unpublished): string
+    {
+        return match (true) {
+            ! $envBacked => 'app-side',
+            ! $offered && $used => 'conflict',
+            $offered && $used => 'provision',
+            ! $offered => 'off',
+            default => $unpublished ? 'retain' : 'teardown',
+        };
+    }
+
+    /**
+     * One-line summary of an offer for the table — `version=29.0 nodes=2`, or a
+     * tick for an offer that carries no fields.
+     *
+     * @param  array<string, mixed>|null  $offer
+     */
+    public static function offerSummary(?array $offer): string
+    {
+        if ($offer === null || $offer === []) {
+            return '✓';
+        }
+
+        return implode(' ', array_map(static fn (mixed $value, string $key): string => "$key=$value", $offer, array_keys($offer)));
+    }
+
+    protected function interactive(): int
+    {
+        while (true) {
+            $rows = static::rows();
+
+            table(['Service', 'Offered', 'Used by', 'State'], array_map(static fn (array $row): array => [
+                $row['service'],
+                $row['offered'] ? static::offerSummary($row['offer']) : ($row['envBacked'] ? '—' : 'app-side'),
+                $row['usedBy'] === [] ? '—' : implode(', ', $row['usedBy']),
+                $row['state'],
+            ], $rows));
+
+            $choices = ['__quit__' => 'Quit'];
+
+            foreach ($rows as $row) {
+                if ($row['envBacked']) {
+                    $choices[$row['service']] = $row['service'];
+                }
+            }
+
+            $pick = select(label: 'Manage which service?', options: $choices, scroll: 10);
+
+            if ($pick === '__quit__') {
+                return self::SUCCESS;
+            }
+
+            $this->manage(Service::from($pick));
+        }
+    }
+
+    protected function manage(Service $service): void
+    {
+        $offered = EnvManifest::has($service->envManifestKey());
+
+        $action = select(label: $service->value, options: array_filter([
+            'edit' => $offered ? 'Edit offer' : 'Add offer',
+            'remove' => $offered ? 'Remove offer' : null,
+            'cancel' => 'Cancel',
+        ]));
+
+        match ($action) {
+            'edit' => $this->editOffer($service),
+            'remove' => $this->applyRemove($service->value, interactive: true),
+            default => null,
+        };
+    }
+
+    protected function editOffer(Service $service): void
+    {
+        $current = (array) EnvManifest::get($service->envManifestKey(), []);
+        $offer = [];
+
+        foreach ($service->definition()->offerKeys() as $key) {
+            $value = text(label: $key, default: (string) ($current[$key] ?? ''));
+
+            if ($value !== '') {
+                $offer[$key] = static::coerce($value);
+            }
+        }
+
+        try {
+            $this->writeOffer($service, $offer);
+        } catch (IntegrityCheckException $exception) {
+            error($exception->getMessage());
+
+            return;
+        }
+
+        info(sprintf('Offered %s. Run `yolo sync:environment %s` to provision it.', $service->value, $this->argument('environment')));
+    }
+
+    protected function applyAdd(string $name): int
+    {
+        if (! ($service = $this->envBackedService($name)) instanceof Service) {
+            return self::FAILURE;
+        }
+
+        $offer = [];
+
+        foreach ($this->option('set') as $pair) {
+            if (! str_contains((string) $pair, '=')) {
+                error(sprintf('--set expects key=value, got "%s".', $pair));
+
+                return self::FAILURE;
+            }
+
+            [$key, $value] = explode('=', (string) $pair, 2);
+            $offer[$key] = static::coerce($value);
+        }
+
+        try {
+            $this->writeOffer($service, $offer);
+        } catch (IntegrityCheckException $exception) {
+            error($exception->getMessage());
+
+            return self::FAILURE;
+        }
+
+        $this->output->writeln((string) json_encode(static::rows(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return self::SUCCESS;
+    }
+
+    protected function applyRemove(string $name, bool $interactive): int
+    {
+        if (! ($service = $this->envBackedService($name)) instanceof Service) {
+            return self::FAILURE;
+        }
+
+        if (! EnvManifest::has($service->envManifestKey())) {
+            error(sprintf('%s is not currently offered by %s.', $service->value, $this->argument('environment')));
+
+            return self::FAILURE;
+        }
+
+        // Mirror environment:manifest:push — a service can't be withdrawn while a
+        // running app still claims it, and can't be safely judged while an app
+        // hasn't published what it uses.
+        if (($using = Lifecycle::liveAppsUsing($service)) !== []) {
+            error(sprintf('%s still %s the %s service — remove it from each app\'s yolo.yml and deploy first.', implode(', ', $using), count($using) === 1 ? 'uses' : 'use', $service->value));
+
+            return self::FAILURE;
+        }
+
+        if (($unpublished = Lifecycle::unpublishedLiveApps()) !== []) {
+            error(sprintf('%s %s not published what they use yet — deploy them before withdrawing a service.', implode(', ', $unpublished), count($unpublished) === 1 ? 'has' : 'have'));
+
+            return self::FAILURE;
+        }
+
+        if ($interactive && ! confirm(label: sprintf('Withdraw the %s offer? It will be torn down on the next sync.', $service->value), default: false)) {
+            info('Nothing changed.');
+
+            return self::SUCCESS;
+        }
+
+        $this->writeOffer($service, null);
+
+        info(sprintf('Withdrew %s. Run `yolo sync:environment %s` to tear it down.', $service->value, $this->argument('environment')));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Write a service offer into the env manifest and upload it. A null offer
+     * removes the service. The whole document is re-validated (which runs the
+     * service's validateOffer) before it leaves the machine.
+     *
+     * @param  array<string, mixed>|null  $offer
+     */
+    protected function writeOffer(Service $service, ?array $offer): void
+    {
+        $manifest = EnvManifest::current();
+        $manifest['services'] ??= [];
+
+        if ($offer === null) {
+            unset($manifest['services'][$service->value]);
+        } else {
+            $manifest['services'][$service->value] = $offer;
+        }
+
+        $yaml = Yaml::dump($manifest, 6, 2);
+
+        EnvManifest::parse($yaml);
+
+        $this->upload(EnvManifest::filename(), $yaml, EnvManifest::filename());
+
+        EnvManifest::reset();
+    }
+
+    /**
+     * Resolve a service name to an env-offerable Service, or surface why it isn't
+     * one (unknown, or app-side-only) and return null.
+     */
+    protected function envBackedService(string $name): ?Service
+    {
+        $service = Service::tryFrom($name);
+
+        if (! $service instanceof Service) {
+            error(sprintf('Unknown service "%s". Known: %s.', $name, implode(', ', Service::values())));
+
+            return null;
+        }
+
+        if (! $service->definition()->envBacked()) {
+            error(sprintf('%s is app-side only — it is claimed in an app\'s yolo.yml, not offered at the environment tier.', $service->value));
+
+            return null;
+        }
+
+        return $service;
+    }
+
+    /**
+     * Coerce a pure-integer offer value to int (so counts like nodes=3 store
+     * unquoted), leaving everything else — including dotted version tags like
+     * 29.0 — as a string.
+     */
+    protected static function coerce(string $value): int|string
+    {
+        return ctype_digit($value) ? (int) $value : $value;
+    }
+}

--- a/src/Commands/TuiCommand.php
+++ b/src/Commands/TuiCommand.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Tui\Tui;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Tui\Screen;
+use Codinglabs\Yolo\Tui\Keyboard;
+use Codinglabs\Yolo\Tui\Panels\StatusPanel;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use function Laravel\Prompts\error;
+use function Laravel\Prompts\select;
+
+/**
+ * The interactive dashboard — a tabbed terminal UI over the environment: live
+ * status, the service gate, deployments + rollback, logs, and the manifest, in
+ * the Outrun theme. It supersedes nothing — `yolo status` and friends stay as
+ * one-shot commands; `tui` is the live cockpit on top of them.
+ *
+ * With no environment argument it prompts for one (auto-selecting the only
+ * environment when there's just one).
+ *
+ *   yolo tui                # prompt for the environment
+ *   yolo tui production     # straight in
+ */
+class TuiCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('tui')
+            ->addArgument('environment', InputArgument::OPTIONAL, 'The environment name (prompts when omitted)')
+            ->setDescription('Open the interactive dashboard — status, services, deployments, logs and the manifest');
+    }
+
+    #[\Override]
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->input = $input;
+        $this->output = $output;
+
+        // Resolve the environment before the base command validates it, so a
+        // bare `yolo tui` can prompt instead of failing on a missing argument.
+        if ($input->getArgument('environment') === null) {
+            $environment = $this->promptEnvironment();
+
+            if ($environment === null) {
+                return self::FAILURE;
+            }
+
+            $input->setArgument('environment', $environment);
+        }
+
+        return parent::execute($input, $output);
+    }
+
+    public function handle(): int
+    {
+        if (! $this->input->isInteractive() || ! $this->output->isDecorated()) {
+            error('yolo tui is an interactive dashboard — run it in a real terminal (use `yolo status --snapshot` for a one-off frame).');
+
+            return self::FAILURE;
+        }
+
+        return (new Tui(
+            screen: new Screen($this->output),
+            keyboard: new Keyboard(),
+            environment: (string) $this->argument('environment'),
+            panels: [
+                new StatusPanel(),
+            ],
+        ))->run();
+    }
+
+    /**
+     * The environment to open: the manifest's sole environment when there's only
+     * one, otherwise a picker. Returns null (with the reason surfaced) when the
+     * manifest is missing/empty or the shell can't prompt.
+     */
+    protected function promptEnvironment(): ?string
+    {
+        if (! Manifest::exists()) {
+            error("Could not find yolo.yml — run 'yolo init' first.");
+
+            return null;
+        }
+
+        $environments = array_keys((array) (Manifest::current()['environments'] ?? []));
+
+        if ($environments === []) {
+            error('No environments are declared in yolo.yml.');
+
+            return null;
+        }
+
+        if (count($environments) === 1) {
+            return (string) $environments[0];
+        }
+
+        if (! $this->input->isInteractive()) {
+            error('yolo tui needs an environment argument in a non-interactive shell.');
+
+            return null;
+        }
+
+        return (string) select(
+            label: 'Which environment?',
+            options: array_combine($environments, $environments),
+        );
+    }
+}

--- a/src/Commands/TuiCommand.php
+++ b/src/Commands/TuiCommand.php
@@ -6,7 +6,11 @@ use Codinglabs\Yolo\Tui\Tui;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Tui\Screen;
 use Codinglabs\Yolo\Tui\Keyboard;
+use Codinglabs\Yolo\Tui\Panels\LogsPanel;
 use Codinglabs\Yolo\Tui\Panels\StatusPanel;
+use Codinglabs\Yolo\Tui\Panels\ManifestPanel;
+use Codinglabs\Yolo\Tui\Panels\ServicesPanel;
+use Codinglabs\Yolo\Tui\Panels\DeploymentsPanel;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -65,13 +69,20 @@ class TuiCommand extends Command
             return self::FAILURE;
         }
 
+        $environment = (string) $this->argument('environment');
+
         return (new Tui(
             screen: new Screen($this->output),
             keyboard: new Keyboard(),
-            environment: (string) $this->argument('environment'),
+            environment: $environment,
             panels: [
-                new StatusPanel(),
+                new StatusPanel($this->output),
+                new ServicesPanel($environment, $this->output),
+                new DeploymentsPanel($environment, $this->output),
+                new LogsPanel(),
+                new ManifestPanel(),
             ],
+            output: $this->output,
         ))->run();
     }
 

--- a/src/Tui/Columns.php
+++ b/src/Tui/Columns.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui;
+
+/**
+ * Renders a fixed-width, themed table row. Each cell is padded to its column
+ * width BEFORE the colour tag is applied, so ANSI escape codes never count
+ * toward the visible width — the alignment trap that makes naively-coloured
+ * terminal tables jagged.
+ */
+class Columns
+{
+    /**
+     * @param  array<int, array{0: string, 1: int, 2?: Theme|null}>  $cells  [text, width, colour?]
+     */
+    public static function row(array $cells): string
+    {
+        $rendered = array_map(static function (array $cell): string {
+            $padded = mb_str_pad($cell[0], $cell[1]);
+            $colour = $cell[2] ?? null;
+
+            return $colour instanceof Theme ? $colour->fg($padded) : $padded;
+        }, $cells);
+
+        return '  ' . implode(' ', $rendered);
+    }
+}

--- a/src/Tui/DeployObserver.php
+++ b/src/Tui/DeployObserver.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui;
+
+/**
+ * Reads in-flight rollouts straight from the gathered ECS service statuses, so a
+ * deploy shows up in the TUI whoever triggered it — `yolo deploy` in another
+ * shell, CI, the Deployments tab's own rollback, even a raw update-service. The
+ * shell uses active() to lock actions while a rollout runs and banner() to flag
+ * it on the global bar.
+ */
+class DeployObserver
+{
+    /**
+     * The service groups whose primary deployment is mid-rollout.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     * @return array<int, array<string, mixed>>
+     */
+    public static function inProgress(array $statuses): array
+    {
+        return array_values(array_filter(
+            $statuses,
+            static fn (array $status): bool => ($status['rolloutState'] ?? null) === 'IN_PROGRESS',
+        ));
+    }
+
+    /**
+     * Is any group mid-rollout right now?
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     */
+    public static function active(array $statuses): bool
+    {
+        return self::inProgress($statuses) !== [];
+    }
+
+    /**
+     * A compact one-line rollout summary for the global bar (`deploying web 2/3`),
+     * or null when nothing is rolling.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     */
+    public static function banner(array $statuses): ?string
+    {
+        $rolling = self::inProgress($statuses);
+
+        if ($rolling === []) {
+            return null;
+        }
+
+        $parts = array_map(
+            static fn (array $status): string => sprintf('%s %d/%d', $status['group']->value, (int) $status['running'], (int) $status['desired']),
+            $rolling,
+        );
+
+        return 'deploying ' . implode(', ', $parts);
+    }
+}

--- a/src/Tui/Keyboard.php
+++ b/src/Tui/Keyboard.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui;
+
+/**
+ * Non-blocking keyboard reader for the TUI loop. Puts the terminal into raw,
+ * no-echo mode so single keypresses arrive immediately (no Enter), reads
+ * whatever is waiting each poll, and decodes the common escape sequences (the
+ * arrow keys) into stable names. Always restore() on the way out — raw mode
+ * outlives the process otherwise.
+ */
+class Keyboard
+{
+    protected ?string $original = null;
+
+    /** @codeCoverageIgnore raw terminal I/O */
+    public function rawMode(): void
+    {
+        if (! $this->ttyAvailable()) {
+            return;
+        }
+
+        $this->original = trim((string) shell_exec('stty -g'));
+        shell_exec('stty -echo -icanon min 0 time 0');
+        stream_set_blocking(STDIN, false);
+    }
+
+    /** @codeCoverageIgnore raw terminal I/O */
+    public function restore(): void
+    {
+        if ($this->original !== null) {
+            shell_exec('stty ' . $this->original);
+            $this->original = null;
+        }
+    }
+
+    /**
+     * Read whatever keypress is waiting, or null if none.
+     *
+     * @codeCoverageIgnore raw terminal I/O
+     */
+    public function read(): ?string
+    {
+        $bytes = fread(STDIN, 8);
+
+        if ($bytes === false || $bytes === '') {
+            return null;
+        }
+
+        return static::decode($bytes);
+    }
+
+    /**
+     * Map a raw byte sequence to a stable key name — arrows to up/down/left/right,
+     * the control keys by name, printable keys through unchanged.
+     */
+    public static function decode(string $bytes): string
+    {
+        return match ($bytes) {
+            "\e[A", "\eOA" => 'up',
+            "\e[B", "\eOB" => 'down',
+            "\e[C", "\eOC" => 'right',
+            "\e[D", "\eOD" => 'left',
+            "\t" => 'tab',
+            "\r", "\n" => 'enter',
+            "\e" => 'esc',
+            "\x03" => 'ctrl-c',
+            default => $bytes,
+        };
+    }
+
+    /** @codeCoverageIgnore raw terminal I/O */
+    protected function ttyAvailable(): bool
+    {
+        return stream_isatty(STDIN) && function_exists('shell_exec');
+    }
+}

--- a/src/Tui/Panels/DeploymentsPanel.php
+++ b/src/Tui/Panels/DeploymentsPanel.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Carbon\Carbon;
+use Codinglabs\Yolo\Aws\Ecr;
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\Tui\Columns;
+use Codinglabs\Yolo\Tui\DeployObserver;
+use Codinglabs\Yolo\Commands\RollbackCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Codinglabs\Yolo\Resources\Ecr\EcrRepository;
+use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Deploy history + rollback. When a rollout is in flight (whoever triggered it),
+ * the tab shows the live progress and locks the rollback action; otherwise it
+ * lists the last deployments from ECR (newest first, the running one marked) and
+ * ⏎ launches the interactive rollback (reusing RollbackCommand).
+ */
+class DeploymentsPanel implements Panel
+{
+    use RendersServiceStatus;
+
+    /** @var array<int, array{version: string, pushedAt: int}> */
+    protected array $targets = [];
+
+    /** @var array<int, array<string, mixed>> */
+    protected array $statuses = [];
+
+    public function __construct(protected string $environment, protected OutputInterface $output) {}
+
+    public function title(): string
+    {
+        return 'Deployments';
+    }
+
+    public function hotkey(): string
+    {
+        return 'd';
+    }
+
+    public function gather(): void
+    {
+        $this->statuses = static::gatherServiceStatuses(withLoad: false);
+        $this->targets = RollbackCommand::rollbackTargets(Ecr::images((new EcrRepository())->name()));
+    }
+
+    public function render(int $width): array
+    {
+        if (DeployObserver::active($this->statuses)) {
+            return [
+                Theme::Active->bold('  ⟳ deploy in progress'),
+                '',
+                ...$this->statusLines($this->statuses, time(), deployments: true, load: false),
+                '',
+                Theme::Muted->fg('  rollback disabled until the rollout settles'),
+            ];
+        }
+
+        return self::historyLines($this->targets, $this->currentVersion());
+    }
+
+    /**
+     * The deploy-history rows — version, when it was pushed, and a marker on the
+     * version that's running now.
+     *
+     * @param  array<int, array{version: string, pushedAt: int}>  $targets
+     * @return array<int, string>
+     */
+    public static function historyLines(array $targets, ?string $current): array
+    {
+        if ($targets === []) {
+            return [Theme::Muted->fg('  No previous versions in ECR.')];
+        }
+
+        $lines = [Theme::Muted->fg('  recent deployments (from ECR)'), ''];
+
+        foreach (array_slice($targets, 0, 10) as $target) {
+            $isCurrent = $target['version'] === $current;
+
+            $lines[] = Columns::row([
+                [$isCurrent ? '●' : ' ', 1, Theme::Healthy],
+                [$target['version'], 18, Theme::Primary],
+                ['pushed ' . Carbon::createFromTimestamp($target['pushedAt'])->diffForHumans(), 30, Theme::Muted],
+                [$isCurrent ? 'current' : '', 8, Theme::Healthy],
+            ]);
+        }
+
+        return $lines;
+    }
+
+    public function hints(): array
+    {
+        return ['⏎ roll back'];
+    }
+
+    public function onKey(string $key): ?Closure
+    {
+        if (($key !== 'enter' && $key !== 'r') || DeployObserver::active($this->statuses)) {
+            return null;
+        }
+
+        return $this->rollback(...);
+    }
+
+    protected function currentVersion(): ?string
+    {
+        foreach ($this->statuses as $status) {
+            if (($status['version'] ?? null) !== null) {
+                return $status['version'];
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * Launch the interactive rollback — the same picker + guards as `yolo rollback`.
+     *
+     * @codeCoverageIgnore drives Laravel Prompts; verified by hand
+     */
+    protected function rollback(): void
+    {
+        $command = new RollbackCommand();
+        $command->input = new ArrayInput(['environment' => $this->environment], $command->getDefinition());
+        $command->output = $this->output;
+        $command->handle();
+    }
+}

--- a/src/Tui/Panels/LogsPanel.php
+++ b/src/Tui/Panels/LogsPanel.php
@@ -1,0 +1,84 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Aws\CloudWatchLogs;
+use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
+
+/**
+ * Tails CloudWatch logs for one service group at a time — the "why" to the Status
+ * tab's "what". `g` cycles through the groups the app runs (web/queue/scheduler).
+ * Read-only.
+ */
+class LogsPanel implements Panel
+{
+    /** @var array<int, array<string, mixed>> */
+    protected array $events = [];
+
+    protected ServerGroup $group = ServerGroup::WEB;
+
+    protected int $groupIndex = 0;
+
+    public function title(): string
+    {
+        return 'Logs';
+    }
+
+    public function hotkey(): string
+    {
+        return 'l';
+    }
+
+    public function gather(): void
+    {
+        $groups = Manifest::serverGroups();
+        $this->group = $groups === [] ? ServerGroup::WEB : $groups[$this->groupIndex % count($groups)];
+        $this->events = CloudWatchLogs::recent((new TaskLogGroup())->name(), $this->group->value, 60);
+    }
+
+    public function render(int $width): array
+    {
+        return [
+            Theme::Primary->bold('  logs') . Theme::Muted->fg(sprintf('  %s · %s', $this->group->value, (new TaskLogGroup())->name())),
+            '',
+            ...self::eventLines($this->events),
+        ];
+    }
+
+    /**
+     * Format log events as `HH:MM:SS message` lines, oldest at the top.
+     *
+     * @param  array<int, array<string, mixed>>  $events
+     * @return array<int, string>
+     */
+    public static function eventLines(array $events): array
+    {
+        if ($events === []) {
+            return [Theme::Muted->fg('  No recent log events.')];
+        }
+
+        return array_map(static function (array $event): string {
+            $time = date('H:i:s', (int) (((int) ($event['timestamp'] ?? 0)) / 1000));
+
+            return '  ' . Theme::Muted->fg($time) . ' ' . Theme::Text->fg(rtrim((string) ($event['message'] ?? '')));
+        }, $events);
+    }
+
+    public function hints(): array
+    {
+        return ['g cycle group'];
+    }
+
+    public function onKey(string $key): ?Closure
+    {
+        if ($key === 'g') {
+            $this->groupIndex++;
+        }
+
+        return null;
+    }
+}

--- a/src/Tui/Panels/ManifestPanel.php
+++ b/src/Tui/Panels/ManifestPanel.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\EnvManifest;
+use Codinglabs\Yolo\Tui\Columns;
+use Codinglabs\Yolo\Commands\ServicesCommand;
+
+/**
+ * A read view of both manifests for the environment — the operator-owned env
+ * manifest (domain + the service offers) and the app's own yolo.yml (name,
+ * region, account, claimed services). Service offers are edited from the
+ * Services tab; broader env-manifest edits go through `environment:manifest:pull
+ * / push`. Read-only here by design — the destructive surface stays explicit.
+ */
+class ManifestPanel implements Panel
+{
+    /** @var array<string, mixed> */
+    protected array $env = [];
+
+    /** @var array<string, mixed> */
+    protected array $app = [];
+
+    public function title(): string
+    {
+        return 'Manifest';
+    }
+
+    public function hotkey(): string
+    {
+        return 'm';
+    }
+
+    public function gather(): void
+    {
+        $this->env = EnvManifest::current();
+        $this->app = [
+            'name' => Manifest::name(),
+            'region' => Manifest::get('region'),
+            'account-id' => Manifest::get('account-id'),
+            'services' => Manifest::services(),
+        ];
+    }
+
+    public function render(int $width): array
+    {
+        $lines = [
+            Theme::Primary->bold('  Environment manifest') . Theme::Muted->fg('  ' . EnvManifest::filename()),
+            Columns::row([['domain', 16, Theme::Muted], [(string) ($this->env['domain'] ?? '—'), 44, Theme::Text]]),
+        ];
+
+        $services = (array) ($this->env['services'] ?? []);
+
+        if ($services === []) {
+            $lines[] = Columns::row([['services', 16, Theme::Muted], ['none offered', 44, Theme::Muted]]);
+        } else {
+            foreach ($services as $name => $offer) {
+                $lines[] = Columns::row([
+                    ['services.' . $name, 16, Theme::Muted],
+                    [ServicesCommand::offerSummary(is_array($offer) ? $offer : null), 44, Theme::Primary],
+                ]);
+            }
+        }
+
+        $claimed = $this->app['services'] === [] ? '—' : implode(', ', (array) $this->app['services']);
+
+        $lines[] = '';
+        $lines[] = Theme::Primary->bold('  App') . Theme::Muted->fg('  yolo.yml');
+        $lines[] = Columns::row([['name', 16, Theme::Muted], [(string) $this->app['name'], 44, Theme::Text]]);
+        $lines[] = Columns::row([['region', 16, Theme::Muted], [(string) ($this->app['region'] ?? '—'), 44, Theme::Text]]);
+        $lines[] = Columns::row([['account-id', 16, Theme::Muted], [(string) ($this->app['account-id'] ?? '—'), 44, Theme::Text]]);
+        $lines[] = Columns::row([['uses', 16, Theme::Muted], [$claimed, 44, $claimed === '—' ? Theme::Muted : Theme::Text]]);
+
+        return $lines;
+    }
+
+    public function hints(): array
+    {
+        return ['offers: Services tab', 'env:manifest:pull/push'];
+    }
+
+    public function onKey(string $key): ?Closure
+    {
+        return null;
+    }
+}

--- a/src/Tui/Panels/Panel.php
+++ b/src/Tui/Panels/Panel.php
@@ -5,13 +5,13 @@ declare(strict_types=1);
 namespace Codinglabs\Yolo\Tui\Panels;
 
 use Closure;
-use Codinglabs\Yolo\Tui\Theme;
 
 /**
  * A TUI tab. The shell owns the loop, the global health bar and the tab bar; a
  * Panel owns one tab's body and its key handling. render() returns ANSI-tagged
  * lines (pure — it never touches the terminal), so panels are testable frame by
  * frame; the shell paints them. gather() refreshes live AWS state each tick.
+ * Panels colour themselves directly off the Theme enum.
  */
 interface Panel
 {
@@ -29,7 +29,7 @@ interface Panel
      *
      * @return array<int, string>
      */
-    public function render(int $width, Theme $theme): array;
+    public function render(int $width): array;
 
     /**
      * The footer key hints for this tab (e.g. ['↑↓ select', '⏎ actions']).

--- a/src/Tui/Panels/Panel.php
+++ b/src/Tui/Panels/Panel.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Codinglabs\Yolo\Tui\Theme;
+
+/**
+ * A TUI tab. The shell owns the loop, the global health bar and the tab bar; a
+ * Panel owns one tab's body and its key handling. render() returns ANSI-tagged
+ * lines (pure — it never touches the terminal), so panels are testable frame by
+ * frame; the shell paints them. gather() refreshes live AWS state each tick.
+ */
+interface Panel
+{
+    /** The tab label shown in the tab bar. */
+    public function title(): string;
+
+    /** The hotkey that jumps straight to this tab (e.g. 's'). */
+    public function hotkey(): string;
+
+    /** Refresh live state from AWS. Called on each poll tick before render(). */
+    public function gather(): void;
+
+    /**
+     * The body lines for this tab — themed and wrapped to $width, no terminal writes.
+     *
+     * @return array<int, string>
+     */
+    public function render(int $width, Theme $theme): array;
+
+    /**
+     * The footer key hints for this tab (e.g. ['↑↓ select', '⏎ actions']).
+     *
+     * @return array<int, string>
+     */
+    public function hints(): array;
+
+    /**
+     * Handle a keypress while this tab is active. Return a closure for the shell
+     * to run as a modal (it pauses the loop, drops to cooked mode for Laravel
+     * Prompts, then resumes), or null when the key is handled in place or ignored.
+     */
+    public function onKey(string $key): ?Closure;
+}

--- a/src/Tui/Panels/ServicesPanel.php
+++ b/src/Tui/Panels/ServicesPanel.php
@@ -1,0 +1,101 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\Tui\Columns;
+use Codinglabs\Yolo\Commands\ServicesCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The two-key service gate as a tab — the same offered · used by · state table
+ * the `yolo services` command shows, themed. ⏎ launches the full interactive
+ * manager (it reuses ServicesCommand, so add/edit/remove and its guards live in
+ * exactly one place).
+ */
+class ServicesPanel implements Panel
+{
+    /** @var array<int, array<string, mixed>> */
+    protected array $rows = [];
+
+    public function __construct(protected string $environment, protected OutputInterface $output) {}
+
+    public function title(): string
+    {
+        return 'Services';
+    }
+
+    public function hotkey(): string
+    {
+        return 'v';
+    }
+
+    public function gather(): void
+    {
+        $this->rows = ServicesCommand::rows();
+    }
+
+    public function render(int $width): array
+    {
+        $lines = [Columns::row([
+            ['service', 14, Theme::Muted],
+            ['offered', 22, Theme::Muted],
+            ['used by', 22, Theme::Muted],
+            ['state', 10, Theme::Muted],
+        ])];
+
+        foreach ($this->rows as $row) {
+            $offered = $row['offered']
+                ? ServicesCommand::offerSummary($row['offer'])
+                : ($row['envBacked'] ? '—' : 'app-side');
+
+            $usedBy = $row['usedBy'] === [] ? '—' : implode(', ', $row['usedBy']);
+
+            $lines[] = Columns::row([
+                [$row['service'], 14, Theme::Text],
+                [$offered, 22, $row['offered'] ? Theme::Primary : Theme::Muted],
+                [$usedBy, 22, $usedBy === '—' ? Theme::Muted : Theme::Text],
+                [$row['state'], 10, self::stateTheme($row['state'])],
+            ]);
+        }
+
+        return $lines;
+    }
+
+    public function hints(): array
+    {
+        return ['⏎ manage'];
+    }
+
+    public function onKey(string $key): ?Closure
+    {
+        return $key === 'enter' ? $this->manage(...) : null;
+    }
+
+    /** The accent colour for a lifecycle state in the table. */
+    public static function stateTheme(string $state): Theme
+    {
+        return match ($state) {
+            'provision' => Theme::Healthy,
+            'conflict', 'teardown' => Theme::Danger,
+            'retain' => Theme::Warning,
+            'app-side' => Theme::Accent,
+            default => Theme::Muted,
+        };
+    }
+
+    /**
+     * Launch the interactive services manager — the same flow as `yolo services`.
+     *
+     * @codeCoverageIgnore drives Laravel Prompts; verified by hand
+     */
+    protected function manage(): void
+    {
+        $command = new ServicesCommand();
+        $command->input = new ArrayInput(['environment' => $this->environment], $command->getDefinition());
+        $command->output = $this->output;
+        $command->handle();
+    }
+}

--- a/src/Tui/Panels/StatusPanel.php
+++ b/src/Tui/Panels/StatusPanel.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Tui\Panels;
+
+use Closure;
+use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+
+/**
+ * The landing tab — the live status the `yolo status` command shows (per-group
+ * vitals, load, and any in-flight rollout), reusing the proven RendersServiceStatus
+ * renderer. Read-only; the global bar above it carries the at-a-glance health.
+ */
+class StatusPanel implements Panel
+{
+    use RendersServiceStatus;
+
+    /** @var array<int, array<string, mixed>> */
+    protected array $statuses = [];
+
+    public function title(): string
+    {
+        return 'Status';
+    }
+
+    public function hotkey(): string
+    {
+        return 's';
+    }
+
+    public function gather(): void
+    {
+        $this->statuses = static::gatherServiceStatuses(withLoad: true);
+    }
+
+    public function render(int $width): array
+    {
+        return $this->statusLines($this->statuses, time(), deployments: true, load: true);
+    }
+
+    public function hints(): array
+    {
+        return ['live'];
+    }
+
+    public function onKey(string $key): ?Closure
+    {
+        return null;
+    }
+}

--- a/src/Tui/Panels/StatusPanel.php
+++ b/src/Tui/Panels/StatusPanel.php
@@ -6,6 +6,7 @@ namespace Codinglabs\Yolo\Tui\Panels;
 
 use Closure;
 use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The landing tab — the live status the `yolo status` command shows (per-group
@@ -18,6 +19,8 @@ class StatusPanel implements Panel
 
     /** @var array<int, array<string, mixed>> */
     protected array $statuses = [];
+
+    public function __construct(public OutputInterface $output) {}
 
     public function title(): string
     {

--- a/src/Tui/Screen.php
+++ b/src/Tui/Screen.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui;
+
+use Symfony\Component\Console\Terminal;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Owns the raw terminal: the alternate-screen buffer, cursor visibility, and the
+ * low-flicker in-place repaint the status loop pioneered (home, clear each line,
+ * wipe below). The shell hands whole frames to paint(); Screen never decides
+ * what's on them.
+ *
+ * @codeCoverageIgnore raw terminal control — exercised by hand, not in CI.
+ */
+class Screen
+{
+    protected Terminal $terminal;
+
+    protected bool $active = false;
+
+    public function __construct(protected OutputInterface $output)
+    {
+        $this->terminal = new Terminal();
+    }
+
+    /** Switch to the alternate buffer, hide the cursor, and clear. */
+    public function open(): void
+    {
+        $this->output->write("\e[?1049h\e[?25l\e[2J");
+        $this->active = true;
+    }
+
+    /** Restore the cursor and the user's original buffer + scrollback. */
+    public function close(): void
+    {
+        if (! $this->active) {
+            return;
+        }
+
+        $this->output->write("\e[?25h\e[?1049l");
+        $this->active = false;
+    }
+
+    /**
+     * Repaint the frame in place — home the cursor, overwrite each line (clearing
+     * it first so a now-shorter line leaves no tail), then wipe any stale rows
+     * below.
+     *
+     * @param  array<int, string>  $lines
+     */
+    public function paint(array $lines): void
+    {
+        $this->output->write("\e[H");
+
+        foreach ($lines as $line) {
+            $this->output->write("\e[2K" . $line . "\n");
+        }
+
+        $this->output->write("\e[J");
+    }
+
+    public function width(): int
+    {
+        return $this->terminal->getWidth();
+    }
+
+    public function height(): int
+    {
+        return $this->terminal->getHeight();
+    }
+}

--- a/src/Tui/Splash.php
+++ b/src/Tui/Splash.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui;
+
+/**
+ * The launch splash — a rocket and flame above the cyan→lime YOLO wordmark, in
+ * the Outrun palette. It plays over the first AWS fetch (so it masks latency
+ * rather than adding it), holds to a ~1s floor so it registers, and any keypress
+ * skips it. The caller gates it off for non-TTY / NO_COLOR shells.
+ */
+class Splash
+{
+    /** @var array<int, string> */
+    public const ROCKET = [
+        '    /\\',
+        '   /  \\',
+        '  | () |',
+        '  |    |',
+        ' /|    |\\',
+        '/_|____|_\\',
+    ];
+
+    /** @var array<int, string> */
+    public const FLAME = [
+        '   )||(',
+        '  ◢◤◢◤◢',
+    ];
+
+    /** @var array<int, string> */
+    public const WORD = [
+        '██╗   ██╗ ██████╗ ██╗      ██████╗',
+        '╚██╗ ██╔╝██╔═══██╗██║     ██╔═══██╗',
+        ' ╚████╔╝ ██║   ██║██║     ██║   ██║',
+        '  ╚██╔╝  ██║   ██║██║     ██║   ██║',
+        '   ██║   ╚██████╔╝███████╗╚██████╔╝',
+        '   ╚═╝    ╚═════╝ ╚══════╝ ╚═════╝',
+    ];
+
+    public const TAGLINE = 'deploy · observe · steer';
+
+    /**
+     * The composed splash frame — rocket and flame above the cyan→lime wordmark,
+     * each row centred to $width. Pure: returns themed lines, writes nothing.
+     *
+     * @return array<int, string>
+     */
+    public static function lines(int $width = 80): array
+    {
+        $rows = [''];
+
+        foreach (static::ROCKET as $line) {
+            $rows[] = self::centre(Theme::Text->fg($line), mb_strlen($line), $width);
+        }
+
+        foreach (static::FLAME as $line) {
+            $rows[] = self::centre(Theme::Active->fg($line), mb_strlen($line), $width);
+        }
+
+        $rows[] = '';
+
+        foreach (static::wordmark() as [$tagged, $rawLength]) {
+            $rows[] = self::centre($tagged, $rawLength, $width);
+        }
+
+        $rows[] = '';
+        $rows[] = self::centre(Theme::Accent->fg(static::TAGLINE), mb_strlen((string) static::TAGLINE), $width);
+        $rows[] = '';
+
+        return $rows;
+    }
+
+    /**
+     * Each wordmark line split at its midpoint — left half cyan, right half lime —
+     * to echo the logo's gradient cheaply. Returns [taggedLine, rawLength] pairs.
+     *
+     * @return array<int, array{0: string, 1: int}>
+     */
+    public static function wordmark(): array
+    {
+        return array_map(static function (string $line): array {
+            $length = mb_strlen($line);
+            $mid = (int) ceil($length / 2);
+
+            $tagged = Theme::Primary->fg(mb_substr($line, 0, $mid))
+                . Theme::Healthy->fg(mb_substr($line, $mid));
+
+            return [$tagged, $length];
+        }, static::WORD);
+    }
+
+    private static function centre(string $tagged, int $rawLength, int $width): string
+    {
+        return str_repeat(' ', max(0, intdiv($width - $rawLength, 2))) . $tagged;
+    }
+
+    /**
+     * Paint the splash, run $work (the first fetch) underneath it, then hold to a
+     * ~1s floor so it's seen — bailing early on any keypress. Never adds time
+     * beyond the floor: a slow fetch is simply masked by the frame.
+     *
+     * @codeCoverageIgnore timing + terminal I/O — exercised by hand, not in CI.
+     */
+    public function play(Screen $screen, Keyboard $keyboard, callable $work): void
+    {
+        $screen->paint(static::lines($screen->width()));
+
+        $started = microtime(true);
+        $work();
+
+        while (microtime(true) - $started < 1.0) {
+            if ($keyboard->read() !== null) {
+                break;
+            }
+
+            usleep(50_000);
+        }
+    }
+}

--- a/src/Tui/Theme.php
+++ b/src/Tui/Theme.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui;
+
+/**
+ * The "Outrun YOLO" palette — the logo's cyan→lime signature on a deep-indigo
+ * synthwave canvas, with neon magenta for selection and the flame's gold for
+ * highlights. Values are truecolor hex; Symfony's OutputFormatter degrades them
+ * to the nearest 256/16 colour on terminals without truecolor, so callers only
+ * ever name a role.
+ */
+enum Theme: string
+{
+    case Primary = '#2DD4D4';    // brand cyan — titles, sparkline start, tab labels
+    case Healthy = '#A3E635';    // lime — OK states, healthy counts, sparkline end
+    case Selection = '#FF2E97';  // neon magenta — the focused row / control
+    case Accent = '#A24BFF';     // purple — rules, the active-panel border
+    case Active = '#FFC83D';     // gold — active tab + underline, "deploying"
+    case Warning = '#FF8A1F';    // orange — drift, latency creep
+    case Danger = '#FF3B5C';     // neon red — dead tier, FAILED, destroy
+    case Canvas = '#160E2E';     // deep indigo — selected-row text on neon fills
+    case Muted = '#6C7A99';      // slate — inactive tabs, hints, borders
+    case Text = '#E6ECF5';       // off-white — body text
+
+    /** Wrap text in this colour's foreground tag. */
+    public function fg(string $text): string
+    {
+        return sprintf('<fg=%s>%s</>', $this->value, $text);
+    }
+
+    /** Bold foreground in this colour. */
+    public function bold(string $text): string
+    {
+        return sprintf('<fg=%s;options=bold>%s</>', $this->value, $text);
+    }
+
+    /** This colour as a background fill, with $fg text on top (dark canvas by default). */
+    public function bg(string $text, self $fg = self::Canvas): string
+    {
+        return sprintf('<fg=%s;bg=%s>%s</>', $fg->value, $this->value, $text);
+    }
+}

--- a/src/Tui/Tui.php
+++ b/src/Tui/Tui.php
@@ -6,6 +6,7 @@ use Closure;
 use Laravel\Prompts\Prompt;
 use Codinglabs\Yolo\Tui\Panels\Panel;
 use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * The dashboard shell — the status command's live-render loop, generalised into a
@@ -31,6 +32,7 @@ class Tui
         protected Keyboard $keyboard,
         protected string $environment,
         protected array $panels,
+        public OutputInterface $output,
         protected int $active = 0,
         protected bool $splash = true,
     ) {}

--- a/src/Tui/Tui.php
+++ b/src/Tui/Tui.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace Codinglabs\Yolo\Tui;
+
+use Closure;
+use Laravel\Prompts\Prompt;
+use Codinglabs\Yolo\Tui\Panels\Panel;
+use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+
+/**
+ * The dashboard shell — the status command's live-render loop, generalised into a
+ * tab host. It owns the poll/redraw loop, the always-on global health bar, the
+ * tab bar, the footer, and key routing; each Panel owns its own tab body. When a
+ * panel returns a modal closure for a key, the loop pauses, drops to cooked mode
+ * so Laravel Prompts can take the screen, then resumes.
+ *
+ * The chrome (global bar, tab bar, footer, frame, key routing) is pure and
+ * tested; only the raw terminal loop and the modal handoff are @codeCoverageIgnore.
+ */
+class Tui
+{
+    use RendersServiceStatus;
+
+    protected bool $quit = false;
+
+    /**
+     * @param  array<int, Panel>  $panels
+     */
+    public function __construct(
+        protected Screen $screen,
+        protected Keyboard $keyboard,
+        protected string $environment,
+        protected array $panels,
+        protected int $active = 0,
+        protected bool $splash = true,
+    ) {}
+
+    /**
+     * The live dashboard: enter the alternate screen + raw mode, optionally play
+     * the splash over the first gather, then poll/redraw and route keys until quit.
+     *
+     * @codeCoverageIgnore the live loop — raw terminal I/O + timing, verified by hand
+     */
+    public function run(): int
+    {
+        $this->keyboard->rawMode();
+        $this->screen->open();
+
+        try {
+            if ($this->splash) {
+                (new Splash())->play($this->screen, $this->keyboard, fn () => $this->panels[$this->active]->gather());
+            }
+
+            while (! $this->quit) {
+                $statuses = static::gatherServiceStatuses(withLoad: true);
+                $this->panels[$this->active]->gather();
+                $this->screen->paint($this->frame($statuses, $this->screen->width()));
+
+                $deadline = microtime(true) + 3.0;
+
+                // Wait out the poll window, but repaint promptly after any key —
+                // a key may switch tabs or set quit (which the outer loop checks).
+                while (microtime(true) < $deadline) {
+                    $key = $this->keyboard->read();
+
+                    if ($key !== null) {
+                        $modal = $this->handleKey($key);
+
+                        if ($modal instanceof Closure) {
+                            $this->runModal($modal);
+                        }
+
+                        break;
+                    }
+
+                    usleep(40_000);
+                }
+            }
+        } finally {
+            $this->screen->close();
+            $this->keyboard->restore();
+        }
+
+        return 0;
+    }
+
+    /**
+     * Hand the screen to a Laravel Prompts modal: leave the alternate buffer and
+     * raw mode so Prompts draws and reads normally, run it, then re-enter.
+     *
+     * @codeCoverageIgnore modal handoff — terminal mode switching
+     */
+    protected function runModal(Closure $modal): void
+    {
+        $this->screen->close();
+        $this->keyboard->restore();
+
+        Prompt::interactive(true);
+        $modal();
+
+        $this->keyboard->rawMode();
+        $this->screen->open();
+    }
+
+    /**
+     * Compose the whole frame — global health bar, tab bar, active panel body, footer.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     * @return array<int, string>
+     */
+    public function frame(array $statuses, int $width): array
+    {
+        $panel = $this->panels[$this->active];
+
+        return [
+            '',
+            self::globalBar($this->environment, $statuses),
+            self::tabBar($this->panels, $this->active),
+            '',
+            ...$panel->render($width),
+            '',
+            self::footer($panel, count($this->panels)),
+        ];
+    }
+
+    /**
+     * Route a keypress: quit, tab navigation (arrows/tab), number and letter
+     * hotkeys jump tabs; anything else delegates to the active panel, which may
+     * return a modal closure for the loop to run.
+     */
+    public function handleKey(string $key): ?Closure
+    {
+        $count = count($this->panels);
+
+        if ($key === 'q' || $key === 'ctrl-c') {
+            $this->quit = true;
+
+            return null;
+        }
+
+        if ($key === 'right' || $key === 'tab') {
+            $this->active = ($this->active + 1) % $count;
+
+            return null;
+        }
+
+        if ($key === 'left') {
+            $this->active = ($this->active - 1 + $count) % $count;
+
+            return null;
+        }
+
+        if (ctype_digit($key) && isset($this->panels[(int) $key - 1])) {
+            $this->active = (int) $key - 1;
+
+            return null;
+        }
+
+        foreach ($this->panels as $index => $panel) {
+            if ($panel->hotkey() === $key) {
+                $this->active = $index;
+
+                return null;
+            }
+        }
+
+        return $this->panels[$this->active]->onKey($key);
+    }
+
+    public function activeIndex(): int
+    {
+        return $this->active;
+    }
+
+    public function quitting(): bool
+    {
+        return $this->quit;
+    }
+
+    /**
+     * The always-on top line: brand + environment on the left, and either the
+     * live rollout banner (when deploying) or the per-group health dots.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     */
+    public static function globalBar(string $environment, array $statuses): string
+    {
+        $left = Theme::Primary->bold('yolo tui') . Theme::Muted->fg(' · ' . $environment);
+
+        $banner = DeployObserver::banner($statuses);
+
+        $right = $banner !== null
+            ? Theme::Active->fg('⟳ ' . $banner)
+            : self::healthDots($statuses);
+
+        return '  ' . $left . '    ' . $right;
+    }
+
+    /**
+     * One coloured dot per group — lime when healthy, red when down, gold when
+     * mid-roll, slate when idle at zero.
+     *
+     * @param  array<int, array<string, mixed>>  $statuses
+     */
+    public static function healthDots(array $statuses): string
+    {
+        return implode('   ', array_map(self::dotFor(...), $statuses));
+    }
+
+    /**
+     * @param  array<string, mixed>  $status
+     */
+    protected static function dotFor(array $status): string
+    {
+        $running = (int) ($status['running'] ?? 0);
+        $desired = (int) ($status['desired'] ?? 0);
+        $label = sprintf('%s %d/%d', $status['group']->value, $running, $desired);
+
+        return match (true) {
+            $desired === 0 => Theme::Muted->fg('· ' . $label),
+            $running >= $desired => Theme::Healthy->fg('● ' . $label),
+            $running === 0 => Theme::Danger->fg('✗ ' . $label),
+            default => Theme::Warning->fg('◐ ' . $label),
+        };
+    }
+
+    /**
+     * The tab bar — the active tab gold + underlined, the rest slate.
+     *
+     * @param  array<int, Panel>  $panels
+     */
+    public static function tabBar(array $panels, int $active): string
+    {
+        $tabs = [];
+
+        foreach ($panels as $index => $panel) {
+            $tabs[] = $index === $active
+                ? sprintf('<fg=%s;options=bold,underscore>%s</>', Theme::Active->value, $panel->title())
+                : Theme::Muted->fg($panel->title());
+        }
+
+        return '  ' . implode('   ', $tabs);
+    }
+
+    /** The footer hints — the active panel's, then the global navigation keys. */
+    public static function footer(Panel $panel, int $count): string
+    {
+        $hints = [...$panel->hints(), '◂ ▸ tabs', '1-' . $count . ' jump', 'q quit'];
+
+        return '  ' . Theme::Muted->fg(implode('   ', $hints));
+    }
+}

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -44,6 +44,9 @@ class Yolo
         // Services (the env service gate)
         Commands\ServicesCommand::class,
 
+        // Interactive dashboard
+        Commands\TuiCommand::class,
+
         // Sync (scope-grouped: account → environment → app, orchestrated by `sync`)
         Commands\SyncCommand::class,
         Commands\SyncAccountCommand::class,

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -41,6 +41,9 @@ class Yolo
         // Scale
         Commands\ScaleCommand::class,
 
+        // Services (the env service gate)
+        Commands\ServicesCommand::class,
+
         // Sync (scope-grouped: account → environment → app, orchestrated by `sync`)
         Commands\SyncCommand::class,
         Commands\SyncAccountCommand::class,

--- a/tests/Unit/Commands/ServicesCommandTest.php
+++ b/tests/Unit/Commands/ServicesCommandTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use Codinglabs\Yolo\Yolo;
+use Laravel\Prompts\Prompt;
+use Codinglabs\Yolo\Commands\ServicesCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+/**
+ * Drive ServicesCommand::handle() directly. Prompts run non-interactively, so
+ * tests exercise the --json / --add / --remove paths (the interactive picker
+ * isn't driven here). Returns the exit code and the command's own output buffer.
+ *
+ * @param  array<string, string|bool|array<int, string>>  $options
+ * @return array{exit: int, output: string}
+ */
+function invokeServices(array $options = [], string $environment = 'testing'): array
+{
+    Prompt::interactive(false);
+    Prompt::setOutput(new BufferedOutput());
+
+    $command = new ServicesCommand();
+
+    $input = ['environment' => $environment];
+
+    foreach ($options as $name => $value) {
+        $input['--' . $name] = $value;
+    }
+
+    $command->input = new ArrayInput($input, $command->getDefinition());
+    $command->output = $output = new BufferedOutput();
+
+    return ['exit' => $command->handle(), 'output' => $output->fetch()];
+}
+
+function offeringTypesense(array $claims = [], array $clusters = []): array
+{
+    return [
+        'manifest' => "domain: example.com\nservices:\n  typesense:\n    version: '29.0'\n    nodes: 3\n",
+        'claims' => $claims,
+        'clusters' => $clusters,
+    ];
+}
+
+it('is named services and is registered', function (): void {
+    expect((new ServicesCommand())->getName())->toBe('services')
+        ->and((new ReflectionClass(Yolo::class))->getDefaultProperties()['commands'])->toContain(ServicesCommand::class);
+});
+
+it('derives the lifecycle display state from the two-key gate', function (): void {
+    expect(ServicesCommand::displayState(envBacked: true, offered: true, used: true, unpublished: false))->toBe('provision')
+        ->and(ServicesCommand::displayState(true, true, false, false))->toBe('teardown')
+        ->and(ServicesCommand::displayState(true, true, false, true))->toBe('retain')
+        ->and(ServicesCommand::displayState(true, false, true, false))->toBe('conflict')
+        ->and(ServicesCommand::displayState(true, false, false, false))->toBe('off')
+        ->and(ServicesCommand::displayState(false, false, true, false))->toBe('app-side');
+});
+
+it('summarises an offer for the table', function (): void {
+    expect(ServicesCommand::offerSummary(['version' => '29.0', 'nodes' => 2]))->toBe('version=29.0 nodes=2')
+        ->and(ServicesCommand::offerSummary([]))->toBe('✓')
+        ->and(ServicesCommand::offerSummary(null))->toBe('✓');
+});
+
+it('reports the service state as json', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld(offeringTypesense(claims: ['convict' => ['typesense']], clusters: ['convict' => true]), $captured);
+
+    $result = invokeServices(options: ['json' => true]);
+    $typesense = collect(json_decode($result['output'], true))->firstWhere('service', 'typesense');
+
+    expect($result['exit'])->toBe(0)
+        ->and($typesense['offered'])->toBeTrue()
+        ->and($typesense['usedBy'])->toBe(['convict'])
+        ->and($typesense['state'])->toBe('provision');
+});
+
+it('adds a service offer and uploads the env manifest', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld(['manifest' => "domain: example.com\nservices: {}\n", 'claims' => [], 'clusters' => []], $captured);
+
+    $result = invokeServices(options: ['add' => 'typesense', 'set' => ['version=29.0', 'nodes=3']]);
+    $put = collect($captured)->firstWhere('name', 'PutObject');
+
+    expect($result['exit'])->toBe(0)
+        ->and($put)->not->toBeNull()
+        ->and($put['args']['Body'])->toContain('typesense')
+        ->and($put['args']['Body'])->toContain('29.0');
+});
+
+it('refuses to withdraw a service a running app still uses', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld(offeringTypesense(claims: ['convict' => ['typesense']], clusters: ['convict' => true]), $captured);
+
+    $result = invokeServices(options: ['remove' => 'typesense']);
+
+    expect($result['exit'])->toBe(1)
+        ->and(collect($captured)->where('name', 'PutObject'))->toBeEmpty();
+});
+
+it('withdraws an unused service offer', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld(offeringTypesense(claims: [], clusters: []), $captured);
+
+    $result = invokeServices(options: ['remove' => 'typesense']);
+    $put = collect($captured)->firstWhere('name', 'PutObject');
+
+    expect($result['exit'])->toBe(0)
+        ->and($put)->not->toBeNull()
+        ->and($put['args']['Body'])->not->toContain('typesense');
+});
+
+it('rejects offering an app-side-only service', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld(['manifest' => "domain: example.com\nservices: {}\n", 'claims' => [], 'clusters' => []], $captured);
+
+    $result = invokeServices(options: ['add' => 'rekognition', 'set' => []]);
+
+    expect($result['exit'])->toBe(1)
+        ->and(collect($captured)->where('name', 'PutObject'))->toBeEmpty();
+});

--- a/tests/Unit/Tui/ColumnsTest.php
+++ b/tests/Unit/Tui/ColumnsTest.php
@@ -1,0 +1,15 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\Tui\Columns;
+
+it('pads each cell before colouring so tags do not skew alignment', function (): void {
+    $row = Columns::row([['typesense', 12, Theme::Primary], ['provision', 10, Theme::Healthy]]);
+
+    expect($row)->toContain('<fg=#2DD4D4>typesense   </>')   // padded to 12 inside the tag
+        ->toContain('<fg=#A3E635>provision </>');             // padded to 10 inside the tag
+});
+
+it('renders an uncoloured cell as plain padded text', function (): void {
+    expect(Columns::row([['svc', 5, null]]))->toBe('  svc  ');
+});

--- a/tests/Unit/Tui/ColumnsTest.php
+++ b/tests/Unit/Tui/ColumnsTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codinglabs\Yolo\Tui\Theme;
 use Codinglabs\Yolo\Tui\Columns;
 

--- a/tests/Unit/Tui/DeployObserverTest.php
+++ b/tests/Unit/Tui/DeployObserverTest.php
@@ -1,0 +1,28 @@
+<?php
+
+use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Tui\DeployObserver;
+
+function rolloutStatus(ServerGroup $group, int $running, int $desired, ?string $rollout = null): array
+{
+    return ['group' => $group, 'running' => $running, 'desired' => $desired, 'rolloutState' => $rollout];
+}
+
+it('detects an in-flight rollout from gathered ECS state', function (): void {
+    $statuses = [
+        rolloutStatus(ServerGroup::WEB, 2, 3, 'IN_PROGRESS'),
+        rolloutStatus(ServerGroup::QUEUE, 1, 1),
+    ];
+
+    expect(DeployObserver::active($statuses))->toBeTrue()
+        ->and(DeployObserver::inProgress($statuses))->toHaveCount(1);
+});
+
+it('is inactive when nothing is rolling', function (): void {
+    expect(DeployObserver::active([rolloutStatus(ServerGroup::WEB, 3, 3, 'COMPLETED')]))->toBeFalse();
+});
+
+it('summarises the live rollout as a banner', function (): void {
+    expect(DeployObserver::banner([rolloutStatus(ServerGroup::WEB, 2, 3, 'IN_PROGRESS')]))->toBe('deploying web 2/3')
+        ->and(DeployObserver::banner([rolloutStatus(ServerGroup::WEB, 3, 3)]))->toBeNull();
+});

--- a/tests/Unit/Tui/DeployObserverTest.php
+++ b/tests/Unit/Tui/DeployObserverTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Tui\DeployObserver;
 

--- a/tests/Unit/Tui/DeploymentsPanelTest.php
+++ b/tests/Unit/Tui/DeploymentsPanelTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Carbon\Carbon;
+use Codinglabs\Yolo\Tui\Panels\DeploymentsPanel;
+
+it('lists deploy history newest-first with the current version marked', function (): void {
+    $targets = [
+        ['version' => '26.24.2.1130', 'pushedAt' => Carbon::now()->subHours(2)->getTimestamp()],
+        ['version' => '26.24.1.0900', 'pushedAt' => Carbon::now()->subDay()->getTimestamp()],
+    ];
+
+    $body = implode("\n", DeploymentsPanel::historyLines($targets, '26.24.2.1130'));
+
+    expect($body)->toContain('26.24.2.1130')
+        ->toContain('26.24.1.0900')
+        ->toContain('current')
+        ->toContain('pushed');
+});
+
+it('shows an empty state when ECR has no versions', function (): void {
+    expect(implode("\n", DeploymentsPanel::historyLines([], null)))->toContain('No previous versions');
+});

--- a/tests/Unit/Tui/DeploymentsPanelTest.php
+++ b/tests/Unit/Tui/DeploymentsPanelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Carbon\Carbon;
 use Codinglabs\Yolo\Tui\Panels\DeploymentsPanel;
 

--- a/tests/Unit/Tui/KeyboardTest.php
+++ b/tests/Unit/Tui/KeyboardTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codinglabs\Yolo\Tui\Keyboard;
 
 it('decodes arrow escape sequences', function (): void {

--- a/tests/Unit/Tui/KeyboardTest.php
+++ b/tests/Unit/Tui/KeyboardTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Keyboard;
+
+it('decodes arrow escape sequences', function (): void {
+    expect(Keyboard::decode("\e[A"))->toBe('up')
+        ->and(Keyboard::decode("\e[B"))->toBe('down')
+        ->and(Keyboard::decode("\eOC"))->toBe('right')
+        ->and(Keyboard::decode("\e[D"))->toBe('left');
+});
+
+it('decodes the control keys by name', function (): void {
+    expect(Keyboard::decode("\r"))->toBe('enter')
+        ->and(Keyboard::decode("\t"))->toBe('tab')
+        ->and(Keyboard::decode("\x03"))->toBe('ctrl-c')
+        ->and(Keyboard::decode("\e"))->toBe('esc');
+});
+
+it('passes printable keys through unchanged', function (): void {
+    expect(Keyboard::decode('s'))->toBe('s')
+        ->and(Keyboard::decode('q'))->toBe('q');
+});

--- a/tests/Unit/Tui/LogsPanelTest.php
+++ b/tests/Unit/Tui/LogsPanelTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Helpers;
+use Aws\Command as AwsCommand;
+use GuzzleHttp\Promise\Create;
+use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Aws\CloudWatchLogs;
+use Codinglabs\Yolo\Tui\Panels\LogsPanel;
+use Aws\CloudWatchLogs\CloudWatchLogsClient;
+
+function cloudWatchLogsMock(Result|AwsException $entry): CloudWatchLogsClient
+{
+    return new CloudWatchLogsClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => fn ($cmd, $req) => $entry instanceof AwsException
+            ? Create::rejectionFor($entry)
+            : Create::promiseFor($entry),
+    ]);
+}
+
+it('formats log events as timestamped lines, oldest first', function (): void {
+    $lines = LogsPanel::eventLines([
+        ['timestamp' => 1718000000000, 'message' => 'booting'],
+        ['timestamp' => 1718000001000, 'message' => 'ready'],
+    ]);
+
+    expect($lines)->toHaveCount(2)
+        ->and(implode("\n", $lines))->toContain('booting')->toContain('ready');
+});
+
+it('shows an empty state when there are no log events', function (): void {
+    expect(implode("\n", LogsPanel::eventLines([])))->toContain('No recent log events');
+});
+
+it('reads recent events from CloudWatch', function (): void {
+    Helpers::app()->instance('cloudWatchLogs', cloudWatchLogsMock(
+        new Result(['events' => [['timestamp' => 1718000000000, 'message' => 'hi']]]),
+    ));
+
+    expect(CloudWatchLogs::recent('/yolo/testing/app', 'web'))->toHaveCount(1);
+});
+
+it('treats a missing log group as no events', function (): void {
+    Helpers::app()->instance('cloudWatchLogs', cloudWatchLogsMock(
+        new AwsException('missing', new AwsCommand('FilterLogEvents'), ['code' => 'ResourceNotFoundException']),
+    ));
+
+    expect(CloudWatchLogs::recent('/yolo/testing/app', 'web'))->toBe([]);
+});

--- a/tests/Unit/Tui/LogsPanelTest.php
+++ b/tests/Unit/Tui/LogsPanelTest.php
@@ -6,6 +6,7 @@ use Aws\Command as AwsCommand;
 use GuzzleHttp\Promise\Create;
 use Aws\Exception\AwsException;
 use Codinglabs\Yolo\Aws\CloudWatchLogs;
+use GuzzleHttp\Promise\PromiseInterface;
 use Codinglabs\Yolo\Tui\Panels\LogsPanel;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 
@@ -15,7 +16,7 @@ function cloudWatchLogsMock(Result|AwsException $entry): CloudWatchLogsClient
         'region' => 'ap-southeast-2',
         'version' => 'latest',
         'credentials' => false,
-        'handler' => fn ($cmd, $req) => $entry instanceof AwsException
+        'handler' => fn ($cmd, $req): PromiseInterface => $entry instanceof AwsException
             ? Create::rejectionFor($entry)
             : Create::promiseFor($entry),
     ]);

--- a/tests/Unit/Tui/ManifestPanelTest.php
+++ b/tests/Unit/Tui/ManifestPanelTest.php
@@ -1,0 +1,29 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Panels\ManifestPanel;
+
+it('shows the env manifest and the app config', function (): void {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+        'services' => ['typesense'],
+    ]);
+
+    $captured = [];
+    bindServiceLifecycleWorld([
+        'manifest' => "domain: example.com\nservices:\n  typesense:\n    version: '29.0'\n    nodes: 3\n",
+        'claims' => [],
+        'clusters' => [],
+    ], $captured);
+
+    $panel = new ManifestPanel();
+    $panel->gather();
+    $body = implode("\n", $panel->render(120));
+
+    expect($body)->toContain('example.com')        // env domain
+        ->toContain('services.typesense')          // env offer
+        ->toContain('version=29.0')                // offer summary
+        ->toContain('my-app')                      // app name
+        ->toContain('ap-southeast-2');             // app region
+});

--- a/tests/Unit/Tui/ServicesPanelTest.php
+++ b/tests/Unit/Tui/ServicesPanelTest.php
@@ -1,5 +1,7 @@
 <?php
 
+declare(strict_types=1);
+
 use Codinglabs\Yolo\Tui\Theme;
 use Codinglabs\Yolo\Tui\Panels\ServicesPanel;
 use Symfony\Component\Console\Output\BufferedOutput;

--- a/tests/Unit/Tui/ServicesPanelTest.php
+++ b/tests/Unit/Tui/ServicesPanelTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Theme;
+use Codinglabs\Yolo\Tui\Panels\ServicesPanel;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+it('maps lifecycle states to theme colours', function (): void {
+    expect(ServicesPanel::stateTheme('provision'))->toBe(Theme::Healthy)
+        ->and(ServicesPanel::stateTheme('teardown'))->toBe(Theme::Danger)
+        ->and(ServicesPanel::stateTheme('conflict'))->toBe(Theme::Danger)
+        ->and(ServicesPanel::stateTheme('retain'))->toBe(Theme::Warning)
+        ->and(ServicesPanel::stateTheme('app-side'))->toBe(Theme::Accent)
+        ->and(ServicesPanel::stateTheme('off'))->toBe(Theme::Muted);
+});
+
+it('renders the gate as a themed table', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+
+    $captured = [];
+    bindServiceLifecycleWorld([
+        'manifest' => "domain: example.com\nservices:\n  typesense:\n    version: '29.0'\n    nodes: 3\n",
+        'claims' => ['convict' => ['typesense']],
+        'clusters' => ['convict' => true],
+    ], $captured);
+
+    $panel = new ServicesPanel('testing', new BufferedOutput());
+    $panel->gather();
+    $body = implode("\n", $panel->render(120));
+
+    expect($body)->toContain('typesense')
+        ->toContain('convict')                   // used by
+        ->toContain('version=29.0')              // offer summary
+        ->toContain('<fg=#A3E635>provision');    // healthy state colour
+});

--- a/tests/Unit/Tui/SplashTest.php
+++ b/tests/Unit/Tui/SplashTest.php
@@ -1,0 +1,25 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Splash;
+
+it('splits each wordmark line cyan→lime', function (): void {
+    $wordmark = Splash::wordmark();
+
+    expect($wordmark)->toHaveCount(count(Splash::WORD));
+
+    foreach ($wordmark as [$tagged, $length]) {
+        expect($tagged)->toContain('<fg=#2DD4D4>')   // cyan left half
+            ->toContain('<fg=#A3E635>')               // lime right half
+            ->and($length)->toBeGreaterThan(0);
+    }
+});
+
+it('composes a centred splash frame with the wordmark, flame and tagline', function (): void {
+    $lines = Splash::lines(80);
+    $joined = implode("\n", $lines);
+
+    expect($joined)->toContain('deploy · observe · steer')   // tagline
+        ->toContain('<fg=#FFC83D>')                          // gold flame
+        ->toContain('<fg=#2DD4D4>')                          // cyan wordmark half
+        ->and($lines[1])->toStartWith(' ');                  // rows are centre-padded
+});

--- a/tests/Unit/Tui/ThemeTest.php
+++ b/tests/Unit/Tui/ThemeTest.php
@@ -1,0 +1,20 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Theme;
+
+it('wraps text in a truecolor foreground tag', function (): void {
+    expect(Theme::Primary->fg('hi'))->toBe('<fg=#2DD4D4>hi</>');
+});
+
+it('renders a bold foreground tag', function (): void {
+    expect(Theme::Danger->bold('down'))->toBe('<fg=#FF3B5C;options=bold>down</>');
+});
+
+it('renders dark canvas text on a neon background fill', function (): void {
+    expect(Theme::Selection->bg('typesense'))->toBe('<fg=#160E2E;bg=#FF2E97>typesense</>');
+});
+
+it('exposes a hex value per role', function (): void {
+    expect(Theme::Healthy->value)->toBe('#A3E635')
+        ->and(Theme::Canvas->value)->toBe('#160E2E');
+});

--- a/tests/Unit/Tui/TuiTest.php
+++ b/tests/Unit/Tui/TuiTest.php
@@ -44,7 +44,9 @@ function stubPanel(string $title, string $hotkey): Panel
 
 function tui(array $panels): Tui
 {
-    return new Tui(new Screen(new BufferedOutput()), new Keyboard(), 'production', $panels);
+    $output = new BufferedOutput();
+
+    return new Tui(new Screen($output), new Keyboard(), 'production', $panels, $output);
 }
 
 function dotStatus(ServerGroup $group, int $running, int $desired, ?string $rollout = null): array

--- a/tests/Unit/Tui/TuiTest.php
+++ b/tests/Unit/Tui/TuiTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use Codinglabs\Yolo\Tui\Tui;
+use Codinglabs\Yolo\Tui\Screen;
+use Codinglabs\Yolo\Tui\Keyboard;
+use Codinglabs\Yolo\Tui\Panels\Panel;
+use Codinglabs\Yolo\Enums\ServerGroup;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+function stubPanel(string $title, string $hotkey): Panel
+{
+    return new class($title, $hotkey) implements Panel
+    {
+        public function __construct(public string $label, public string $key) {}
+
+        public function title(): string
+        {
+            return $this->label;
+        }
+
+        public function hotkey(): string
+        {
+            return $this->key;
+        }
+
+        public function gather(): void {}
+
+        public function render(int $width): array
+        {
+            return ['body:' . $this->label];
+        }
+
+        public function hints(): array
+        {
+            return ['x thing'];
+        }
+
+        public function onKey(string $key): ?Closure
+        {
+            return $key === 'r' ? fn (): string => 'modal' : null;
+        }
+    };
+}
+
+function tui(array $panels): Tui
+{
+    return new Tui(new Screen(new BufferedOutput()), new Keyboard(), 'production', $panels);
+}
+
+function dotStatus(ServerGroup $group, int $running, int $desired, ?string $rollout = null): array
+{
+    return ['group' => $group, 'running' => $running, 'desired' => $desired, 'rolloutState' => $rollout];
+}
+
+it('navigates tabs with arrows and tab, wrapping at both ends', function (): void {
+    $tui = tui([stubPanel('A', 'a'), stubPanel('B', 'b'), stubPanel('C', 'c')]);
+
+    $tui->handleKey('right');
+    expect($tui->activeIndex())->toBe(1);
+
+    $tui->handleKey('tab');
+    expect($tui->activeIndex())->toBe(2);
+
+    $tui->handleKey('right');
+    expect($tui->activeIndex())->toBe(0);
+
+    $tui->handleKey('left');
+    expect($tui->activeIndex())->toBe(2);
+});
+
+it('jumps to a tab by number and by hotkey', function (): void {
+    $tui = tui([stubPanel('A', 'a'), stubPanel('B', 'b'), stubPanel('C', 'c')]);
+
+    $tui->handleKey('3');
+    expect($tui->activeIndex())->toBe(2);
+
+    $tui->handleKey('a');
+    expect($tui->activeIndex())->toBe(0);
+});
+
+it('delegates an unhandled key to the active panel as a modal closure', function (): void {
+    $tui = tui([stubPanel('A', 'a'), stubPanel('B', 'b')]);
+
+    expect($tui->handleKey('r'))->toBeInstanceOf(Closure::class)
+        ->and($tui->handleKey('z'))->toBeNull();
+});
+
+it('quits on q', function (): void {
+    $tui = tui([stubPanel('A', 'a')]);
+
+    expect($tui->quitting())->toBeFalse();
+
+    $tui->handleKey('q');
+
+    expect($tui->quitting())->toBeTrue();
+});
+
+it('renders the global bar with brand, environment and coloured health dots', function (): void {
+    $bar = Tui::globalBar('production', [dotStatus(ServerGroup::WEB, 3, 3), dotStatus(ServerGroup::SCHEDULER, 0, 1)]);
+
+    expect($bar)->toContain('yolo tui')
+        ->toContain('production')
+        ->toContain('<fg=#A3E635>')   // healthy web → lime
+        ->toContain('<fg=#FF3B5C>');  // dead scheduler → neon red
+});
+
+it('shows the deploy banner on the global bar while a rollout is live', function (): void {
+    $bar = Tui::globalBar('production', [dotStatus(ServerGroup::WEB, 2, 3, 'IN_PROGRESS')]);
+
+    expect($bar)->toContain('deploying web 2/3')
+        ->toContain('<fg=#FFC83D>');  // gold
+});
+
+it('marks the active tab gold and underlined, the rest slate', function (): void {
+    $bar = Tui::tabBar([stubPanel('Status', 's'), stubPanel('Logs', 'l')], 0);
+
+    expect($bar)->toContain('options=bold,underscore')
+        ->toContain('Status')
+        ->toContain('<fg=#6C7A99>Logs</>');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

`yolo` had no live operator surface — diagnosing an environment meant juggling `yolo status`, `yolo audit`, the AWS console, and hand-edited YAML. This adds an interactive, tabbed terminal dashboard (`yolo tui`) plus the standalone command it leans on (`yolo services`), in an 80s "Outrun" theme drawn from the logo.

Built in dependency order, one commit per layer:

- **`yolo services <env>`** — the two-key service gate (env offers ∧ app claims) made visible and editable. Interactive table (offered · used by · lifecycle state) with add/edit/remove driven generically off each service's offer fields — no per-service code. `--json` reads state and `--add/--remove/--set` mutate non-interactively (the agent/CI contract). Editing writes + uploads the env manifest; guards match `environment:manifest:push`.
- **`yolo tui [env]`** — a tabbed shell over the status live-loop: always-on global health bar, tab bar, footer, key routing (arrows/tab/number/hotkey), and a Laravel Prompts modal handoff. Prompts for the environment when omitted.
  - **Status** — reuses `RendersServiceStatus`.
  - **Services** — the gate; ⏎ launches the full interactive manager (reuses `ServicesCommand`).
  - **Deployments** — ECR history with the running version marked; live rollout progress (locking rollback) when one's in flight; ⏎ launches the interactive `rollback`.
  - **Logs** — tails CloudWatch per group (`g` cycles); new `CloudWatchLogs::recent()`.
  - **Manifest** — read view of the env + app manifests.
- **DeployObserver** — reads in-flight rollouts straight from ECS, so a deploy shows on the global bar whoever triggered it (your shell, CI, or the tab's own rollback).
- **Theme / Screen / Keyboard / Splash / Columns** — the Outrun palette (truecolor with named-fallback degradation), the alternate-screen render loop, a non-blocking raw-mode key reader, the launch splash (rocket + cyan→lime wordmark, plays over the first fetch, any-key skip), and a pad-before-colour table helper.

**Is there anything the reviewer needs to know to deploy this?**

- **`tui` adds no new powers** — every action routes through the existing commands (`status`, `services`, `rollback`), so the destructive surface and its guards live in exactly one place. The standalone commands are unchanged; `tui` is the cockpit on top.
- **The interactive loop needs a real terminal to sign off.** The raw-ANSI render loop, `stty` key reader, alternate-screen, and the Prompts modal handoff can't be meaningfully unit-tested — they're `@codeCoverageIgnore`d, and all the *logic* (theme tags, key decode + routing, splash/table composition, observer, services CRUD, every panel's render/gather) is tested. Please drive it in a terminal (`yolo tui <env>`) to confirm the live UX.
- It's interactive only — non-TTY / `NO_COLOR` / `--snapshot` paths are unaffected; `tui` refuses a non-interactive shell and points at `status --snapshot`.
- New surface is documented (command reference + a new Interactive Dashboard guide + sidebar).
- Full local quality stack green — Rector / Pint / PHPStan (L5) / Pest (968 passing). Coverage gate (≥68) runs on CI (no local driver).

🤖 Generated with [Claude Code](https://claude.ai/code)
