### PR TITLE
Animate the yolo tui splash — rocket launch + wordmark wipe

### DIFF
--- a/src/Tui/Keyboard.php
+++ b/src/Tui/Keyboard.php
@@ -37,7 +37,10 @@ class Keyboard
     }
 
     /**
-     * Read whatever keypress is waiting, or null if none.
+     * Read whatever keypress is waiting, or null if none. Impure — each poll may
+     * return a different key (or nothing), so callers can poll it in a loop.
+     *
+     * @phpstan-impure
      *
      * @codeCoverageIgnore raw terminal I/O
      */

--- a/src/Tui/Splash.php
+++ b/src/Tui/Splash.php
@@ -3,13 +3,17 @@
 namespace Codinglabs\Yolo\Tui;
 
 /**
- * The launch splash — a rocket and flame above the cyan→lime YOLO wordmark, in
- * the Outrun palette. It plays over the first AWS fetch (so it masks latency
- * rather than adding it), holds to a ~1s floor so it registers, and any keypress
- * skips it. The caller gates it off for non-TTY / NO_COLOR shells.
+ * The launch splash. The rocket sits on the pad while the first fetch runs, then
+ * lifts off — climbing a constant-height canvas with a growing flame/exhaust
+ * trail — while the YOLO wordmark wipes in left-to-right (cyan→lime, the logo's
+ * gradient) and the tagline lands as it settles. Any keypress skips it; the
+ * caller gates it off for non-TTY / NO_COLOR shells.
  */
 class Splash
 {
+    /** How many rows the rocket climbs across the animation. */
+    public const LIFT = 5;
+
     /** @var array<int, string> */
     public const ROCKET = [
         '    /\\',
@@ -18,12 +22,6 @@ class Splash
         '  |    |',
         ' /|    |\\',
         '/_|____|_\\',
-    ];
-
-    /** @var array<int, string> */
-    public const FLAME = [
-        '   )||(',
-        '  ◢◤◢◤◢',
     ];
 
     /** @var array<int, string> */
@@ -39,53 +37,83 @@ class Splash
     public const TAGLINE = 'deploy · observe · steer';
 
     /**
-     * The composed splash frame — rocket and flame above the cyan→lime wordmark,
-     * each row centred to $width. Pure: returns themed lines, writes nothing.
+     * The thrust + exhaust glyphs below the rocket, brightest first, fading down
+     * the trail. Index 0 is the always-lit base thrust; deeper rows appear as the
+     * rocket climbs.
+     *
+     * @var array<int, array{0: string, 1: Theme}>
+     */
+    private const array TRAIL = [
+        ['◢◤◢◤◢', Theme::Active],
+        ['▒▓▓▒', Theme::Active],
+        ['░▒▒░', Theme::Warning],
+        [' ░░ ', Theme::Warning],
+        [' ·· ', Theme::Muted],
+        ['  ·  ', Theme::Muted],
+    ];
+
+    /**
+     * One animation frame at $progress (0 = on the pad, 1 = settled). The canvas
+     * is a constant height so the in-place repaint never jumps: as the rocket
+     * rises, the blank rows above it become exhaust-trail rows below it.
      *
      * @return array<int, string>
      */
-    public static function lines(int $width = 80): array
+    public static function frame(float $progress, int $width = 80): array
     {
-        $rows = [''];
+        $progress = max(0.0, min(1.0, $progress));
+        $above = (int) round((1.0 - $progress) * self::LIFT);
+        $trail = self::LIFT - $above;
 
-        foreach (static::ROCKET as $line) {
+        $rows = array_fill(0, $above, '');
+
+        foreach (self::ROCKET as $line) {
             $rows[] = self::centre(Theme::Text->fg($line), mb_strlen($line), $width);
         }
 
-        foreach (static::FLAME as $line) {
-            $rows[] = self::centre(Theme::Active->fg($line), mb_strlen($line), $width);
+        foreach (array_slice(self::TRAIL, 0, $trail + 1) as [$glyph, $colour]) {
+            $rows[] = self::centre($colour->fg($glyph), mb_strlen($glyph), $width);
         }
 
         $rows[] = '';
 
-        foreach (static::wordmark() as [$tagged, $rawLength]) {
+        foreach (self::wordmarkReveal($progress) as [$tagged, $rawLength]) {
             $rows[] = self::centre($tagged, $rawLength, $width);
         }
 
         $rows[] = '';
-        $rows[] = self::centre(Theme::Accent->fg(static::TAGLINE), mb_strlen((string) static::TAGLINE), $width);
-        $rows[] = '';
+        $rows[] = $progress >= 1.0
+            ? self::centre(Theme::Accent->fg(self::TAGLINE), mb_strlen(self::TAGLINE), $width)
+            : '';
 
         return $rows;
     }
 
     /**
-     * Each wordmark line split at its midpoint — left half cyan, right half lime —
-     * to echo the logo's gradient cheaply. Returns [taggedLine, rawLength] pairs.
+     * The wordmark wiped in left-to-right to $progress — the revealed run split
+     * cyan (left half) → lime (right half), echoing the logo. Each entry is
+     * [taggedVisible, fullLineLength] so centring stays fixed as it fills.
      *
      * @return array<int, array{0: string, 1: int}>
      */
-    public static function wordmark(): array
+    public static function wordmarkReveal(float $progress): array
     {
-        return array_map(static function (string $line): array {
+        $progress = max(0.0, min(1.0, $progress));
+        $longest = max(array_map(mb_strlen(...), self::WORD));
+        $reveal = (int) ceil($progress * $longest);
+
+        return array_map(static function (string $line) use ($reveal): array {
             $length = mb_strlen($line);
+            $shown = min($reveal, $length);
             $mid = (int) ceil($length / 2);
 
-            $tagged = Theme::Primary->fg(mb_substr($line, 0, $mid))
-                . Theme::Healthy->fg(mb_substr($line, $mid));
+            $cyan = mb_substr($line, 0, min($shown, $mid));
+            $lime = $shown > $mid ? mb_substr($line, $mid, $shown - $mid) : '';
+
+            $tagged = Theme::Primary->fg($cyan) . ($lime === '' ? '' : Theme::Healthy->fg($lime));
 
             return [$tagged, $length];
-        }, static::WORD);
+        }, self::WORD);
     }
 
     private static function centre(string $tagged, int $rawLength, int $width): string
@@ -94,25 +122,52 @@ class Splash
     }
 
     /**
-     * Paint the splash, run $work (the first fetch) underneath it, then hold to a
-     * ~1s floor so it's seen — bailing early on any keypress. Never adds time
-     * beyond the floor: a slow fetch is simply masked by the frame.
+     * Hold the rocket on the pad while $work (the first fetch) runs, then play the
+     * launch — progress 0→1 over ~1.2s — and settle briefly. Any keypress skips.
      *
      * @codeCoverageIgnore timing + terminal I/O — exercised by hand, not in CI.
      */
     public function play(Screen $screen, Keyboard $keyboard, callable $work): void
     {
-        $screen->paint(static::lines($screen->width()));
+        $width = $screen->width();
 
-        $started = microtime(true);
+        $screen->paint(self::frame(0.0, $width));
         $work();
 
-        while (microtime(true) - $started < 1.0) {
-            if ($keyboard->read() !== null) {
-                break;
+        $steps = 26;
+
+        for ($step = 0; $step <= $steps; $step++) {
+            if (self::skipRequested($keyboard)) {
+                return;
             }
 
-            usleep(50_000);
+            $screen->paint(self::frame($step / $steps, $width));
+            usleep(42_000);
         }
+
+        $settle = microtime(true) + 0.5;
+
+        while (microtime(true) < $settle) {
+            if (self::skipRequested($keyboard)) {
+                return;
+            }
+
+            usleep(40_000);
+        }
+    }
+
+    /**
+     * Whether the operator pressed a key to skip the splash. Reads live keyboard
+     * input, so each call stands alone (the two poll loops both consult it).
+     *
+     * @phpstan-impure
+     *
+     * @codeCoverageIgnore raw terminal I/O — exercised by hand, not in CI.
+     */
+    private static function skipRequested(Keyboard $keyboard): bool
+    {
+        $key = $keyboard->read();
+
+        return $key !== null;
     }
 }

--- a/src/Tui/Splash.php
+++ b/src/Tui/Splash.php
@@ -137,7 +137,7 @@ class Splash
         $steps = 26;
 
         for ($step = 0; $step <= $steps; $step++) {
-            if (self::skipRequested($keyboard)) {
+            if ($keyboard->read() !== null) {
                 return;
             }
 
@@ -148,26 +148,11 @@ class Splash
         $settle = microtime(true) + 0.5;
 
         while (microtime(true) < $settle) {
-            if (self::skipRequested($keyboard)) {
+            if ($keyboard->read() !== null) {
                 return;
             }
 
             usleep(40_000);
         }
-    }
-
-    /**
-     * Whether the operator pressed a key to skip the splash. Reads live keyboard
-     * input, so each call stands alone (the two poll loops both consult it).
-     *
-     * @phpstan-impure
-     *
-     * @codeCoverageIgnore raw terminal I/O — exercised by hand, not in CI.
-     */
-    private static function skipRequested(Keyboard $keyboard): bool
-    {
-        $key = $keyboard->read();
-
-        return $key !== null;
     }
 }

--- a/tests/Unit/Tui/SplashTest.php
+++ b/tests/Unit/Tui/SplashTest.php
@@ -2,24 +2,56 @@
 
 use Codinglabs\Yolo\Tui\Splash;
 
-it('splits each wordmark line cyan→lime', function (): void {
-    $wordmark = Splash::wordmark();
+function leadingBlankRows(array $rows): int
+{
+    $count = 0;
 
-    expect($wordmark)->toHaveCount(count(Splash::WORD));
+    foreach ($rows as $row) {
+        if ($row !== '') {
+            break;
+        }
 
-    foreach ($wordmark as [$tagged, $length]) {
+        $count++;
+    }
+
+    return $count;
+}
+
+it('reveals the wordmark left-to-right, splitting cyan→lime when fully shown', function (): void {
+    $full = Splash::wordmarkReveal(1.0);
+
+    expect($full)->toHaveCount(count(Splash::WORD));
+
+    foreach ($full as [$tagged, $length]) {
         expect($tagged)->toContain('<fg=#2DD4D4>')   // cyan left half
             ->toContain('<fg=#A3E635>')               // lime right half
             ->and($length)->toBeGreaterThan(0);
     }
 });
 
-it('composes a centred splash frame with the wordmark, flame and tagline', function (): void {
-    $lines = Splash::lines(80);
-    $joined = implode("\n", $lines);
+it('shows no wordmark at the start of the wipe', function (): void {
+    [$tagged] = Splash::wordmarkReveal(0.0)[0];
 
-    expect($joined)->toContain('deploy · observe · steer')   // tagline
-        ->toContain('<fg=#FFC83D>')                          // gold flame
-        ->toContain('<fg=#2DD4D4>')                          // cyan wordmark half
-        ->and($lines[1])->toStartWith(' ');                  // rows are centre-padded
+    expect($tagged)->toBe('<fg=#2DD4D4></>');  // an empty cyan run, no lime yet
+});
+
+it('animates the rocket: on the pad at 0, lifted off with the tagline at 1', function (): void {
+    $start = Splash::frame(0.0, 80);
+    $end = Splash::frame(1.0, 80);
+
+    // Constant-height canvas — the in-place repaint must never jump.
+    expect($start)->toHaveCount(count($end));
+
+    // The rocket sits low on the pad, then climbs (fewer blank rows above it).
+    expect(leadingBlankRows($start))->toBeGreaterThan(leadingBlankRows($end));
+
+    expect(implode("\n", $end))->toContain('deploy · observe · steer')   // tagline lands
+        ->toContain('<fg=#A3E635>');                                     // lime wordmark
+    expect(implode("\n", $start))->not->toContain('deploy · observe · steer');
+});
+
+it('grows the exhaust trail as the rocket climbs', function (): void {
+    $trailRows = fn (array $rows): int => count(array_filter($rows, fn (string $row): bool => str_contains($row, '◢') || str_contains($row, '▓') || str_contains($row, '·')));
+
+    expect($trailRows(Splash::frame(1.0, 80)))->toBeGreaterThan($trailRows(Splash::frame(0.0, 80)));
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

The splash was static — it painted one frame and held. This makes it a real launch animation:

- `frame(progress)` composes a **constant-height** canvas (the in-place repaint never jumps): as the rocket climbs, the blank rows above it become a growing flame/exhaust trail below it.
- The **YOLO wordmark wipes in left-to-right**, the revealed run split cyan→lime (the logo's gradient).
- The **tagline lands** as it settles.
- The rocket **waits on the pad while the first fetch runs**, then lifts off; any key skips.

**Is there anything the reviewer needs to know to deploy this?**

- Pure, tested frame composition (`frame()` / `wordmarkReveal()` — rocket position, trail growth, wipe, tagline); only the ~1.2s timing loop is `@codeCoverageIgnore`. Best seen live: `yolo tui <env>`.
- Full local quality stack green — Rector / Pint / PHPStan (L5) / Pest.

🤖 Generated with [Claude Code](https://claude.ai/code)