### PR TITLE
Splash boot line — 'connecting to <env>…' on the pad

### DIFF
--- a/src/Tui/Splash.php
+++ b/src/Tui/Splash.php
@@ -59,7 +59,7 @@ class Splash
      *
      * @return array<int, string>
      */
-    public static function frame(float $progress, int $width = 80): array
+    public static function frame(float $progress, int $width = 80, string $status = ''): array
     {
         $progress = max(0.0, min(1.0, $progress));
         $above = (int) round((1.0 - $progress) * self::LIFT);
@@ -85,6 +85,13 @@ class Splash
         $rows[] = $progress >= 1.0
             ? self::centre(Theme::Accent->fg(self::TAGLINE), mb_strlen(self::TAGLINE), $width)
             : '';
+
+        // A boot line for the pad-wait (the rocket holds here while the first
+        // fetch runs). Always a row — empty during the launch — so the height
+        // stays constant and the repaint never jumps.
+        $rows[] = $status === ''
+            ? ''
+            : self::centre(Theme::Muted->fg('▸ ' . $status), mb_strlen('▸ ' . $status), $width);
 
         return $rows;
     }
@@ -127,11 +134,11 @@ class Splash
      *
      * @codeCoverageIgnore timing + terminal I/O — exercised by hand, not in CI.
      */
-    public function play(Screen $screen, Keyboard $keyboard, callable $work): void
+    public function play(Screen $screen, Keyboard $keyboard, callable $work, string $status = ''): void
     {
         $width = $screen->width();
 
-        $screen->paint(self::frame(0.0, $width));
+        $screen->paint(self::frame(0.0, $width, $status));
         $work();
 
         $steps = 26;

--- a/src/Tui/Tui.php
+++ b/src/Tui/Tui.php
@@ -50,7 +50,12 @@ class Tui
 
         try {
             if ($this->splash) {
-                (new Splash())->play($this->screen, $this->keyboard, fn () => $this->panels[$this->active]->gather());
+                (new Splash())->play(
+                    $this->screen,
+                    $this->keyboard,
+                    fn () => $this->panels[$this->active]->gather(),
+                    'connecting to ' . $this->environment . '…',
+                );
             }
 
             while (! $this->quit) {

--- a/tests/Unit/Tui/SplashTest.php
+++ b/tests/Unit/Tui/SplashTest.php
@@ -50,6 +50,15 @@ it('animates the rocket: on the pad at 0, lifted off with the tagline at 1', fun
     expect(implode("\n", $start))->not->toContain('deploy · observe · steer');
 });
 
+it('shows a boot line on the pad without changing the canvas height', function (): void {
+    $padWithStatus = Splash::frame(0.0, 80, 'connecting to production…');
+    $launch = Splash::frame(1.0, 80);
+
+    expect(implode("\n", $padWithStatus))->toContain('connecting to production…')
+        ->and($padWithStatus)->toHaveCount(count($launch));  // the status row is always reserved
+    expect(implode("\n", $launch))->not->toContain('connecting');
+});
+
 it('grows the exhaust trail as the rocket climbs', function (): void {
     $trailRows = fn (array $rows): int => count(array_filter($rows, fn (string $row): bool => str_contains($row, '◢') || str_contains($row, '▓') || str_contains($row, '·')));
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

While the rocket waits on the pad during the first fetch, the splash now shows a `▸ connecting to <env>…` line, so the brief load reads as intentional rather than a frozen frame. The status row is always reserved (empty during the launch) so the constant-height canvas never jumps.

**Is there anything the reviewer needs to know to deploy this?**

- Small, pure addition to `frame()` (tested); the env message threads through `Tui::run()`. Best seen live: `yolo tui <env>`.
- Rector / Pint / PHPStan (L5) / Pest green locally (matched to CI tool versions).

🤖 Generated with [Claude Code](https://claude.ai/code)