### PR TITLE
LPX-680: /yolo Boost skill + auto-discovered guideline (package-shipped)

### DIFF
--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -48,6 +48,7 @@ export default defineConfig({
           { text: 'Multi-Tenancy', link: '/guide/multi-tenancy' },
           { text: 'Scaling', link: '/guide/scaling' },
           { text: 'Interactive Dashboard', link: '/guide/tui' },
+          { text: 'The /yolo Skill', link: '/guide/the-yolo-skill' },
           { text: 'CI/CD', link: '/guide/ci-cd' },
         ],
       },

--- a/docs/guide/the-yolo-skill.md
+++ b/docs/guide/the-yolo-skill.md
@@ -20,7 +20,7 @@ There is deliberately **no dotfiles / hand-copied skill** — the package is the
 
 ## The guideline (works today)
 
-Laravel Boost composes `resources/boost/guidelines/*.blade.php` from every installed package into your app's AI context. Because the file lives in YOLO's package, **any app that requires YOLO automatically gets it** — no install step. It orients the agent on the command surface, the manifest essentials, the read-only `--json` data-pipe, and the safety rule that infrastructure mutations are human-gated.
+Laravel Boost discovers `resources/boost/guidelines/*.blade.php` in your **direct** Composer dependencies — no service provider or registration needed; the directory existing in `vendor/codinglabsau/yolo/` is the whole mechanism. It's **opt-in at install time**, not automatic on `composer require`: run `boost:install` (or re-run it after adding YOLO) and tick **`codinglabsau/yolo`** in the *"Which third-party AI guidelines do you want to install?"* prompt. Boost then composes the guideline into your app's `CLAUDE.md` / `AGENTS.md`. It orients the agent on the command surface, the manifest essentials, the read-only `--json` data-pipe, and the safety rule that infrastructure mutations are human-gated.
 
 ## The skill
 

--- a/docs/guide/the-yolo-skill.md
+++ b/docs/guide/the-yolo-skill.md
@@ -1,0 +1,52 @@
+# The `/yolo` Skill
+
+YOLO ships an AI **skill** and a **Boost guideline** inside the composer package, so an agent (Claude Code, or anything reading [Laravel Boost](https://github.com/laravel/boost) guidelines) can operate a YOLO environment knowledgeably and safely — without you hand-maintaining a copy somewhere.
+
+The design rule is a hard split:
+
+- **YOLO is a dumb data-pipe.** Its read commands emit machine-readable JSON; it never calls an AI.
+- **The skill is the brain.** It reads that JSON, reasons about health, drift, scaling and inventory, and *proposes* changes. Every mutation stays human-gated.
+
+## What ships
+
+Both artefacts live under `resources/` (which the package exports — unlike `docs/` and `tests/`), so they travel with `composer require codinglabsau/yolo`:
+
+| Artefact | Path in the package | Role |
+|---|---|---|
+| Skill | `resources/boost/skills/yolo/SKILL.md` | The `/yolo` agent skill — the brain |
+| Guideline | `resources/boost/guidelines/yolo.blade.php` | Always-on YOLO context for any agent in a Boost app |
+
+There is deliberately **no dotfiles / hand-copied skill** — the package is the single source of truth, so the skill is always version-accurate with the YOLO you have installed.
+
+## The guideline (works today)
+
+Laravel Boost composes `resources/boost/guidelines/*.blade.php` from every installed package into your app's AI context. Because the file lives in YOLO's package, **any app that requires YOLO automatically gets it** — no install step. It orients the agent on the command surface, the manifest essentials, the read-only `--json` data-pipe, and the safety rule that infrastructure mutations are human-gated.
+
+## The skill
+
+The skill is a standard Agent Skill (the same `SKILL.md` frontmatter format Claude Code uses, which Boost adopts for skill distribution). Boost installs package-provided skills for you; on a Boost version without skill installation, symlink it from the package as an interim:
+
+```bash
+ln -s "$(pwd)/vendor/codinglabsau/yolo/resources/boost/skills/yolo" ~/.claude/skills/yolo
+```
+
+### Invoking it
+
+- **`/yolo`** — a full sweep: read `status`/`audit` (and a `sync --check`) across the environments and report a tight green / needs-attention summary.
+- **`/yolo <question>`** — a specific ask ("is prod scaling healthy?"); it pulls only the data the question needs.
+- **`/loop /yolo`** — an attended copilot that stays quiet while everything's green and speaks up when a signal crosses a line.
+
+## The data-pipe the skill reads
+
+These commands are read-only and scriptable (non-zero exit signals a problem):
+
+| Command | Emits |
+|---|---|
+| [`status <env> --json`](/reference/commands#yolo-status) | `{app, environment, groups[]}` — per-group tasks, spec, revision, version, rollout, scaling, load. Non-zero if a deploy is failed. |
+| [`audit <env> --json`](/reference/commands#yolo-audit) | `{environment, liveApps[], okCount, unexpectedCount, resources[]}` — ownership/inventory check. |
+| [`sync <env> --check`](/reference/commands#yolo-sync) | The read-only plan; non-zero exit on [drift](/guide/provisioning). |
+| [`services <env> --json`](/reference/commands#yolo-services) | The [service-lifecycle](/guide/provisioning#the-service-lifecycle) gate as data. |
+
+## Safety
+
+The skill is read-first. It will run the `--json` reads and `sync --check` freely, but it **never** runs a mutation — `deploy`, `rollback`, [`scale`](/guide/scaling), `sync` (apply), `env:push` — on its own. It prepares the command for you to run, or lands the change as a PR for a human to merge and deploy. This matches YOLO's own approve-before-apply posture for [provisioning](/guide/provisioning).

--- a/resources/boost/guidelines/yolo.blade.php
+++ b/resources/boost/guidelines/yolo.blade.php
@@ -1,0 +1,44 @@
+## YOLO deployment (codinglabsau/yolo)
+
+This app is deployed to **AWS Fargate (ECS)** with YOLO (`vendor/bin/yolo`). YOLO provisions and reconciles the app's AWS resources (VPC/subnets, ALB, ECR, ECS cluster/service/task defs, S3, IAM, Route 53, ACM, SQS, CloudWatch) and runs zero-downtime container deploys. Config lives in `yolo.yml`; each command takes an `<env>` argument naming a key under `environments`.
+
+### Safety — never run infrastructure mutations unprompted
+
+Treat these as **human-gated**: `deploy`, `rollback`, `scale`, `sync` (apply), `env:push`, `environment:*:push`, `services --add/--remove/--set`. They hit a real AWS account. Prepare and explain them; let a human run them (or land the change as a PR). Do **not** pass `--force`/`-f` unless explicitly asked for an unattended apply.
+
+These are **read-only and safe** to run when you need live state: `status <env> --json`, `audit <env> --json`, `services <env> --json`, `sync <env> --check`.
+
+### Machine-readable state (the data-pipe)
+
+- `yolo status <env> --json` → `{app, environment, groups[]}`; each group (`web`/`queue`/`scheduler`) carries `tasks{running,desired,pending}`, `spec{cpu,memory,launch}`, `revision`, `version`, `rollout{state,reason}`, `scaling`, `cpuTarget`, `load`. **Exits non-zero if a deploy is currently failed.**
+- `yolo audit <env> --json` → `{environment, liveApps[], okCount, unexpectedCount, resources[]}`; each resource has `{scope, status, type, name, app, reason, arn}` where `status` is `ok`/`unexpected`. Ownership/inventory check, not a config check.
+- `yolo sync <env> --check` → read-only plan; **non-zero exit on drift** from the manifest. The CI drift gate.
+- `yolo services <env> --json` → which env-shared services are offered and which apps claim them.
+
+### Command surface
+
+| Command | Purpose |
+|---|---|
+| `init` | Scaffold `yolo.yml`, Dockerfile, supporting files (only command that runs without a manifest) |
+| `build <env>` | Build + push the container image to ECR |
+| `deploy <env>` | Build, then zero-downtime rollout (circuit breaker auto-rolls-back on failure) |
+| `rollback <env>` | Re-deploy a prior ECR version, no build (DB is **not** reverted) |
+| `status <env>` | Live dashboard (`--snapshot` one frame, `--json` machine-readable) |
+| `run <env>` | Shell / one-off command in a running container (ECS Exec) |
+| `scale <env> [count]` | Adjust capacity out of band (`--web`/`--queue`, `--min`/`--max`) |
+| `services <env>` | View/manage env-shared services |
+| `tui [env]` | Interactive dashboard |
+| `sync[:account\|:environment\|:app] <env>` | Provision/reconcile resources (`--check` plan-only, `--force` skip confirm) |
+| `audit[:environment\|:app] <env>` | Flag resources YOLO can't account for (`--unexpected`, `--json`) |
+| `env:pull\|env:push <env>` | Download/upload the app's `.env` from S3 (push shows a diff, then offers to delete the local copy) |
+
+`sync` is always approve-before-apply: it prints the full plan (Will create / Pending changes / Skipping) and confirms before writing — declining is the preview. `--check` is the non-interactive plan-only/fail-on-drift form for CI. There is **no `--dry-run`** (that was the retired EC2-era YOLO).
+
+### Manifest (`yolo.yml`) essentials
+
+- Required keys per environment: `name`, `region`, `account-id`. Topology is encoded by what's declared.
+- `tasks.web` / `tasks.queue` / `tasks.scheduler` — declaring a task provisions its ECS service; bundling vs standalone is derived from presence. `tasks.web.autoscaling` (with `min`/`max`) turns on web target-tracking autoscaling (on by default from `init`, bounds 1–4).
+- Multi-tenancy is a manifest concern (`tenants`), fanned out at the step level — there is no `sync:tenant`/`deploy:tenant` verb; narrow with `--tenant=<id>`.
+- This is the **Fargate** YOLO. There is no EC2/ASG/CodeDeploy/AMI/`image:create`/`stage`/instance-type — if you see those referenced anywhere, it's stale alpha-era material.
+
+When unsure of a flag, run `vendor/bin/yolo <command> --help`.

--- a/resources/boost/skills/yolo/SKILL.md
+++ b/resources/boost/skills/yolo/SKILL.md
@@ -1,0 +1,117 @@
+---
+name: yolo
+description: Operate a YOLO-deployed Laravel app on AWS Fargate — read live service/infra state and reason about health, drift, scaling and cost. Use when asked to check, audit, diagnose, or propose changes to a YOLO environment (status, deploys, autoscaling, infra drift, manifest hygiene). Read-first; every mutation is human-gated.
+allowed-tools:
+  - Bash
+  - Read
+  - Grep
+  - Glob
+  - Edit
+  - Write
+---
+
+# YOLO
+
+[YOLO](https://github.com/codinglabsau/yolo) deploys Laravel apps to **AWS Fargate (ECS)**. This skill is the *brain*; the `vendor/bin/yolo` CLI is a **dumb data-pipe**. You read its machine-readable output, reason about it, and **propose** changes — you never let YOLO act on its own, and **YOLO never calls Claude**. You are the only agent in this loop.
+
+## The one rule that matters
+
+**Read freely. Never mutate AWS without explicit human approval.**
+
+- **Safe to run unprompted** (read-only, no AWS writes): `status --json`, `audit --json`, `services --json`, `sync <env> --check`.
+- **Mutations — never run these yourself.** `sync` (apply), `deploy`, `rollback`, `scale`, `env:push`, `environment:*:push`, `services --add/--remove/--set`. Prepare them, explain them, and hand them to the human to run — or land the change as a **PR** (edit `yolo.yml`, open the PR) and let a human merge and deploy.
+- Even with approval, honour YOLO's own confirm gates — don't reach for `--force`/`-f` unless the human explicitly asked for an unattended apply.
+
+This mirrors the operator's standing rule: infrastructure commands never run against a real account without explicit confirmation.
+
+## Prerequisites
+
+- `codinglabsau/yolo` installed (`vendor/bin/yolo` exists) and a `yolo.yml` manifest in the project root.
+- AWS auth resolves outside CI from `YOLO_<ENV>_AWS_PROFILE` in `.env`; YOLO STS-verifies the profile matches the manifest `account-id` before any call. If a command errors on auth, surface it — don't try to "fix" credentials.
+- `<env>` is a key under `environments` in `yolo.yml` (usually `production` / `staging`). Read the manifest first if you don't know the env names.
+
+## The data surface
+
+These are your eyes. All exit non-zero on a problem, so they're scriptable.
+
+### `yolo status <env> --json`
+
+Live ECS / Auto Scaling / CloudWatch state. **Exits non-zero if a deployment is currently failed.**
+
+```json
+{
+  "app": "myapp",
+  "environment": "production",
+  "groups": [
+    {
+      "group": "web",
+      "exists": true,
+      "tasks": { "running": 3, "desired": 3, "pending": 0 },
+      "spec": { "cpu": "512", "memory": "1024", "launch": "FARGATE" },
+      "revision": "web:42",
+      "version": "26.24.1.0930",
+      "rollout": { "state": "COMPLETED", "reason": null },
+      "scaling": { "min": 1, "max": 4, "policies": ["cpu 65%", "req 1200"] },
+      "cpuTarget": 65,
+      "load": { "cpu": 18.4, "memory": 41.2, "requestRate": 7.1, "responseTime": 0.12 }
+    }
+  ]
+}
+```
+
+One object per service group (`web` / `queue` / `scheduler`). Health signals: `tasks.running` vs `tasks.desired`, `rollout.state`, and `load` against `cpuTarget`.
+
+### `yolo audit <env> --json`
+
+Ownership/inventory check (not a config check). Flags anything tagged into the env's namespace that YOLO can't account for.
+
+```json
+{
+  "environment": "production",
+  "liveApps": ["myapp", "otherapp"],
+  "okCount": 23,
+  "unexpectedCount": 1,
+  "resources": [
+    {
+      "scope": "app",
+      "status": "unexpected",
+      "type": "AWS::S3::Bucket",
+      "name": "stray-bucket",
+      "app": null,
+      "reason": "no ownership tag",
+      "arn": "arn:aws:s3:::stray-bucket"
+    }
+  ]
+}
+```
+
+`status` is `ok` or `unexpected`; `reason` on an unexpected row is one of `no ownership tag`, `service no longer provisioned`, `app cluster gone`. `--unexpected` narrows to just the rows needing attention. Scope-narrow with `audit:environment <env>` / `audit:app <env> <app>`.
+
+### `yolo sync <env> --check`
+
+Read-only plan pass. Prints the full diff (Will create / Pending changes / Skipping) and **exits non-zero when infra has drifted** from the manifest (zero when in sync). This is the drift detector — parse the printed plan, trust the exit code.
+
+### `yolo services <env> --json`
+
+The service-lifecycle gate as data: which env-shared services (IVS, Typesense, …) are offered and which apps claim them.
+
+## Workflows
+
+**Bare `/yolo` — full sweep.** Read the manifest for env names, then for each env run `status --json` + `audit --json` (+ `sync --check` for drift). Report a tight health summary: per-group task health, any in-flight or failed rollout, autoscaling headroom (load vs `cpuTarget`), unexpected resources, and drift. End with **green / needs-attention** and a short list of any proposals. Change nothing.
+
+**`/yolo <question>` — specific ask.** Pull only the data the question needs (e.g. "is prod scaling ok?" → `status --json`, look at `scaling`/`load`/`cpuTarget`). Answer from the data; cite the numbers.
+
+**`/loop /yolo` — attended copilot.** Quiet when everything's green; speak up only when a signal crosses a line (failed rollout, drift appears, tasks stuck pending, load pinned above target). Stay read-only.
+
+**Proposing a change.** When the data warrants a change (scale bounds, a manifest fix, drift to reconcile): describe *what* and *why* with the numbers behind it, then either (a) hand the human the exact `yolo` command to run, or (b) edit `yolo.yml` and open a PR. One change per PR. Never run the mutation yourself.
+
+## Reasoning notes
+
+- **Scaling.** `scaling.policies` shows the active target-tracking policies; `load.cpu` against `cpuTarget` is the headroom read. Bounds live in the manifest (`tasks.web.autoscaling.min/max`), so a scaling proposal is a manifest edit, applied by the next sync — not a raw `scale` call, unless it's a deliberate out-of-band nudge.
+- **Drift vs inventory.** `sync --check` catches *config* drift (attributes vs manifest). `audit` catches *ownership* surprises (untagged or orphaned resources). They answer different questions — run both for a real sweep.
+- **A failed deploy** shows as `rollout.state` failed and a non-zero `status` exit. YOLO's circuit breaker auto-rolls-back a broken rollout, so a failed state is usually already reverting — confirm with a second read before proposing anything.
+- **Don't infer cost or budget yet** — there's no cost surface in this version. Stick to what the JSON gives you.
+
+## Full reference
+
+The complete command and manifest reference ships as a Boost guideline (`resources/boost/guidelines/yolo.blade.php`) and, for humans, at the [docs site](https://github.com/codinglabsau/yolo). When in doubt about a flag, `vendor/bin/yolo <command> --help`.

--- a/tests/Unit/BoostSkillTest.php
+++ b/tests/Unit/BoostSkillTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use Symfony\Component\Yaml\Yaml;
+
+/*
+ * The Boost distribution artefacts ship inside the composer package (under
+ * `resources/`, which `.gitattributes` does NOT export-ignore), so any app that
+ * requires YOLO gets the `/yolo` skill and the auto-composed guideline. These
+ * tests pin that they exist and that the skill carries a valid Boost/Claude
+ * frontmatter contract (name + description) — the package is the single source
+ * of truth, not a hand-copied dotfiles skill.
+ */
+
+function packageRoot(): string
+{
+    return dirname(__DIR__, 2);
+}
+
+it('ships the /yolo skill in the package', function (): void {
+    expect(packageRoot() . '/resources/boost/skills/yolo/SKILL.md')->toBeFile();
+});
+
+it('gives the skill a valid frontmatter contract', function (): void {
+    $contents = (string) file_get_contents(packageRoot() . '/resources/boost/skills/yolo/SKILL.md');
+
+    expect($contents)->toStartWith('---');
+
+    [, $frontmatter] = explode('---', $contents, 3);
+    $meta = Yaml::parse($frontmatter);
+
+    expect($meta['name'])->toBe('yolo')
+        ->and($meta['description'])->toBeString()->not->toBeEmpty();
+});
+
+it('ships a Boost guideline Boost will auto-discover', function (): void {
+    // Boost composes `resources/boost/guidelines/*.blade.php` from every installed
+    // package, so the file living here is what wires YOLO into a consuming app.
+    $guideline = packageRoot() . '/resources/boost/guidelines/yolo.blade.php';
+
+    expect($guideline)->toBeFile()
+        ->and(trim((string) file_get_contents($guideline)))->not->toBeEmpty();
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

First slice of the **[LPX-680](https://linear.app/codinglabsau/issue/LPX-680)** epic's *skill + Boost distribution* workstream. YOLO stays a dumb data-pipe; the `/yolo` skill is the brain that reads its `--json` read surface and **proposes** changes — every mutation human-gated.

**What problems are you solving?**
- The `/yolo` skill wasn't shipped with the package, and the version floating around had rotted to the **EC2/CodeDeploy alpha** era (`image:create`, `--dry-run`, instance types) — describing a YOLO that no longer exists.
- It belongs **in the package**, version-accurate, so any app that requires YOLO can pull in a correct skill + Boost context, with nothing to drift out of sync.

**What's in it**
- `resources/boost/skills/yolo/SKILL.md` — the `/yolo` skill, authored fresh against the real Fargate CLI and the `status`/`audit` `--json` shapes. Read-first; mutations (`deploy`/`sync` apply/`scale`/`rollback`/`env:push`) are never run by the skill — it prepares them or lands a PR. Invocation modes: bare sweep · `/yolo <q>` · `/loop /yolo`.
- `resources/boost/guidelines/yolo.blade.php` — a self-contained Boost guideline.
- `docs/guide/the-yolo-skill.md` + sidebar entry.
- `tests/Unit/BoostSkillTest.php` — pins both artefacts ship and the skill carries valid frontmatter.

Both live under `resources/` (which the package exports), so they travel with `composer require codinglabsau/yolo`.

**Is there anything the reviewer needs to know to deploy this?**

No infra impact — this adds packaged AI artefacts only. Two judgement calls worth your eyes:

1. **Boost integration is opt-in, not zero-touch — and needs no service provider.** Boost discovers `resources/boost/guidelines/*.blade.php` from a **direct** composer dependency (the dir existing in `vendor/codinglabsau/yolo/` is the whole mechanism — no service provider / `extra.laravel` needed). But it's pulled in by **`boost:install`**, where the user ticks `codinglabsau/yolo` in the third-party-guidelines multiselect; Boost then composes it into the app's `CLAUDE.md`/`AGENTS.md`. So a consuming app must (re-)run `boost:install` and select it. Installed Boost is **v1.8.13, which has _no_ skills mechanism** — so the **`SKILL.md` ships but isn't auto-installed until Boost v2** (interim: `ln -s vendor/codinglabsau/yolo/resources/boost/skills/yolo ~/.claude/skills/yolo`).
2. **`docs/` is `export-ignore`d from the package**, so a guideline can't reference `vendor/.../docs/`. The guideline is deliberately **self-contained** (distilled command/manifest reference) rather than the epic's "ship docs/reference verbatim".

**Not in this slice** (later epic bullets): read-only Boost MCP tools (`laravel/mcp`); the scheduled Leeloo observer → PR + Slack digest.

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **978 green** · doc anchors verified.

🤖 Generated with [Claude Code](https://claude.ai/code)