### PR TITLE
LPX-680: queue backlog in yolo status

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -253,17 +253,18 @@ yolo status <environment> [--json]
 
 | Option | Value | Default | Description |
 |---|---|---|---|
-| `--json` | flag | off | Emit the status as JSON (`{app, environment, groups}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if a deployment is currently failed. |
+| `--json` | flag | off | Emit the status as JSON (`{app, environment, groups, queues}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if a deployment is currently failed. |
 
-It renders three panels, read live from ECS, Application Auto Scaling and CloudWatch:
+It renders up to four panels, read live from ECS, Application Auto Scaling, CloudWatch and SQS:
 
 - **Deployment in progress** (only when a rollout is mid-flight) — a progress bar of new-revision tasks per rolling group, its rollout state, the revision, and how long it's been running.
 - **Services** — one row per group (web / queue / scheduler) with the task spec (vCPU/memory/launch type), running/desired task count, scaling bounds + policies (`1–4 auto (cpu 65%, req 1200)`, or `fixed` / `singleton`), and the deployed revision + app version.
 - **Load** (last 5 min) — ECS CPU/memory per group, shown against the CPU scaling target so headroom is obvious, plus the web service's ALB request rate and response time. Each reading trails a small `▁▂▃▅▇` sparkline of its recent trend.
+- **Queue** (backlog) — the visible-message count for each SQS queue (one for a solo app; the landlord queue plus one per tenant when multi-tenant). Shown even when the queue worker is bundled into the web container rather than its own service.
 
 Below the panels is a clickable deep link to the app's CloudWatch dashboard for the full metrics view.
 
-It **renders once and exits**, returning a non-zero exit code if a deployment is currently failed — so it doubles as a lightweight health probe. For the live, polling cockpit (it redraws and picks up deploys as they start), open [`yolo tui`](/guide/tui); its Status tab is this same picture, kept fresh. `--json` emits the same state as a structured payload rather than the panels — the machine-readable contract the `/yolo` skill (and any script) consumes. Each group's `load` carries both the latest reading and a `series` of its recent datapoints per metric (`load.series.cpu`, `.memory`, `.requests`, `.response`), so a consumer sees the trend, not just a lone number.
+It **renders once and exits**, returning a non-zero exit code if a deployment is currently failed — so it doubles as a lightweight health probe. For the live, polling cockpit (it redraws and picks up deploys as they start), open [`yolo tui`](/guide/tui); its Status tab is this same picture, kept fresh. `--json` emits the same state as a structured payload rather than the panels — the machine-readable contract the `/yolo` skill (and any script) consumes. Each group's `load` carries both the latest reading and a `series` of its recent datapoints per metric (`load.series.cpu`, `.memory`, `.requests`, `.response`), so a consumer sees the trend, not just a lone number; `queues` lists each queue's `{label, name, backlog}`.
 
 ---
 

--- a/src/Aws/Sqs.php
+++ b/src/Aws/Sqs.php
@@ -26,4 +26,22 @@ class Sqs
 
         throw new ResourceDoesNotExistException("Could not find SQS queue $name");
     }
+
+    /**
+     * The visible-message backlog for a queue — its `ApproximateNumberOfMessages`
+     * attribute — or null when the queue doesn't exist, so `yolo status` shows a
+     * backlog without a hard error on a not-yet-provisioned queue.
+     */
+    public static function approximateMessages(string $name): ?int
+    {
+        try {
+            $attributes = static::queue($name)['Attributes'] ?? [];
+        } catch (ResourceDoesNotExistException) {
+            return null;
+        }
+
+        return isset($attributes['ApproximateNumberOfMessages'])
+            ? (int) $attributes['ApproximateNumberOfMessages']
+            : null;
+    }
 }

--- a/src/Commands/StatusCommand.php
+++ b/src/Commands/StatusCommand.php
@@ -32,6 +32,7 @@ class StatusCommand extends Command
     public function handle(): int
     {
         $statuses = static::gatherServiceStatuses();
+        $queues = static::gatherQueueBacklogs();
 
         // `--json` is the machine-readable contract: emit the structured payload
         // and exit non-zero if a deploy is failed so it stays scriptable.
@@ -40,6 +41,7 @@ class StatusCommand extends Command
                 'app' => Manifest::current()['name'] ?? null,
                 'environment' => $this->argument('environment'),
                 'groups' => static::jsonStatuses($statuses),
+                'queues' => $queues,
             ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
             return static::anyDeploymentFailed($statuses) ? 1 : 0;
@@ -47,7 +49,7 @@ class StatusCommand extends Command
 
         intro(sprintf('yolo status · %s · %s', Manifest::current()['name'] ?? '', $this->argument('environment')));
 
-        foreach ($this->statusLines($statuses, time()) as $line) {
+        foreach ($this->statusLines($statuses, time(), queues: $queues) as $line) {
             $this->output->writeln($line);
         }
 

--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Concerns;
 
 use Codinglabs\Yolo\Aws\Ecs;
+use Codinglabs\Yolo\Aws\Sqs;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\CloudWatch;
@@ -248,6 +249,51 @@ trait RendersServiceStatus
     protected static function latestOf(array $series): ?float
     {
         return $series === [] ? null : $series[array_key_last($series)];
+    }
+
+    /**
+     * Each of the app's SQS queues and its current backlog (visible messages). A
+     * solo app has one queue; a multi-tenant app has the landlord queue plus one
+     * per tenant. Surfaced app-level (not per ECS group) so the backlog shows even
+     * when the queue worker is bundled into the web container. A queue that isn't
+     * provisioned yet is skipped.
+     *
+     * @return array<int, array{label: string, name: string, backlog: int}>
+     */
+    protected static function gatherQueueBacklogs(): array
+    {
+        $queues = [];
+
+        foreach (static::queueNames() as $label => $name) {
+            $backlog = Sqs::approximateMessages($name);
+
+            if ($backlog !== null) {
+                $queues[] = ['label' => $label, 'name' => $name, 'backlog' => $backlog];
+            }
+        }
+
+        return $queues;
+    }
+
+    /**
+     * The app's queue names, keyed by a short label: `queue` for a solo app, or
+     * `landlord` plus each tenant id for a multi-tenant one.
+     *
+     * @return array<string, string>
+     */
+    protected static function queueNames(): array
+    {
+        if (! Manifest::isMultitenanted()) {
+            return ['queue' => Helpers::keyedResourceName()];
+        }
+
+        $names = ['landlord' => Helpers::keyedResourceName('landlord')];
+
+        foreach (array_keys(Manifest::tenants()) as $tenantId) {
+            $names[$tenantId] = Helpers::keyedResourceName($tenantId);
+        }
+
+        return $names;
     }
 
     /**
@@ -527,6 +573,17 @@ trait RendersServiceStatus
     }
 
     /**
+     * `empty` (gray) for a drained queue, else `N pending`. Backlog alone can't
+     * say "healthy" without knowing throughput, so it's reported, not alarmed.
+     */
+    public static function formatBacklog(int $backlog): string
+    {
+        return $backlog === 0
+            ? '<fg=gray>empty</>'
+            : sprintf('%s pending', number_format($backlog));
+    }
+
+    /**
      * A `███████░░░░░` bar of the new revision's running/desired ratio.
      */
     public static function progressBar(int $running, int $desired, int $width = 12): string
@@ -631,13 +688,15 @@ trait RendersServiceStatus
 
     /**
      * The full set of display lines for a status frame. `deployments` puts the
-     * in-progress rollout bars on top; `load` adds the per-group load panel. The
-     * end-of-deploy recap turns both off and shows just the summary + link.
+     * in-progress rollout bars on top; `load` adds the per-group load panel;
+     * `$queues` (when passed) adds the queue-backlog panel. The end-of-deploy
+     * recap turns deployments/load off and shows just the summary + link.
      *
      * @param  array<int, array<string, mixed>>  $statuses
+     * @param  array<int, array{label: string, name: string, backlog: int}>  $queues
      * @return array<int, string>
      */
-    protected function statusLines(array $statuses, int $now, bool $deployments = true, bool $load = true): array
+    protected function statusLines(array $statuses, int $now, bool $deployments = true, bool $load = true, array $queues = []): array
     {
         $lines = [];
 
@@ -650,6 +709,8 @@ trait RendersServiceStatus
         if ($load) {
             $lines = [...$lines, ...$this->loadLines($statuses)];
         }
+
+        $lines = [...$lines, ...$this->queueLines($queues)];
 
         return [...$lines, ...$this->dashboardLink()];
     }
@@ -755,6 +816,29 @@ trait RendersServiceStatus
                 $status['group']->value,
                 static::formatLoad($status['load'], $status['cpuTarget'], $status['group']),
             );
+        }
+
+        return $lines;
+    }
+
+    /**
+     * The queue-backlog panel — one row per SQS queue (solo: one; multi-tenant:
+     * landlord + per tenant), shown regardless of whether the worker is its own
+     * service or bundled into web. Empty when the app has no readable queue.
+     *
+     * @param  array<int, array{label: string, name: string, backlog: int}>  $queues
+     * @return array<int, string>
+     */
+    protected function queueLines(array $queues): array
+    {
+        if ($queues === []) {
+            return [];
+        }
+
+        $lines = ['', '  <options=bold>Queue</> <fg=gray>(backlog)</>'];
+
+        foreach ($queues as $queue) {
+            $lines[] = sprintf('  %-10s %s', $queue['label'], static::formatBacklog($queue['backlog']));
         }
 
         return $lines;

--- a/src/Tui/Panels/StatusPanel.php
+++ b/src/Tui/Panels/StatusPanel.php
@@ -20,6 +20,9 @@ class StatusPanel implements Panel
     /** @var array<int, array<string, mixed>> */
     protected array $statuses = [];
 
+    /** @var array<int, array{label: string, name: string, backlog: int}> */
+    protected array $queues = [];
+
     public function __construct(public OutputInterface $output) {}
 
     public function title(): string
@@ -35,11 +38,12 @@ class StatusPanel implements Panel
     public function gather(): void
     {
         $this->statuses = static::gatherServiceStatuses(withLoad: true);
+        $this->queues = static::gatherQueueBacklogs();
     }
 
     public function render(int $width, int $height): array
     {
-        return $this->statusLines($this->statuses, time(), deployments: true, load: true);
+        return $this->statusLines($this->statuses, time(), deployments: true, load: true, queues: $this->queues);
     }
 
     public function hints(): array

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -7,6 +7,7 @@ use Aws\Ec2\Ec2Client;
 use Aws\Ecr\EcrClient;
 use Aws\Ecs\EcsClient;
 use Aws\Iam\IamClient;
+use Aws\Sqs\SqsClient;
 use Aws\CommandInterface;
 use Aws\WAFV2\WAFV2Client;
 use Codinglabs\Yolo\Helpers;
@@ -371,6 +372,39 @@ function bindMockCloudWatchClient(array $byCommand, array &$captured): void
     };
 
     Helpers::app()->instance('cloudWatch', new CloudWatchClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
+ * Bind a mock SQS client with command-routed responses, capturing every call.
+ * Mirrors bindMockCloudWatchClient.
+ *
+ * @param  array<string, Result|Throwable>  $byCommand
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
+ */
+function bindMockSqsClient(array $byCommand, array &$captured): void
+{
+    $mock = new class($byCommand, $captured) extends MockHandler
+    {
+        public function __construct(protected array $byCommand, protected array &$captured) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $this->captured[] = ['name' => $cmd->getName(), 'args' => $cmd->toArray()];
+
+            $entry = $this->byCommand[$cmd->getName()] ?? new Result();
+
+            return $entry instanceof Throwable
+                ? Create::rejectionFor($entry)
+                : Create::promiseFor($entry);
+        }
+    };
+
+    Helpers::app()->instance('sqs', new SqsClient([
         'region' => 'ap-southeast-2',
         'version' => 'latest',
         'credentials' => false,

--- a/tests/Unit/Aws/SqsTest.php
+++ b/tests/Unit/Aws/SqsTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Aws\Sqs;
+
+it('reads the approximate visible-message backlog for a queue', function (): void {
+    $captured = [];
+    bindMockSqsClient([
+        'ListQueues' => new Result(['QueueUrls' => ['https://sqs.ap-southeast-2.amazonaws.com/1234/yolo-testing-my-app']]),
+        'GetQueueAttributes' => new Result(['Attributes' => ['ApproximateNumberOfMessages' => '42']]),
+    ], $captured);
+
+    expect(Sqs::approximateMessages('yolo-testing-my-app'))->toBe(42);
+});
+
+it('returns null for the backlog when the queue does not exist', function (): void {
+    $captured = [];
+    bindMockSqsClient(['ListQueues' => new Result(['QueueUrls' => []])], $captured);
+
+    expect(Sqs::approximateMessages('yolo-testing-missing'))->toBeNull();
+});

--- a/tests/Unit/Commands/StatusCommandTest.php
+++ b/tests/Unit/Commands/StatusCommandTest.php
@@ -168,6 +168,51 @@ it('trails a load reading with a gray sparkline when a series is present', funct
         ->toContain('▁');          // low bar from the flat memory series / cpu start
 });
 
+it('formats the queue backlog, gray "empty" when drained', function (): void {
+    expect(StatusCommand::formatBacklog(0))->toContain('empty')->toContain('gray');
+    expect(StatusCommand::formatBacklog(1))->toBe('1 pending');
+    expect(StatusCommand::formatBacklog(12500))->toBe('12,500 pending');
+});
+
+it('lists the solo queue, or landlord + tenants when multi-tenant', function (): void {
+    $probe = new class()
+    {
+        use RendersServiceStatus;
+
+        /** @return array<string, string> */
+        public function names(): array
+        {
+            return self::queueNames();
+        }
+
+        /**
+         * @param  array<int, array{label: string, name: string, backlog: int}>  $queues
+         * @return array<int, string>
+         */
+        public function lines(array $queues): array
+        {
+            return $this->queueLines($queues);
+        }
+    };
+
+    writeManifest([]);
+    expect($probe->names())->toBe(['queue' => 'yolo-testing-my-app']);
+
+    writeManifest(['tenants' => ['acme' => [], 'globex' => []]]);
+    expect($probe->names())->toBe([
+        'landlord' => 'yolo-testing-my-app-landlord',
+        'acme' => 'yolo-testing-my-app-acme',
+        'globex' => 'yolo-testing-my-app-globex',
+    ]);
+
+    // No queues → no panel; a queue → a labelled backlog row.
+    expect($probe->lines([]))->toBe([]);
+    expect(implode("\n", $probe->lines([['label' => 'queue', 'name' => 'yolo-testing-my-app', 'backlog' => 7]])))
+        ->toContain('Queue')
+        ->toContain('queue')
+        ->toContain('7 pending');
+});
+
 it('colours the rollout state', function (): void {
     expect(StatusCommand::formatRolloutState('IN_PROGRESS'))->toContain('IN PROGRESS')->toContain('blue');
     expect(StatusCommand::formatRolloutState('COMPLETED'))->toContain('COMPLETED')->toContain('green');


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Phase 1 **slice 2 of 3** of the **[LPX-680](https://linear.app/codinglabsau/issue/LPX-680)** read-surface work — queue backlog in `yolo status`.

**What problems are you solving?**
- `yolo status` showed services, load and scaling but nothing about the **queue backlog** — the single most useful "is work piling up?" signal. And it had to work **even in combined mode**, where the queue worker rides the web container and there's no standalone queue service to hang it off.

**What's in it**
- `Sqs::approximateMessages($name)` — the visible-message backlog (`ApproximateNumberOfMessages`), null on a not-yet-provisioned queue.
- A new **app-level Queue panel** in `status` (and the TUI Status tab): one row per queue — `queue` for a solo app, `landlord` + each tenant when multi-tenant. App-level, so it's independent of ECS group topology (shows in combined mode).
- `status --json` gains a `queues` array (`{label, name, backlog}`).
- New `bindMockSqsClient` test helper (SQS had no test infra yet) + coverage for the backlog read, queue-name enumeration (solo vs multi-tenant), and the panel render.

**Is there anything the reviewer needs to know to deploy this?**
- **Additive / read-only.** New `queues` key in `--json`; new panel; no change to existing fields or behaviour.
- The backlog read uses the SQS queue attribute (real-time, cheap) rather than a CloudWatch metric — one `ListQueues`+`GetQueueAttributes` per queue. Fine for an occasional status read; a many-tenant app does one lookup per tenant queue.
- **Next slice (separate PR):** `status:app` / `status:environment` scope namespace (slice 3).

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1024 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)