### PR TITLE
LPX-680: status:app / status:environment scope namespace

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -22,7 +22,9 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`build <env>`](#yolo-build) | Build and push the container image |
 | [`deploy <env>`](#yolo-deploy) | Build, then roll out a zero-downtime deploy |
 | [`rollback <env>`](#yolo-rollback) | Re-deploy a previously-built version from ECR, without a build |
-| [`status <env>`](#yolo-status) | Live dashboard of services, load, scaling and any in-progress deploy |
+| [`status <env>`](#yolo-status) | Snapshot of one app's services, load, scaling and any in-progress deploy |
+| [`status:app <env>`](#yolo-status-app) | App-tier status (the same as `status`, under the scope namespace) |
+| [`status:environment <env>`](#yolo-status-environment) | Roll up every app's status across an environment |
 | [`run <env>`](#yolo-run) | Open a shell / run a command in a running container |
 | [`scale <env> [count]`](#yolo-scale) | Adjust the web service's task count out of band |
 | [`services <env>`](#yolo-services) | View and manage the services an environment offers |
@@ -265,6 +267,40 @@ It renders up to four panels, read live from ECS, Application Auto Scaling, Clou
 Below the panels is a clickable deep link to the app's CloudWatch dashboard for the full metrics view.
 
 It **renders once and exits**, returning a non-zero exit code if a deployment is currently failed — so it doubles as a lightweight health probe. For the live, polling cockpit (it redraws and picks up deploys as they start), open [`yolo tui`](/guide/tui); its Status tab is this same picture, kept fresh. `--json` emits the same state as a structured payload rather than the panels — the machine-readable contract the `/yolo` skill (and any script) consumes. Each group's `load` carries both the latest reading and a `series` of its recent datapoints per metric (`load.series.cpu`, `.memory`, `.requests`, `.response`), so a consumer sees the trend, not just a lone number; `queues` lists each queue's `{label, name, backlog}`.
+
+`status` is the **app tier** of a scope-first namespace it shares with `status:app` and `status:environment`, mirroring [`sync:*`](#yolo-sync) and [`audit:*`](#yolo-audit).
+
+---
+
+## `yolo status:app`
+
+The app-tier status under the scope-first namespace — **identical to bare [`status`](#yolo-status)** (the app scope is the default). It exists so `status:app` and `status:environment` read as a pair, the way `sync:*` and `audit:*` do.
+
+```bash
+yolo status:app <environment> [--json]
+```
+
+Arguments and options as [`status`](#yolo-status).
+
+---
+
+## `yolo status:environment`
+
+Roll up **every app's status** across an environment — a compact health row per app (its web service's task counts, rollout state and version), discovered from the live ECS clusters in the environment's `yolo-{env}-` namespace. The per-app detail (load, scaling, queues) is [`status`](#yolo-status) / [`status:app`](#yolo-status-app).
+
+```bash
+yolo status:environment <environment> [--json]
+```
+
+| Argument | Required | Description |
+|---|---|---|
+| `environment` | yes | The environment name |
+
+| Option | Value | Default | Description |
+|---|---|---|---|
+| `--json` | flag | off | Emit the roll-up as JSON (`{environment, apps}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if any app has a failed deploy. |
+
+It renders an **App / Web / Rollout / Version** table — one row per live app — and exits non-zero if any app's deploy is currently failed, so it's usable as an environment-wide health probe. With no live apps it says so and exits zero. `--json` emits `{environment, apps[]}`, each app carrying `{app, exists, tasks, revision, version, rollout}`.
 
 ---
 

--- a/src/Commands/StatusAppCommand.php
+++ b/src/Commands/StatusAppCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Commands;
+
+/**
+ * The app-tier status under the scope-first namespace — identical to bare
+ * `status` (the app scope is the default), provided so `status:app` and
+ * `status:environment` read as a pair, the way `sync:*` and `audit:*` do.
+ */
+class StatusAppCommand extends StatusCommand
+{
+    #[\Override]
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->setName('status:app')
+            ->setDescription("Show a snapshot of one app's services, load, scaling and any in-progress deploy");
+    }
+}

--- a/src/Commands/StatusEnvironmentCommand.php
+++ b/src/Commands/StatusEnvironmentCommand.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Symfony\Component\Console\Input\InputOption;
+use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+
+/**
+ * The env-tier status roll-up — a compact health row per app in the environment
+ * (each app's web service: task counts, rollout state and version), discovered
+ * from the live ECS clusters in the env's namespace. The per-app detail (load,
+ * scaling, queues) is `status` / `status:app`.
+ */
+class StatusEnvironmentCommand extends Command
+{
+    use RendersServiceStatus;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('status:environment')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit the roll-up as JSON and exit (machine-readable; for the /yolo skill and scripts)')
+            ->setDescription("Roll up every app's status across an environment");
+    }
+
+    public function handle(): int
+    {
+        $environment = $this->argument('environment');
+        $rows = static::gatherEnvStatuses($environment);
+
+        // `--json` is the machine-readable contract: emit the roll-up and exit
+        // non-zero if any app has a failed deploy so it stays scriptable.
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode([
+                'environment' => $environment,
+                'apps' => static::jsonEnvStatuses($rows),
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return static::anyDeploymentFailed($rows) ? 1 : 0;
+        }
+
+        if ($rows === []) {
+            info(sprintf("No live apps in '%s'.", $environment));
+
+            return self::SUCCESS;
+        }
+
+        intro(sprintf('yolo status · %s · all apps', $environment));
+
+        foreach ($this->envRollupLines($rows) as $line) {
+            $this->output->writeln($line);
+        }
+
+        return static::anyDeploymentFailed($rows) ? 1 : 0;
+    }
+}

--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -79,31 +79,7 @@ trait RendersServiceStatus
             return $row;
         }
 
-        $row['exists'] = true;
-        $row['running'] = (int) ($service['runningCount'] ?? 0);
-        $row['desired'] = (int) ($service['desiredCount'] ?? 0);
-        $row['pending'] = (int) ($service['pendingCount'] ?? 0);
-        $row['launch'] = static::launchType($service);
-
-        $primary = collect($service['deployments'] ?? [])->firstWhere('status', 'PRIMARY');
-
-        if ($primary !== null) {
-            $taskDefinitionArn = $primary['taskDefinition'] ?? null;
-
-            $row['primary'] = $primary;
-            $row['rolloutState'] = $primary['rolloutState'] ?? null;
-            $row['rolloutReason'] = $primary['rolloutStateReason'] ?? null;
-            $row['revision'] = static::revisionLabel($taskDefinitionArn);
-
-            try {
-                $taskDefinition = $taskDefinitionArn === null ? [] : Ecs::taskDefinition($taskDefinitionArn);
-                $row['cpu'] = $taskDefinition['cpu'] ?? null;
-                $row['memory'] = $taskDefinition['memory'] ?? null;
-                $row['version'] = static::versionFromImage($taskDefinition['containerDefinitions'][0]['image'] ?? '');
-            } catch (ResourceDoesNotExistException) {
-                // leave the task-def-derived fields null
-            }
-        }
+        $row = [...$row, 'exists' => true, ...static::serviceCore($service)];
 
         $row['scaling'] = static::gatherScaling($group);
         $row['cpuTarget'] = static::cpuTargetFrom($row['scaling']);
@@ -113,6 +89,105 @@ trait RendersServiceStatus
         }
 
         return $row;
+    }
+
+    /**
+     * Map a live ECS service to the status fields shared by the per-group status
+     * and the per-app env roll-up: task counts, launch type, the primary
+     * deployment + its rollout state/revision, and the spec/version read from the
+     * task definition (a missing task def leaves those null, never throws).
+     *
+     * @param  array<string, mixed>  $service
+     * @return array<string, mixed>
+     */
+    protected static function serviceCore(array $service): array
+    {
+        $core = [
+            'running' => (int) ($service['runningCount'] ?? 0),
+            'desired' => (int) ($service['desiredCount'] ?? 0),
+            'pending' => (int) ($service['pendingCount'] ?? 0),
+            'launch' => static::launchType($service),
+            'primary' => null,
+            'rolloutState' => null,
+            'rolloutReason' => null,
+            'revision' => null,
+            'cpu' => null,
+            'memory' => null,
+            'version' => null,
+        ];
+
+        $primary = collect($service['deployments'] ?? [])->firstWhere('status', 'PRIMARY');
+
+        if ($primary === null) {
+            return $core;
+        }
+
+        $taskDefinitionArn = $primary['taskDefinition'] ?? null;
+
+        $core['primary'] = $primary;
+        $core['rolloutState'] = $primary['rolloutState'] ?? null;
+        $core['rolloutReason'] = $primary['rolloutStateReason'] ?? null;
+        $core['revision'] = static::revisionLabel($taskDefinitionArn);
+
+        try {
+            $taskDefinition = $taskDefinitionArn === null ? [] : Ecs::taskDefinition($taskDefinitionArn);
+            $core['cpu'] = $taskDefinition['cpu'] ?? null;
+            $core['memory'] = $taskDefinition['memory'] ?? null;
+            $core['version'] = static::versionFromImage($taskDefinition['containerDefinitions'][0]['image'] ?? '');
+        } catch (ResourceDoesNotExistException) {
+            // leave the task-def-derived fields null
+        }
+
+        return $core;
+    }
+
+    /**
+     * A compact health row per app in an environment — the env-tier roll-up
+     * behind `status:environment`. Each app's web service is the headline (task
+     * counts, rollout, version); apps are discovered from live ECS clusters, and
+     * cluster/service names follow the `yolo-{env}-{app}` convention so no
+     * per-app manifest is needed.
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    protected static function gatherEnvStatuses(string $environment): array
+    {
+        return array_map(
+            fn (string $app): array => static::gatherAppRollup($environment, $app),
+            Ecs::liveApps($environment),
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected static function gatherAppRollup(string $environment, string $app): array
+    {
+        $cluster = "yolo-{$environment}-{$app}";
+
+        $row = [
+            'app' => $app,
+            'exists' => false,
+            'running' => 0,
+            'desired' => 0,
+            'pending' => 0,
+            'launch' => 'FARGATE',
+            'primary' => null,
+            'rolloutState' => null,
+            'rolloutReason' => null,
+            'revision' => null,
+            'cpu' => null,
+            'memory' => null,
+            'version' => null,
+        ];
+
+        try {
+            $service = Ecs::service($cluster, "{$cluster}-web");
+        } catch (ResourceDoesNotExistException) {
+            return $row;
+        }
+
+        return [...$row, 'exists' => true, ...static::serviceCore($service)];
     }
 
     /**
@@ -359,6 +434,33 @@ trait RendersServiceStatus
             'cpuTarget' => $status['cpuTarget'],
             'load' => $status['load'],
         ];
+    }
+
+    /**
+     * The machine-readable env roll-up — one compact entry per app for
+     * `status:environment --json`. Pure: flattens the gathered app rows and drops
+     * the raw `primary` deployment blob (DateTimeInterface timestamps).
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @return array<int, array<string, mixed>>
+     */
+    public static function jsonEnvStatuses(array $rows): array
+    {
+        return array_map(static fn (array $row): array => [
+            'app' => $row['app'],
+            'exists' => (bool) $row['exists'],
+            'tasks' => [
+                'running' => (int) $row['running'],
+                'desired' => (int) $row['desired'],
+                'pending' => (int) $row['pending'],
+            ],
+            'revision' => $row['revision'],
+            'version' => $row['version'],
+            'rollout' => [
+                'state' => $row['rolloutState'],
+                'reason' => $row['rolloutReason'],
+            ],
+        ], $rows);
     }
 
     /**
@@ -792,6 +894,51 @@ trait RendersServiceStatus
             static::formatSpec($status['cpu'], $status['memory'], $status['launch']),
             static::formatTasks($status['running'], $status['desired'], $status['pending']),
             static::formatScaling($status['scaling'], $status['group']),
+            $version,
+        ];
+    }
+
+    /**
+     * The env roll-up table — one row per app (its web service's task health,
+     * rollout state and version), for `status:environment`.
+     *
+     * @param  array<int, array<string, mixed>>  $rows
+     * @return array<int, string>
+     */
+    protected function envRollupLines(array $rows): array
+    {
+        $buffer = new BufferedOutput($this->output->getVerbosity(), $this->output->isDecorated(), clone $this->output->getFormatter());
+
+        $table = new Table($buffer);
+        $table->setHeaders(['App', 'Web', 'Rollout', 'Version']);
+
+        foreach ($rows as $row) {
+            $table->addRow($this->envRollupRow($row));
+        }
+
+        $table->render();
+
+        return explode("\n", rtrim($buffer->fetch(), "\n"));
+    }
+
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<int, string>
+     */
+    protected function envRollupRow(array $row): array
+    {
+        if (! $row['exists']) {
+            return [$row['app'], '<fg=gray>—</>', '<fg=gray>not deployed</>', '<fg=gray>—</>'];
+        }
+
+        $version = $row['version'] === null
+            ? ($row['revision'] ?? '—')
+            : sprintf('%s · %s', $row['revision'] ?? '—', $row['version']);
+
+        return [
+            $row['app'],
+            static::formatTasks($row['running'], $row['desired'], $row['pending']),
+            static::formatRolloutState($row['rolloutState']),
             $version,
         ];
     }

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -32,8 +32,10 @@ class Yolo
         // Rollback
         Commands\RollbackCommand::class,
 
-        // Status
+        // Status (scope-grouped: app-tier `status`/`status:app`, env-tier roll-up)
         Commands\StatusCommand::class,
+        Commands\StatusAppCommand::class,
+        Commands\StatusEnvironmentCommand::class,
 
         // Exec
         Commands\RunCommand::class,

--- a/tests/Unit/Commands/StatusCommandTest.php
+++ b/tests/Unit/Commands/StatusCommandTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Commands\StatusCommand;
+use Codinglabs\Yolo\Commands\StatusAppCommand;
 use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Codinglabs\Yolo\Commands\StatusEnvironmentCommand;
 
 // The status dashboard's display logic lives in pure static helpers on the
 // RendersServiceStatus trait, reached here through StatusCommand. They take plain
@@ -330,4 +332,47 @@ it('serialises a not-yet-deployed group without choking on null spec', function 
         'scaling' => null,
         'rollout' => ['state' => null, 'reason' => null],
     ]);
+});
+
+it('registers status:app and status:environment under the scope namespace', function (): void {
+    $app = new StatusAppCommand();
+    expect($app->getName())->toBe('status:app')
+        ->and($app->getDefinition()->hasOption('json'))->toBeTrue();
+
+    $env = new StatusEnvironmentCommand();
+    expect($env->getName())->toBe('status:environment')
+        ->and($env->getDefinition()->hasOption('json'))->toBeTrue()
+        ->and($env->getDefinition()->hasArgument('environment'))->toBeTrue();
+});
+
+it('serialises the env roll-up into a clean json shape, dropping the deployment blob', function (): void {
+    $rows = [[
+        'app' => 'shop',
+        'exists' => true,
+        'running' => 3,
+        'desired' => 3,
+        'pending' => 0,
+        'launch' => 'FARGATE',
+        'primary' => ['createdAt' => new DateTimeImmutable('@1000')],
+        'rolloutState' => 'COMPLETED',
+        'rolloutReason' => null,
+        'revision' => 'web:42',
+        'cpu' => '512',
+        'memory' => '1024',
+        'version' => '20260605-1',
+    ]];
+
+    $json = StatusCommand::jsonEnvStatuses($rows);
+
+    expect($json)->toBe([[
+        'app' => 'shop',
+        'exists' => true,
+        'tasks' => ['running' => 3, 'desired' => 3, 'pending' => 0],
+        'revision' => 'web:42',
+        'version' => '20260605-1',
+        'rollout' => ['state' => 'COMPLETED', 'reason' => null],
+    ]]);
+
+    expect($json[0])->not->toHaveKey('primary');
+    expect(json_encode($json))->toBeJson();
 });

--- a/tests/Unit/Concerns/StatusEnvRollupTest.php
+++ b/tests/Unit/Concerns/StatusEnvRollupTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Aws\Command;
+use Aws\MockHandler;
+use Aws\Ecs\EcsClient;
+use Codinglabs\Yolo\Helpers;
+use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Concerns\RendersServiceStatus;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * The env-tier roll-up (`status:environment`) gathers each app's web service —
+ * cluster/service names follow the yolo-{env}-{app} convention, so no per-app
+ * manifest is needed — and renders a compact one-row-per-app table.
+ */
+function envRollupProbe(): object
+{
+    return new class(new BufferedOutput())
+    {
+        use RendersServiceStatus;
+
+        public function __construct(public OutputInterface $output) {}
+
+        /** @return array<string, mixed> */
+        public function rollup(string $environment, string $app): array
+        {
+            return self::gatherAppRollup($environment, $app);
+        }
+
+        /**
+         * @param  array<int, array<string, mixed>>  $rows
+         * @return array<int, string>
+         */
+        public function lines(array $rows): array
+        {
+            return $this->envRollupLines($rows);
+        }
+    };
+}
+
+it('rolls up an app from its web service and task definition', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new Result(['services' => [[
+        'status' => 'ACTIVE',
+        'runningCount' => 2,
+        'desiredCount' => 2,
+        'pendingCount' => 0,
+        'launchType' => 'FARGATE',
+        'deployments' => [[
+            'status' => 'PRIMARY',
+            'rolloutState' => 'COMPLETED',
+            'taskDefinition' => 'arn:aws:ecs:ap-southeast-2:1234:task-definition/yolo-prod-shop-web:42',
+        ]],
+    ]]]));
+    $mock->append(new Result(['taskDefinition' => [
+        'cpu' => '512',
+        'memory' => '1024',
+        'containerDefinitions' => [['image' => '1234.dkr.ecr.ap-southeast-2.amazonaws.com/yolo-prod-shop:20260605-1']],
+    ]]));
+
+    Helpers::app()->instance('ecs', new EcsClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+
+    expect(envRollupProbe()->rollup('prod', 'shop'))->toMatchArray([
+        'app' => 'shop',
+        'exists' => true,
+        'running' => 2,
+        'desired' => 2,
+        'rolloutState' => 'COMPLETED',
+        'revision' => 'web:42',
+        'version' => '20260605-1',
+    ]);
+});
+
+it('marks an app whose web service is gone as not deployed', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new AwsException('nope', new Command('DescribeServices'), ['code' => 'ServiceNotFoundException']));
+
+    Helpers::app()->instance('ecs', new EcsClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+
+    expect(envRollupProbe()->rollup('prod', 'ghost'))->toMatchArray([
+        'app' => 'ghost',
+        'exists' => false,
+        'running' => 0,
+    ]);
+});
+
+it('renders the env roll-up table, one row per app', function (): void {
+    $rows = [
+        ['app' => 'shop', 'exists' => true, 'running' => 3, 'desired' => 3, 'pending' => 0, 'rolloutState' => 'COMPLETED', 'revision' => 'web:42', 'version' => '20260605-1'],
+        ['app' => 'ghost', 'exists' => false, 'running' => 0, 'desired' => 0, 'pending' => 0, 'rolloutState' => null, 'revision' => null, 'version' => null],
+    ];
+
+    $rendered = implode("\n", envRollupProbe()->lines($rows));
+
+    expect($rendered)
+        ->toContain('shop')
+        ->toContain('3/3')
+        ->toContain('20260605-1')
+        ->toContain('ghost')
+        ->toContain('not deployed');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Phase 1 **slice 3 of 3** (final) of the **[LPX-680](https://linear.app/codinglabsau/issue/LPX-680)** read-surface work — a scope-first `status:*` namespace.

**What problems are you solving?**
- `status` only ever showed the **current app**. There was no environment-wide view ("how's *everything* in prod?"), and the command surface didn't mirror the scope-first `sync:*` / `audit:*` namespaces.

**What's in it**
- **`status:app`** — the app-tier status (identical to bare `status`; named so the namespace reads as a pair).
- **`status:environment`** — an **env roll-up**: a compact health row per app (its web service's task counts, rollout state, version), with apps discovered from the live ECS clusters in the `yolo-{env}-` namespace — no per-app manifest needed. `--json` → `{environment, apps[]}`; exits non-zero if any app's deploy is failed.
- Extracted a shared **`serviceCore()`** mapper (ECS service → status fields) so the per-group gather and the new per-app roll-up share one code path (DRY) with identical behaviour.

**Is there anything the reviewer needs to know to deploy this?**
- **Additive / read-only.** Two new read commands; `serviceCore` is a behaviour-preserving extraction of the existing `gatherServiceStatus` mapping (full suite green proves parity).
- `status:environment` is env-tier (like `audit:environment`) — run it from an app dir in the env; it uses the manifest only for region/account/auth, then reads across all apps.
- **Phase 1 is now complete** (slices 1–3 merged): metric sparklines, queue backlog, scope namespace.

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1029 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)