### PR TITLE
LPX-680: incident read surfaces (status:logs / status:events / status:alarms)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -25,6 +25,9 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`status <env>`](#yolo-status) | Snapshot of one app's services, load, scaling and any in-progress deploy |
 | [`status:app <env>`](#yolo-status-app) | App-tier status (the same as `status`, under the scope namespace) |
 | [`status:environment <env>`](#yolo-status-environment) | Roll up every app's status across an environment |
+| [`status:logs <env>`](#yolo-status-logs) | Recent CloudWatch logs per service group |
+| [`status:events <env>`](#yolo-status-events) | Recent ECS service events per group |
+| [`status:alarms <env>`](#yolo-status-alarms) | The app's CloudWatch alarms and their state |
 | [`run <env>`](#yolo-run) | Open a shell / run a command in a running container |
 | [`scale <env> [count]`](#yolo-scale) | Adjust the web service's task count out of band |
 | [`services <env>`](#yolo-services) | View and manage the services an environment offers |
@@ -301,6 +304,52 @@ yolo status:environment <environment> [--json]
 | `--json` | flag | off | Emit the roll-up as JSON (`{environment, apps}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if any app has a failed deploy. |
 
 It renders an **App / Web / Rollout / Version** table — one row per live app — and exits non-zero if any app's deploy is currently failed, so it's usable as an environment-wide health probe. With no live apps it says so and exits zero. `--json` emits `{environment, apps[]}`, each app carrying `{app, exists, tasks, revision, version, rollout}`.
+
+---
+
+## `yolo status:logs`
+
+Recent CloudWatch logs per service group — the incident read surface for "what is it saying right now".
+
+```bash
+yolo status:logs <environment> [--json]
+```
+
+| Argument | Required | Description |
+|---|---|---|
+| `environment` | yes | The environment name |
+
+| Option | Value | Default | Description |
+|---|---|---|---|
+| `--json` | flag | off | Emit recent logs as JSON (`{app, environment, groups}`) and exit — machine-readable for the `/yolo` skill and scripts. |
+
+One block per group (web / queue / scheduler), each the recent log events with timestamps (or "no recent log events"). `--json` carries each group's raw `{timestamp, message}` events.
+
+---
+
+## `yolo status:events`
+
+Recent ECS service events per group — the deploy / placement narrative ECS keeps (capacity, health-check, steady-state messages).
+
+```bash
+yolo status:events <environment> [--json]
+```
+
+Arguments and options as [`status:logs`](#yolo-status-logs). `--json` carries each group's `{createdAt, message}` events.
+
+---
+
+## `yolo status:alarms`
+
+The app's CloudWatch alarms and their current state — the incident read surface for "is anything actually firing".
+
+```bash
+yolo status:alarms <environment> [--json]
+```
+
+Arguments and options as [`status:logs`](#yolo-status-logs), with `--json` emitting `{app, environment, alarms}` (each alarm `{name, state, reason}`).
+
+Each alarm is shown as `OK` / `ALARM` / `?` (insufficient data) with its name and state reason. It **exits non-zero when any alarm is in `ALARM`**, so it doubles as a health probe; with no alarms for the app it says so and exits zero.
 
 ---
 

--- a/src/Aws/CloudWatch.php
+++ b/src/Aws/CloudWatch.php
@@ -20,6 +20,31 @@ class CloudWatch
     }
 
     /**
+     * Every alarm whose name starts with the given prefix, reduced to
+     * {name, state, reason} — the app's alarms for `yolo status:alarms`. Empty
+     * when the read fails or none match, so the caller degrades gracefully.
+     *
+     * @return array<int, array{name: string, state: ?string, reason: ?string}>
+     */
+    public static function alarmsWithPrefix(string $prefix): array
+    {
+        try {
+            $alarms = Aws::cloudWatch()->describeAlarms()['MetricAlarms'] ?? [];
+        } catch (AwsException) {
+            return [];
+        }
+
+        return array_values(array_map(
+            fn (array $alarm): array => [
+                'name' => $alarm['AlarmName'] ?? '',
+                'state' => $alarm['StateValue'] ?? null,
+                'reason' => $alarm['StateReason'] ?? null,
+            ],
+            array_filter($alarms, fn (array $alarm): bool => str_starts_with((string) ($alarm['AlarmName'] ?? ''), $prefix)),
+        ));
+    }
+
+    /**
      * The decoded body of a dashboard, addressed by name. Returns the parsed
      * `{ "widgets": [...] }` document so callers diff an array, not a JSON string.
      * Translates the SDK's not-found error to the project's standard signal.

--- a/src/Commands/StatusAlarmsCommand.php
+++ b/src/Commands/StatusAlarmsCommand.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Manifest;
+use Symfony\Component\Console\Input\InputOption;
+use Codinglabs\Yolo\Concerns\RendersIncidentReads;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\intro;
+
+/**
+ * The app's CloudWatch alarms and their state — the incident read surface for
+ * "is anything actually firing". Exits non-zero when any alarm is in ALARM, so
+ * it doubles as a health probe; `--json` is the form the `/yolo` skill consumes.
+ */
+class StatusAlarmsCommand extends Command
+{
+    use RendersIncidentReads;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('status:alarms')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit the alarm state as JSON and exit (machine-readable; for the /yolo skill and scripts)')
+            ->setDescription("Show the app's CloudWatch alarms and their state");
+    }
+
+    public function handle(): int
+    {
+        $alarms = static::gatherAlarms();
+
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode([
+                'app' => Manifest::current()['name'] ?? null,
+                'environment' => $this->argument('environment'),
+                'alarms' => $alarms,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return static::anyAlarmFiring($alarms) ? 1 : 0;
+        }
+
+        if ($alarms === []) {
+            info(sprintf("No alarms for this app in '%s'.", $this->argument('environment')));
+
+            return self::SUCCESS;
+        }
+
+        intro(sprintf('yolo status:alarms · %s · %s', Manifest::current()['name'] ?? '', $this->argument('environment')));
+
+        foreach ($this->alarmLines($alarms) as $line) {
+            $this->output->writeln($line);
+        }
+
+        return static::anyAlarmFiring($alarms) ? 1 : 0;
+    }
+}

--- a/src/Commands/StatusEventsCommand.php
+++ b/src/Commands/StatusEventsCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Manifest;
+use Symfony\Component\Console\Input\InputOption;
+use Codinglabs\Yolo\Concerns\RendersIncidentReads;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\intro;
+
+/**
+ * Recent ECS service events per group — the deploy/placement narrative ECS
+ * keeps (capacity, health-check, steady-state messages). `--json` is the
+ * machine-readable form the `/yolo` skill consumes.
+ */
+class StatusEventsCommand extends Command
+{
+    use RendersIncidentReads;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('status:events')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit recent service events as JSON and exit (machine-readable; for the /yolo skill and scripts)')
+            ->setDescription('Show recent ECS service events per group');
+    }
+
+    public function handle(): int
+    {
+        $groups = static::gatherServiceEvents();
+
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode([
+                'app' => Manifest::current()['name'] ?? null,
+                'environment' => $this->argument('environment'),
+                'groups' => $groups,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        intro(sprintf('yolo status:events · %s · %s', Manifest::current()['name'] ?? '', $this->argument('environment')));
+
+        foreach ($this->serviceEventLines($groups) as $line) {
+            $this->output->writeln($line);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Commands/StatusLogsCommand.php
+++ b/src/Commands/StatusLogsCommand.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Manifest;
+use Symfony\Component\Console\Input\InputOption;
+use Codinglabs\Yolo\Concerns\RendersIncidentReads;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\intro;
+
+/**
+ * Recent CloudWatch logs per service group — the incident read surface for
+ * "what is it saying right now". `--json` is the machine-readable form the
+ * `/yolo` skill consumes.
+ */
+class StatusLogsCommand extends Command
+{
+    use RendersIncidentReads;
+
+    protected function configure(): void
+    {
+        $this
+            ->setName('status:logs')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit recent logs as JSON and exit (machine-readable; for the /yolo skill and scripts)')
+            ->setDescription('Show recent CloudWatch logs per service group');
+    }
+
+    public function handle(): int
+    {
+        $groups = static::gatherLogs();
+
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode([
+                'app' => Manifest::current()['name'] ?? null,
+                'environment' => $this->argument('environment'),
+                'groups' => $groups,
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        intro(sprintf('yolo status:logs · %s · %s', Manifest::current()['name'] ?? '', $this->argument('environment')));
+
+        foreach ($this->logLines($groups) as $line) {
+            $this->output->writeln($line);
+        }
+
+        return self::SUCCESS;
+    }
+}

--- a/src/Concerns/RendersIncidentReads.php
+++ b/src/Concerns/RendersIncidentReads.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Codinglabs\Yolo\Concerns;
+
+use Codinglabs\Yolo\Aws\Ecs;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Aws\CloudWatch;
+use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Aws\CloudWatchLogs;
+use Codinglabs\Yolo\Resources\Ecs\EcsCluster;
+use Codinglabs\Yolo\Resources\Ecs\EcsService;
+use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * The incident read surfaces behind `status:logs` / `status:events` /
+ * `status:alarms` — thin, app-tier reads of CloudWatch Logs, ECS service events
+ * and CloudWatch alarm state, with matching `--json` and display renderers. Every
+ * read is defensive (a missing log group / service / alarm yields an empty list,
+ * never a crash) so the surface works on a half-provisioned or cold app.
+ */
+trait RendersIncidentReads
+{
+    /**
+     * Recent log events per server group, oldest → newest.
+     *
+     * @return array<int, array{group: string, events: array<int, array{timestamp: int, message: string}>}>
+     */
+    protected static function gatherLogs(int $limit = 60): array
+    {
+        $logGroup = (new TaskLogGroup())->name();
+
+        return array_map(fn (ServerGroup $group): array => [
+            'group' => $group->value,
+            'events' => array_map(
+                fn (array $event): array => [
+                    'timestamp' => (int) ($event['timestamp'] ?? 0),
+                    'message' => rtrim((string) ($event['message'] ?? '')),
+                ],
+                CloudWatchLogs::recent($logGroup, $group->value, $limit),
+            ),
+        ], Manifest::serverGroups());
+    }
+
+    /**
+     * Recent ECS service events per server group (the deploy/placement narrative
+     * ECS keeps), newest first.
+     *
+     * @return array<int, array{group: string, events: array<int, array{createdAt: ?string, message: string}>}>
+     */
+    protected static function gatherServiceEvents(int $limit = 10): array
+    {
+        $cluster = (new EcsCluster())->name();
+
+        return array_map(function (ServerGroup $group) use ($cluster, $limit): array {
+            try {
+                $service = Ecs::service($cluster, (new EcsService($group))->name());
+            } catch (ResourceDoesNotExistException) {
+                return ['group' => $group->value, 'events' => []];
+            }
+
+            $events = array_slice($service['events'] ?? [], 0, $limit);
+
+            return [
+                'group' => $group->value,
+                'events' => array_map(fn (array $event): array => [
+                    'createdAt' => static::eventTimestamp($event['createdAt'] ?? null),
+                    'message' => (string) ($event['message'] ?? ''),
+                ], $events),
+            ];
+        }, Manifest::serverGroups());
+    }
+
+    /**
+     * The app's CloudWatch alarms and their current state.
+     *
+     * @return array<int, array{name: string, state: ?string, reason: ?string}>
+     */
+    protected static function gatherAlarms(): array
+    {
+        return CloudWatch::alarmsWithPrefix(Helpers::keyedResourceName());
+    }
+
+    /**
+     * An AWS timestamp (the SDK's DateTimeResult, or an int/string) as an ISO-8601
+     * string for the JSON contract, or null.
+     */
+    protected static function eventTimestamp(mixed $value): ?string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('c');
+        }
+
+        if (is_int($value)) {
+            return gmdate('c', $value);
+        }
+
+        return is_string($value) && $value !== '' ? $value : null;
+    }
+
+    // --- Rendering (instance — uses $this->output) --------------------------
+
+    /**
+     * @param  array<int, array{group: string, events: array<int, array{timestamp: int, message: string}>}>  $groups
+     * @return array<int, string>
+     */
+    protected function logLines(array $groups): array
+    {
+        $lines = [];
+
+        foreach ($groups as $group) {
+            $lines[] = sprintf('  <options=bold>%s</>', $group['group']);
+
+            if ($group['events'] === []) {
+                $lines[] = '  <fg=gray>no recent log events</>';
+
+                continue;
+            }
+
+            foreach ($group['events'] as $event) {
+                $lines[] = sprintf('  <fg=gray>%s</> %s', gmdate('H:i:s', $event['timestamp'] === 0 ? 0 : (int) ($event['timestamp'] / 1000)), $event['message']);
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param  array<int, array{group: string, events: array<int, array{createdAt: ?string, message: string}>}>  $groups
+     * @return array<int, string>
+     */
+    protected function serviceEventLines(array $groups): array
+    {
+        $lines = [];
+
+        foreach ($groups as $group) {
+            $lines[] = sprintf('  <options=bold>%s</>', $group['group']);
+
+            if ($group['events'] === []) {
+                $lines[] = '  <fg=gray>no recent service events</>';
+
+                continue;
+            }
+
+            foreach ($group['events'] as $event) {
+                $lines[] = sprintf('  <fg=gray>%s</> %s', $event['createdAt'] ?? '—', $event['message']);
+            }
+        }
+
+        return $lines;
+    }
+
+    /**
+     * @param  array<int, array{name: string, state: ?string, reason: ?string}>  $alarms
+     * @return array<int, string>
+     */
+    protected function alarmLines(array $alarms): array
+    {
+        return array_map(fn (array $alarm): string => sprintf(
+            '  %s %s%s',
+            static::formatAlarmState($alarm['state']),
+            $alarm['name'],
+            $alarm['reason'] === null ? '' : sprintf(' <fg=gray>— %s</>', $alarm['reason']),
+        ), $alarms);
+    }
+
+    /**
+     * `OK` (green), `ALARM` (red), `INSUFFICIENT_DATA`/unknown (gray). Pure.
+     */
+    public static function formatAlarmState(?string $state): string
+    {
+        return match ($state) {
+            'OK' => '<fg=green>OK   </>',
+            'ALARM' => '<fg=red>ALARM</>',
+            default => '<fg=gray>  ?  </>',
+        };
+    }
+
+    /**
+     * True when any alarm is in ALARM — the non-zero exit signal for the incident
+     * read commands, so they double as health probes.
+     *
+     * @param  array<int, array{name: string, state: ?string, reason: ?string}>  $alarms
+     */
+    public static function anyAlarmFiring(array $alarms): bool
+    {
+        foreach ($alarms as $alarm) {
+            if ($alarm['state'] === 'ALARM') {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -32,10 +32,14 @@ class Yolo
         // Rollback
         Commands\RollbackCommand::class,
 
-        // Status (scope-grouped: app-tier `status`/`status:app`, env-tier roll-up)
+        // Status (scope-grouped: app-tier `status`/`status:app`, env-tier roll-up,
+        // and the incident read surfaces — logs / events / alarms)
         Commands\StatusCommand::class,
         Commands\StatusAppCommand::class,
         Commands\StatusEnvironmentCommand::class,
+        Commands\StatusLogsCommand::class,
+        Commands\StatusEventsCommand::class,
+        Commands\StatusAlarmsCommand::class,
 
         // Exec
         Commands\RunCommand::class,

--- a/tests/Unit/Concerns/RendersIncidentReadsTest.php
+++ b/tests/Unit/Concerns/RendersIncidentReadsTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Commands\StatusLogsCommand;
+use Codinglabs\Yolo\Commands\StatusAlarmsCommand;
+use Codinglabs\Yolo\Commands\StatusEventsCommand;
+use Codinglabs\Yolo\Concerns\RendersIncidentReads;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Symfony\Component\Console\Output\OutputInterface;
+
+function incidentProbe(): object
+{
+    return new class(new BufferedOutput())
+    {
+        use RendersIncidentReads;
+
+        public function __construct(public OutputInterface $output) {}
+
+        /** @return array<int, array{name: string, state: ?string, reason: ?string}> */
+        public function alarms(): array
+        {
+            return self::gatherAlarms();
+        }
+
+        /**
+         * @param  array<int, array{name: string, state: ?string, reason: ?string}>  $alarms
+         * @return array<int, string>
+         */
+        public function alarmsRender(array $alarms): array
+        {
+            return $this->alarmLines($alarms);
+        }
+
+        /**
+         * @param  array<int, array{group: string, events: array<int, array{timestamp: int, message: string}>}>  $groups
+         * @return array<int, string>
+         */
+        public function logsRender(array $groups): array
+        {
+            return $this->logLines($groups);
+        }
+
+        /**
+         * @param  array<int, array{group: string, events: array<int, array{createdAt: ?string, message: string}>}>  $groups
+         * @return array<int, string>
+         */
+        public function eventsRender(array $groups): array
+        {
+            return $this->serviceEventLines($groups);
+        }
+    };
+}
+
+it('colours alarm state and detects a firing alarm', function (): void {
+    expect(StatusAlarmsCommand::formatAlarmState('OK'))->toContain('OK')->toContain('green');
+    expect(StatusAlarmsCommand::formatAlarmState('ALARM'))->toContain('ALARM')->toContain('red');
+    expect(StatusAlarmsCommand::formatAlarmState('INSUFFICIENT_DATA'))->toContain('gray');
+    expect(StatusAlarmsCommand::formatAlarmState(null))->toContain('gray');
+
+    expect(StatusAlarmsCommand::anyAlarmFiring([['name' => 'a', 'state' => 'OK', 'reason' => null]]))->toBeFalse();
+    expect(StatusAlarmsCommand::anyAlarmFiring([['name' => 'a', 'state' => 'ALARM', 'reason' => 'high']]))->toBeTrue();
+});
+
+it("gathers only the app's alarms, by name prefix", function (): void {
+    writeManifest([]);
+
+    $captured = [];
+    bindMockCloudWatchClient(['DescribeAlarms' => new Result(['MetricAlarms' => [
+        ['AlarmName' => 'yolo-testing-my-app-cpu', 'StateValue' => 'OK', 'StateReason' => 'within'],
+        ['AlarmName' => 'yolo-testing-my-app-5xx', 'StateValue' => 'ALARM', 'StateReason' => 'errors'],
+        ['AlarmName' => 'yolo-testing-other-app-cpu', 'StateValue' => 'OK', 'StateReason' => 'within'],
+    ]])], $captured);
+
+    $alarms = incidentProbe()->alarms();
+
+    expect($alarms)->toHaveCount(2)
+        ->and($alarms[0])->toBe(['name' => 'yolo-testing-my-app-cpu', 'state' => 'OK', 'reason' => 'within'])
+        ->and($alarms[1]['state'])->toBe('ALARM');
+});
+
+it('renders the alarm, log and event panels', function (): void {
+    $probe = incidentProbe();
+
+    expect(implode("\n", $probe->alarmsRender([['name' => 'yolo-x-5xx', 'state' => 'ALARM', 'reason' => 'errors']])))
+        ->toContain('ALARM')->toContain('yolo-x-5xx')->toContain('errors');
+
+    expect(implode("\n", $probe->logsRender([['group' => 'web', 'events' => []]])))
+        ->toContain('web')->toContain('no recent log events');
+
+    expect(implode("\n", $probe->eventsRender([['group' => 'web', 'events' => [['createdAt' => '2026-06-15T00:00:00+00:00', 'message' => 'steady state']]]])))
+        ->toContain('web')->toContain('steady state');
+});
+
+it('registers the incident read commands under the status namespace with --json', function (): void {
+    foreach ([StatusLogsCommand::class, StatusEventsCommand::class, StatusAlarmsCommand::class] as $class) {
+        $command = new $class();
+
+        expect($command->getDefinition()->hasOption('json'))->toBeTrue()
+            ->and($command->getDefinition()->hasArgument('environment'))->toBeTrue();
+    }
+
+    expect((new StatusLogsCommand())->getName())->toBe('status:logs')
+        ->and((new StatusEventsCommand())->getName())->toBe('status:events')
+        ->and((new StatusAlarmsCommand())->getName())->toBe('status:alarms');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Phase 3 of the **[LPX-680](https://linear.app/codinglabsau/issue/LPX-680)** read surface — the incident read commands the `/yolo` skill uses to diagnose "something's wrong".

**What problems are you solving?**
- `status` shows steady-state health, but when something's actually wrong the skill (and a human) needs **logs, deploy/placement events, and alarm state** — the incident triad. There was no machine-readable way to pull those.

**What's in it** — three thin app-tier read commands under the `status:*` namespace, each with `--json`:
- **`status:logs`** — recent CloudWatch logs per service group.
- **`status:events`** — recent ECS service events per group (the capacity / health-check / steady-state narrative ECS keeps).
- **`status:alarms`** — the app's CloudWatch alarms + state; **exits non-zero on any `ALARM`**, so it's a health probe too.
- Shared `RendersIncidentReads` trait (gather + render + json); new `CloudWatch::alarmsWithPrefix` lists the app's alarms by name prefix.

**Is there anything the reviewer needs to know to deploy this?**
- **Additive / read-only.** Three new read commands; no change to existing behaviour. Every read is defensive — a missing log group / service / alarm yields an empty list, never a crash.
- **Phase 3 done** (rollback already shipped in #119). With this, Phases 1 + 3 of LPX-680 are complete; Phase 2 (budget) and the Boost MCP tools remain.

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1034 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)