### PR TITLE
LPX-680: budget read surface (status:budget + Cost Explorer)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -28,6 +28,7 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`status:logs <env>`](#yolo-status-logs) | Recent CloudWatch logs per service group |
 | [`status:events <env>`](#yolo-status-events) | Recent ECS service events per group |
 | [`status:alarms <env>`](#yolo-status-alarms) | The app's CloudWatch alarms and their state |
+| [`status:budget <env>`](#yolo-status-budget) | Month-to-date spend against the app's declared budget |
 | [`run <env>`](#yolo-run) | Open a shell / run a command in a running container |
 | [`scale <env> [count]`](#yolo-scale) | Adjust the web service's task count out of band |
 | [`services <env>`](#yolo-services) | View and manage the services an environment offers |
@@ -350,6 +351,26 @@ yolo status:alarms <environment> [--json]
 Arguments and options as [`status:logs`](#yolo-status-logs), with `--json` emitting `{app, environment, alarms}` (each alarm `{name, state, reason}`).
 
 Each alarm is shown as `OK` / `ALARM` / `?` (insufficient data) with its name and state reason. It **exits non-zero when any alarm is in `ALARM`**, so it doubles as a health probe; with no alarms for the app it says so and exits zero.
+
+---
+
+## `yolo status:budget`
+
+Month-to-date spend for the app against its declared [`budget`](/reference/manifest#budget). YOLO **never enforces** a budget (it never acts) — this reports spend, the cap and the `budget.strategy`, and the [`/yolo` skill](/guide/the-yolo-skill) weights its recommendations by them.
+
+```bash
+yolo status:budget <environment> [--json]
+```
+
+| Argument | Required | Description |
+|---|---|---|
+| `environment` | yes | The environment name |
+
+| Option | Value | Default | Description |
+|---|---|---|---|
+| `--json` | flag | off | Emit the budget state as JSON (`{app, environment, currency, spend, budget}`) and exit — machine-readable for the `/yolo` skill and scripts. |
+
+Spend comes from **AWS Cost Explorer**, attributed to the app via its `yolo:app` tag. Cost Explorer is a global service (queried in us-east-1) that only attributes cost by a tag once that tag is **activated as a cost-allocation tag** in the Billing console, and its data lags ~24h — so until activation the spend shows as `—` (the command never errors on it). The line reads `$42.10 / $100.00 · 42% · strategy: balanced`, or `… · no budget set …` when the manifest declares no cap.
 
 ---
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -313,6 +313,25 @@ On a web app, omitting `session` gives you the `redis` default; set a driver to 
 
 ---
 
+## `budget`
+
+An advisory monthly spend target for the app. YOLO **never enforces** it — it never acts on your account on its own. The budget is read by [`yolo status:budget`](/reference/commands#yolo-status-budget) (spend vs cap) and by the [`/yolo` skill](/guide/the-yolo-skill), which weights its recommendations by the `strategy`.
+
+```yaml
+budget:
+  amount: 100          # USD per month (advisory cap)
+  strategy: balanced   # lean | balanced | conservative (default: balanced)
+```
+
+| Key | Default | Description |
+|---|---|---|
+| `budget.amount` | — | The monthly spend target in USD. Optional; omit it and `status:budget` reports spend with "no budget set". |
+| `budget.strategy` | `balanced` | How aggressively the `/yolo` skill should trade cost against headroom — `lean` (cost-first), `balanced`, or `conservative` (headroom-first). |
+
+Spend is read from AWS Cost Explorer via the app's `yolo:app` tag; it shows once that tag is [activated as a cost-allocation tag](/reference/commands#yolo-status-budget) in Billing.
+
+---
+
 ## `tasks.web.*`
 
 Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely for a build-only / headless app with no container.

--- a/src/Aws.php
+++ b/src/Aws.php
@@ -20,6 +20,7 @@ use Aws\CloudFront\CloudFrontClient;
 use Aws\CloudWatch\CloudWatchClient;
 use Aws\ElastiCache\ElastiCacheClient;
 use Aws\EventBridge\EventBridgeClient;
+use Aws\CostExplorer\CostExplorerClient;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\ServiceDiscovery\ServiceDiscoveryClient;
 use Aws\ApplicationAutoScaling\ApplicationAutoScalingClient;
@@ -602,6 +603,11 @@ class Aws
     public static function cloudFront(): CloudFrontClient
     {
         return Helpers::app('cloudFront');
+    }
+
+    public static function costExplorer(): CostExplorerClient
+    {
+        return Helpers::app('costExplorer');
     }
 
     public static function cloudWatch(): CloudWatchClient

--- a/src/Aws/CostExplorer.php
+++ b/src/Aws/CostExplorer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Aws;
+
+use Codinglabs\Yolo\Aws;
+use Aws\Exception\AwsException;
+
+/**
+ * Reads month-to-date spend from AWS Cost Explorer, attributed per app via the
+ * `yolo:app` tag every App-scope resource carries.
+ *
+ * Cost Explorer is a **global** service — its API only lives in us-east-1 (the
+ * client is pinned there). It attributes cost by a tag only once that tag is
+ * activated as a **cost-allocation tag** in the Billing console, and its data
+ * lags ~24h; until then a tag-filtered query returns nothing. So every read here
+ * degrades to null rather than throwing, and `yolo status:budget` renders "—".
+ */
+class CostExplorer
+{
+    /**
+     * Month-to-date unblended spend (USD) attributed to one app via its
+     * `yolo:app` cost-allocation tag, or null when Cost Explorer has no data
+     * (tag not activated yet, or no spend) or the read fails.
+     */
+    public static function monthToDateByApp(string $app): ?float
+    {
+        try {
+            $results = Aws::costExplorer()->getCostAndUsage([
+                'TimePeriod' => static::monthToDate(),
+                'Granularity' => 'MONTHLY',
+                'Metrics' => ['UnblendedCost'],
+                'Filter' => ['Tags' => ['Key' => 'yolo:app', 'Values' => [$app]]],
+            ])['ResultsByTime'] ?? [];
+        } catch (AwsException) {
+            return null;
+        }
+
+        $amount = $results[0]['Total']['UnblendedCost']['Amount'] ?? null;
+
+        return $amount === null ? null : (float) $amount;
+    }
+
+    /**
+     * The current calendar-month-to-date window for Cost Explorer: first of the
+     * month → tomorrow (the End is exclusive, so tomorrow includes today). On the
+     * 1st this is a one-day span, never an empty start==end range CE rejects.
+     *
+     * @return array{Start: string, End: string}
+     */
+    protected static function monthToDate(): array
+    {
+        return [
+            'Start' => gmdate('Y-m-01'),
+            'End' => gmdate('Y-m-d', time() + 86400),
+        ];
+    }
+}

--- a/src/Commands/StatusBudgetCommand.php
+++ b/src/Commands/StatusBudgetCommand.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Aws\CostExplorer;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputArgument;
+
+use function Laravel\Prompts\intro;
+
+/**
+ * Month-to-date spend for the app against its declared budget — the cost read
+ * surface. YOLO never enforces a budget (it never acts); this reports spend, the
+ * declared cap and the `budget.strategy`, and the `/yolo` skill weights its
+ * recommendations by them. Spend comes from Cost Explorer via the `yolo:app`
+ * cost-allocation tag, so it shows "—" until that tag is activated in Billing.
+ */
+class StatusBudgetCommand extends Command
+{
+    protected function configure(): void
+    {
+        $this
+            ->setName('status:budget')
+            ->addArgument('environment', InputArgument::REQUIRED, 'The environment name')
+            ->addOption('json', null, InputOption::VALUE_NONE, 'Emit the budget state as JSON and exit (machine-readable; for the /yolo skill and scripts)')
+            ->setDescription("Show the app's month-to-date spend against its declared budget");
+    }
+
+    public function handle(): int
+    {
+        $spend = CostExplorer::monthToDateByApp(Manifest::name());
+        $amount = Manifest::get('budget.amount');
+        $amount = $amount === null ? null : (float) $amount;
+        $strategy = (string) (Manifest::get('budget.strategy') ?? 'balanced');
+
+        if ($this->option('json')) {
+            $this->output->writeln((string) json_encode([
+                'app' => Manifest::current()['name'] ?? null,
+                'environment' => $this->argument('environment'),
+                'currency' => 'USD',
+                'spend' => $spend,
+                'budget' => ['amount' => $amount, 'strategy' => $strategy],
+            ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+            return self::SUCCESS;
+        }
+
+        intro(sprintf('yolo status:budget · %s · %s', Manifest::current()['name'] ?? '', $this->argument('environment')));
+
+        $this->output->writeln('  ' . static::formatBudget($spend, $amount, $strategy));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * `$42.10 / $100.00 · 42% · strategy: balanced`, or `… · no budget set …`
+     * when no cap is declared, or a `—` spend when Cost Explorer has no data.
+     * Pure — unit-tested directly.
+     */
+    public static function formatBudget(?float $spend, ?float $amount, string $strategy): string
+    {
+        $spendLabel = $spend === null ? '<fg=gray>—</>' : '$' . number_format($spend, 2);
+
+        if ($amount === null) {
+            return sprintf('%s spent this month · <fg=gray>no budget set</> · strategy: %s', $spendLabel, $strategy);
+        }
+
+        $percent = $amount > 0.0 && $spend !== null ? sprintf(' · %d%%', (int) round($spend / $amount * 100)) : '';
+
+        return sprintf('%s / $%s%s · strategy: %s', $spendLabel, number_format($amount, 2), $percent, $strategy);
+    }
+}

--- a/src/Concerns/RegistersAws.php
+++ b/src/Concerns/RegistersAws.php
@@ -23,6 +23,7 @@ use Aws\CloudWatch\CloudWatchClient;
 use Aws\ElastiCache\ElastiCacheClient;
 use Aws\EventBridge\EventBridgeClient;
 use Aws\Credentials\CredentialProvider;
+use Aws\CostExplorer\CostExplorerClient;
 use GuzzleHttp\Exception\ConnectException;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Aws\ServiceDiscovery\ServiceDiscoveryClient;
@@ -48,6 +49,7 @@ trait RegistersAws
         'cloudWatch',
         'cloudWatchLogs',
         'cloudFront',
+        'costExplorer',
         'ec2',
         'elastiCache',
         'ecr',
@@ -98,6 +100,8 @@ trait RegistersAws
         Helpers::app()->singleton('cloudWatchLogs', fn (): CloudWatchLogsClient => new CloudWatchLogsClient($arguments));
         // CloudFront is a global service — its control-plane API only lives in us-east-1.
         Helpers::app()->singleton('cloudFront', fn (): CloudFrontClient => new CloudFrontClient([...$arguments, 'region' => 'us-east-1']));
+        // Cost Explorer is a global service — its API only lives in us-east-1.
+        Helpers::app()->singleton('costExplorer', fn (): CostExplorerClient => new CostExplorerClient([...$arguments, 'region' => 'us-east-1']));
         Helpers::app()->singleton('ec2', fn (): Ec2Client => new Ec2Client($arguments));
         Helpers::app()->singleton('elastiCache', fn (): ElastiCacheClient => new ElastiCacheClient($arguments));
         Helpers::app()->singleton('ecr', fn (): EcrClient => new EcrClient($arguments));

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -36,6 +36,7 @@ class Manifest
         'cache.store',
         'session.driver',
         'task-role-policies',
+        'budget', 'budget.amount', 'budget.strategy',
         // Each task group has a fixed, known shape, so every key is listed
         // explicitly: an unrecognised key under tasks.web / tasks.queue /
         // tasks.scheduler hard-fails rather than being silently accepted by a

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -40,6 +40,7 @@ class Yolo
         Commands\StatusLogsCommand::class,
         Commands\StatusEventsCommand::class,
         Commands\StatusAlarmsCommand::class,
+        Commands\StatusBudgetCommand::class,
 
         // Exec
         Commands\RunCommand::class,

--- a/tests/Unit/Aws/CostExplorerTest.php
+++ b/tests/Unit/Aws/CostExplorerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Aws\Command;
+use Aws\MockHandler;
+use Codinglabs\Yolo\Helpers;
+use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Aws\CostExplorer;
+use Aws\CostExplorer\CostExplorerClient;
+
+function bindMockCostExplorerClient(MockHandler $mock): void
+{
+    Helpers::app()->instance('costExplorer', new CostExplorerClient([
+        'region' => 'us-east-1',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+it('reads month-to-date unblended spend for an app by its yolo:app tag', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new Result(['ResultsByTime' => [
+        ['Total' => ['UnblendedCost' => ['Amount' => '42.10', 'Unit' => 'USD']]],
+    ]]));
+
+    bindMockCostExplorerClient($mock);
+
+    expect(CostExplorer::monthToDateByApp('my-app'))->toBe(42.10);
+});
+
+it('returns null spend when Cost Explorer has no data', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new Result(['ResultsByTime' => [['Total' => []]]]));
+
+    bindMockCostExplorerClient($mock);
+
+    expect(CostExplorer::monthToDateByApp('my-app'))->toBeNull();
+});
+
+it('returns null spend when the Cost Explorer read fails', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new AwsException('denied', new Command('GetCostAndUsage')));
+
+    bindMockCostExplorerClient($mock);
+
+    expect(CostExplorer::monthToDateByApp('my-app'))->toBeNull();
+});

--- a/tests/Unit/Commands/StatusBudgetCommandTest.php
+++ b/tests/Unit/Commands/StatusBudgetCommandTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Commands\StatusBudgetCommand;
+
+it('formats spend against the budget, the strategy, or notes no budget set', function (): void {
+    expect(StatusBudgetCommand::formatBudget(42.1, 100.0, 'balanced'))
+        ->toContain('$42.10')
+        ->toContain('$100.00')
+        ->toContain('42%')
+        ->toContain('strategy: balanced');
+
+    // No spend data yet (Cost Explorer tag not activated) → em dash, cap still shown.
+    expect(StatusBudgetCommand::formatBudget(null, 100.0, 'lean'))
+        ->toContain('—')
+        ->toContain('$100.00')
+        ->toContain('strategy: lean');
+
+    // No cap declared → reports spend with a "no budget set" note.
+    expect(StatusBudgetCommand::formatBudget(30.0, null, 'conservative'))
+        ->toContain('$30.00')
+        ->toContain('no budget set')
+        ->toContain('strategy: conservative');
+});
+
+it('registers status:budget with --json', function (): void {
+    $command = new StatusBudgetCommand();
+
+    expect($command->getName())->toBe('status:budget')
+        ->and($command->getDefinition()->hasOption('json'))->toBeTrue()
+        ->and($command->getDefinition()->hasArgument('environment'))->toBeTrue();
+});
+
+it('accepts the budget block in the manifest schema', function (): void {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'budget' => ['amount' => 100, 'strategy' => 'balanced'],
+    ]);
+
+    expect(Manifest::unknownKeys())->toBe([]);
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Phase 2 (core) of the **[LPX-680](https://linear.app/codinglabsau/issue/LPX-680)** read surface — month-to-date spend against a declared budget.

**What problems are you solving?**
- The `/yolo` skill is meant to keep each app on the cost↔UX frontier, but there was no way to read **spend** or carry a **budget** intent. This adds both — as a *read surface*, not enforcement (YOLO never acts on your account on its own).

**What's in it**
- **`src/Aws/CostExplorer.php`** + a us-east-1-pinned `costExplorer` client — per-app month-to-date unblended spend via the `yolo:app` tag.
- **`status:budget`** — spend vs the declared cap + `strategy`, with `--json` (`{app, environment, currency, spend, budget}`).
- **manifest `budget` block** — `budget.amount` (USD/month) + `budget.strategy` (`lean` | `balanced` | `conservative`, default `balanced`). The skill weights its recommendations by the strategy.

**Is there anything the reviewer needs to know to deploy this?**
- **Read-only / additive.** New command + manifest block + AWS client; no change to existing behaviour. The bindings-pin test keeps `AWS_CLIENT_BINDINGS` in sync (costExplorer added to both).
- **Cost Explorer is MockHandler-shape-tested only** (the repo's standard for AWS integrations). It's a global service (queried us-east-1) and attributes cost by a tag **only once that tag is activated as a cost-allocation tag in Billing** (data lags ~24h) — so `status:budget` shows `—` for spend until activation, and never errors on it. First-real-run verification + tag activation is a deploy step, documented in the command reference.
- **Deferred follow-ups** (each needs its own groundwork): env-tier budget in the env manifest (EnvManifest schema), and per-tenant reporting via a `yolo:tenant` cost-allocation tag (tenant-resource tagging).

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1040 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)