### PR TITLE
LPX-680: env-tier budget (the second half of the two-tier budget)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -304,9 +304,11 @@ yolo status:environment <environment> [--json]
 
 | Option | Value | Default | Description |
 |---|---|---|---|
-| `--json` | flag | off | Emit the roll-up as JSON (`{environment, apps}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if any app has a failed deploy. |
+| `--json` | flag | off | Emit the roll-up as JSON (`{environment, apps, budget}`) and exit — machine-readable for the `/yolo` skill and scripts. Exits non-zero if any app has a failed deploy. |
 
-It renders an **App / Web / Rollout / Version** table — one row per live app — and exits non-zero if any app's deploy is currently failed, so it's usable as an environment-wide health probe. With no live apps it says so and exits zero. `--json` emits `{environment, apps[]}`, each app carrying `{app, exists, tasks, revision, version, rollout}`.
+It renders an **App / Web / Rollout / Version** table — one row per live app — and exits non-zero if any app's deploy is currently failed, so it's usable as an environment-wide health probe. With no live apps it says so and exits zero. `--json` emits `{environment, apps[], budget}`, each app carrying `{app, exists, tasks, revision, version, rollout}`.
+
+It also reports the **env-tier budget** — the other half of the [two-tier budget](/reference/manifest#budget): total month-to-date spend across the whole environment (every app + shared infra, via the `yolo:environment` tag) against the cap declared in the [environment manifest](/reference/manifest). `budget` is `{currency, amount, strategy, spend}`, with `spend` null until the tag is activated for cost allocation (same as [`status:budget`](#yolo-status-budget)).
 
 ---
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -330,6 +330,8 @@ budget:
 
 Spend is read from AWS Cost Explorer via the app's `yolo:app` tag; it shows once that tag is [activated as a cost-allocation tag](/reference/commands#yolo-status-budget) in Billing.
 
+The budget block is **two-tier**: the same `budget` shape can also be declared in the [environment manifest](#the-environment-manifest-yolo-environment-environment-yml), where it caps the whole environment (every app + shared infra, attributed via the `yolo:environment` tag) and is reported by [`status:environment`](/reference/commands#yolo-status-environment). App-tier `budget` lives in `yolo.yml`; env-tier `budget` in `yolo-environment-<env>.yml`.
+
 ---
 
 ## `tasks.web.*`

--- a/src/Aws/CostExplorer.php
+++ b/src/Aws/CostExplorer.php
@@ -26,12 +26,32 @@ class CostExplorer
      */
     public static function monthToDateByApp(string $app): ?float
     {
+        return static::monthToDateByTag('yolo:app', $app);
+    }
+
+    /**
+     * Month-to-date unblended spend (USD) across an entire environment — every
+     * resource tagged `yolo:environment=<env>` (all apps plus the shared infra).
+     * Same caveats and null-on-no-data behaviour as the per-app read.
+     */
+    public static function monthToDateByEnvironment(string $environment): ?float
+    {
+        return static::monthToDateByTag('yolo:environment', $environment);
+    }
+
+    /**
+     * Month-to-date unblended spend (USD) for everything carrying one tag
+     * key=value, or null when Cost Explorer has no data (tag not activated for
+     * cost allocation yet, or no spend) or the read fails.
+     */
+    protected static function monthToDateByTag(string $key, string $value): ?float
+    {
         try {
             $results = Aws::costExplorer()->getCostAndUsage([
                 'TimePeriod' => static::monthToDate(),
                 'Granularity' => 'MONTHLY',
                 'Metrics' => ['UnblendedCost'],
-                'Filter' => ['Tags' => ['Key' => 'yolo:app', 'Values' => [$app]]],
+                'Filter' => ['Tags' => ['Key' => $key, 'Values' => [$value]]],
             ])['ResultsByTime'] ?? [];
         } catch (AwsException) {
             return null;

--- a/src/Commands/StatusEnvironmentCommand.php
+++ b/src/Commands/StatusEnvironmentCommand.php
@@ -2,6 +2,8 @@
 
 namespace Codinglabs\Yolo\Commands;
 
+use Codinglabs\Yolo\EnvManifest;
+use Codinglabs\Yolo\Aws\CostExplorer;
 use Symfony\Component\Console\Input\InputOption;
 use Codinglabs\Yolo\Concerns\RendersServiceStatus;
 use Symfony\Component\Console\Input\InputArgument;
@@ -32,6 +34,7 @@ class StatusEnvironmentCommand extends Command
     {
         $environment = $this->argument('environment');
         $rows = static::gatherEnvStatuses($environment);
+        $budget = static::gatherEnvBudget($environment);
 
         // `--json` is the machine-readable contract: emit the roll-up and exit
         // non-zero if any app has a failed deploy so it stays scriptable.
@@ -39,6 +42,7 @@ class StatusEnvironmentCommand extends Command
             $this->output->writeln((string) json_encode([
                 'environment' => $environment,
                 'apps' => static::jsonEnvStatuses($rows),
+                'budget' => $budget,
             ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
             return static::anyDeploymentFailed($rows) ? 1 : 0;
@@ -56,6 +60,34 @@ class StatusEnvironmentCommand extends Command
             $this->output->writeln($line);
         }
 
+        // The env-tier half of the two-tier budget: total spend across the env
+        // (all apps + shared infra, via the yolo:environment tag) vs the cap
+        // declared in the env manifest. Shown only when there's something to show.
+        if ($budget['amount'] !== null || $budget['spend'] !== null) {
+            $this->output->writeln('');
+            $this->output->writeln('  <options=bold>Budget</> <fg=gray>(env, month-to-date)</>');
+            $this->output->writeln('  ' . StatusBudgetCommand::formatBudget($budget['spend'], $budget['amount'], $budget['strategy']));
+        }
+
         return static::anyDeploymentFailed($rows) ? 1 : 0;
+    }
+
+    /**
+     * The env-tier budget: the cap + strategy declared in the env manifest, plus
+     * month-to-date spend across the whole environment (Cost Explorer via the
+     * `yolo:environment` tag). Mirrors the app-tier shape `status:budget` emits.
+     *
+     * @return array{currency: string, amount: ?float, strategy: string, spend: ?float}
+     */
+    protected static function gatherEnvBudget(string $environment): array
+    {
+        $amount = EnvManifest::get('budget.amount');
+
+        return [
+            'currency' => 'USD',
+            'amount' => $amount === null ? null : (float) $amount,
+            'strategy' => (string) (EnvManifest::get('budget.strategy') ?? 'balanced'),
+            'spend' => CostExplorer::monthToDateByEnvironment($environment),
+        ];
     }
 }

--- a/src/EnvManifest.php
+++ b/src/EnvManifest.php
@@ -66,7 +66,7 @@ class EnvManifest
             }
         }
 
-        return ['domain', 'services', ...$serviceKeys];
+        return ['domain', 'services', 'budget', 'budget.amount', 'budget.strategy', ...$serviceKeys];
     }
 
     /** @var array<string, mixed>|null */

--- a/tests/Unit/Aws/CostExplorerTest.php
+++ b/tests/Unit/Aws/CostExplorerTest.php
@@ -31,6 +31,17 @@ it('reads month-to-date unblended spend for an app by its yolo:app tag', functio
     expect(CostExplorer::monthToDateByApp('my-app'))->toBe(42.10);
 });
 
+it('reads month-to-date spend across an environment by its yolo:environment tag', function (): void {
+    $mock = new MockHandler();
+    $mock->append(new Result(['ResultsByTime' => [
+        ['Total' => ['UnblendedCost' => ['Amount' => '318.40', 'Unit' => 'USD']]],
+    ]]));
+
+    bindMockCostExplorerClient($mock);
+
+    expect(CostExplorer::monthToDateByEnvironment('production'))->toBe(318.40);
+});
+
 it('returns null spend when Cost Explorer has no data', function (): void {
     $mock = new MockHandler();
     $mock->append(new Result(['ResultsByTime' => [['Total' => []]]]));

--- a/tests/Unit/EnvManifestTest.php
+++ b/tests/Unit/EnvManifestTest.php
@@ -114,6 +114,11 @@ it('accepts a declared ivs service', function (): void {
     expect(EnvManifest::parse("services:\n  ivs: {}\n"))->toBe(['services' => ['ivs' => []]]);
 });
 
+it('accepts an env-tier budget block', function (): void {
+    expect(EnvManifest::parse("budget:\n  amount: 500\n  strategy: balanced\n"))
+        ->toBe(['budget' => ['amount' => 500, 'strategy' => 'balanced']]);
+});
+
 it('rejects a scalar offer — the allow-list cannot catch a leaf, the definition validates the shape', function (): void {
     expect(fn (): array => EnvManifest::parse("services:\n  ivs: true\n"))
         ->toThrow(IntegrityCheckException::class, 'services.ivs');


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Completes Phase 2's **two-tier budget** — app-tier shipped in #132, this adds the **env tier**.

**What problems are you solving?**
- The budget was meant to be two-tier — per-app *and* per-environment (all apps + shared infra). #132 did the app half; an env had no way to declare or see its total spend vs a cap.

**What's in it**
- **`EnvManifest`** gains the `budget` block (`budget.amount` + `budget.strategy`), mirroring the app manifest.
- **`CostExplorer::monthToDateByEnvironment`** — env-wide spend via the `yolo:environment` tag (both per-app and per-env reads now share one `monthToDateByTag`).
- **`status:environment`** reports it: `--json` gains `budget {currency, amount, strategy, spend}`, plus a human footer (reusing `StatusBudgetCommand::formatBudget`).

**Is there anything the reviewer needs to know to deploy this?**
- **Additive / read-only.** New manifest key + a Cost Explorer read on `status:environment`; no behaviour change. `spend` is null until the `yolo:environment` cost-allocation tag is activated in Billing (same gate as the app-tier budget).
- The env-budget read is defensive — a cold env (no env manifest) yields no budget, never a crash.
- **Phase 2 is now complete bar per-tenant reporting**, which needs the `yolo:tenant` resource-tagging groundwork (a tagging-layer change) — flagged as its own slice on the epic.

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1056 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)