### PR TITLE
LPX-635: rename YoloObserver → ObserverPolicy / ObserverRole (naming consistency)

### DIFF
--- a/src/Commands/SyncEnvironmentCommand.php
+++ b/src/Commands/SyncEnvironmentCommand.php
@@ -49,7 +49,7 @@ class SyncEnvironmentCommand extends SyncSteppedCommand
                 // drift-check surface every app's deployer role attaches so the
                 // pre-deploy `sync --check` gate can read the whole stack under the
                 // deploy role, scoped to exactly the services YOLO provisions.
-                Steps\Sync\Environment\SyncYoloObserverPolicyStep::class,
+                Steps\Sync\Environment\SyncObserverPolicyStep::class,
                 // The read-only role an operator/agent assumes for safe inspection
                 // (LPX-635) — created, then the observer policy attached to it.
                 Steps\Sync\Environment\SyncObserverRoleStep::class,

--- a/src/Resources/Iam/ObserverPolicy.php
+++ b/src/Resources/Iam/ObserverPolicy.php
@@ -38,7 +38,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * id, environment), so the document is pure — no live AWS calls. Document drift is
  * reconciled as a plan-visible Change via SynchronisesPolicyDocument.
  */
-class YoloObserver implements Resource, SynchronisesConfiguration
+class ObserverPolicy implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
     use SynchronisesPolicyDocument;

--- a/src/Resources/Iam/ObserverRole.php
+++ b/src/Resources/Iam/ObserverRole.php
@@ -14,7 +14,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 /**
  * YOLO-managed IAM role an operator or an agent (Claude / Leeloo) assumes for
  * **read-only** inspection of the environment — the `*-readonly` profile target
- * from LPX-635. It carries the env-shared {@see YoloObserver} policy (attached by
+ * from LPX-635. It carries the env-shared {@see ObserverPolicy} policy (attached by
  * AttachObserverRolePolicyStep), so a profile assuming it can `describe`/`list`/
  * `get` exactly the services YOLO touches and **nothing mutating** — safe by
  * construction, not by convention.
@@ -31,7 +31,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * `credential_process` source. TODO(review): tighten the trust to the specific
  * operator/agent principal once that identity is settled.
  */
-class YoloObserverRole implements Resource, SynchronisesConfiguration
+class ObserverRole implements Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
     use SynchronisesAssumeRolePolicy;

--- a/src/Steps/Sync/App/AttachDeployerRolePoliciesStep.php
+++ b/src/Steps/Sync/App/AttachDeployerRolePoliciesStep.php
@@ -7,8 +7,8 @@ use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
-use Codinglabs\Yolo\Resources\Iam\YoloObserver;
 use Codinglabs\Yolo\Resources\Iam\DeployerPolicy;
+use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
 use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
 
 class AttachDeployerRolePoliciesStep implements Step
@@ -21,7 +21,7 @@ class AttachDeployerRolePoliciesStep implements Step
             return StepResult::SKIPPED;
         }
 
-        // DeployerPolicy = the deploy-time write/read grants. YoloObserver = the
+        // DeployerPolicy = the deploy-time write/read grants. ObserverPolicy = the
         // env-shared read-only surface the pre-deploy `sync --check` gate
         // (EnsureInSyncStep) needs to inspect the whole stack — attaching it means
         // the deployer inherits exactly that read without a new direct grant, and
@@ -30,7 +30,7 @@ class AttachDeployerRolePoliciesStep implements Step
             (new DeployerRole())->name(),
             [
                 $this->customerManagedPolicyArn((new DeployerPolicy())->name()),
-                $this->customerManagedPolicyArn((new YoloObserver())->name()),
+                $this->customerManagedPolicyArn((new ObserverPolicy())->name()),
             ],
             (bool) Arr::get($options, 'dry-run'),
         );

--- a/src/Steps/Sync/Environment/AttachObserverRolePolicyStep.php
+++ b/src/Steps/Sync/Environment/AttachObserverRolePolicyStep.php
@@ -5,12 +5,12 @@ namespace Codinglabs\Yolo\Steps\Sync\Environment;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Resources\Iam\YoloObserver;
+use Codinglabs\Yolo\Resources\Iam\ObserverRole;
+use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
 use Codinglabs\Yolo\Concerns\AttachesRolePolicies;
-use Codinglabs\Yolo\Resources\Iam\YoloObserverRole;
 
 /**
- * Attaches the read-only {@see YoloObserver} policy to the {@see YoloObserverRole},
+ * Attaches the read-only {@see ObserverPolicy} policy to the {@see ObserverRole},
  * so a profile assuming the role gets exactly YOLO's inspection surface — and
  * nothing mutating. Runs after the role and the policy are provisioned; the
  * attach reconciles idempotently (a missing attachment is recorded as a plan-time
@@ -23,8 +23,8 @@ class AttachObserverRolePolicyStep implements Step
     public function __invoke(array $options): StepResult
     {
         return $this->attachRolePolicies(
-            (new YoloObserverRole())->name(),
-            [$this->customerManagedPolicyArn((new YoloObserver())->name())],
+            (new ObserverRole())->name(),
+            [$this->customerManagedPolicyArn((new ObserverPolicy())->name())],
             (bool) Arr::get($options, 'dry-run'),
         );
     }

--- a/src/Steps/Sync/Environment/SyncObserverPolicyStep.php
+++ b/src/Steps/Sync/Environment/SyncObserverPolicyStep.php
@@ -4,7 +4,7 @@ namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Resources\Iam\YoloObserver;
+use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 
 /**
@@ -16,12 +16,12 @@ use Codinglabs\Yolo\Concerns\SynchronisesResource;
  * Document drift (a YOLO upgrade that reads a new service) surfaces as a plan-time
  * Change via SynchronisesPolicyDocument, so the plan flags it and apply re-versions.
  */
-class SyncYoloObserverPolicyStep implements Step
+class SyncObserverPolicyStep implements Step
 {
     use SynchronisesResource;
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new YoloObserver(), $options);
+        return $this->syncResource(new ObserverPolicy(), $options);
     }
 }

--- a/src/Steps/Sync/Environment/SyncObserverRoleStep.php
+++ b/src/Steps/Sync/Environment/SyncObserverRoleStep.php
@@ -4,8 +4,8 @@ namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Iam\ObserverRole;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
-use Codinglabs\Yolo\Resources\Iam\YoloObserverRole;
 
 /**
  * Provisions the env-shared read-only `yolo-{env}-observer-role` (LPX-635) an
@@ -19,6 +19,6 @@ class SyncObserverRoleStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new YoloObserverRole(), $options);
+        return $this->syncResource(new ObserverRole(), $options);
     }
 }

--- a/tests/Unit/Resources/Iam/DeployerPolicyTest.php
+++ b/tests/Unit/Resources/Iam/DeployerPolicyTest.php
@@ -136,7 +136,7 @@ it('grants object access on this app\'s claim file in the env config bucket, sco
 
     // The env config bucket root is never granted at the object or bucket level —
     // that read is the permission gating env-secret control. (The read surface the
-    // sync-check gate needs lives in the separate YoloObserver policy, scoped to
+    // sync-check gate needs lives in the separate ObserverPolicy policy, scoped to
     // non-secret config — never granted here.)
     $allResources = collect((new DeployerPolicy())->document()['Statement'])
         ->flatMap(fn (array $statement): array => (array) $statement['Resource']);

--- a/tests/Unit/Resources/Iam/ObserverPolicyTest.php
+++ b/tests/Unit/Resources/Iam/ObserverPolicyTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Codinglabs\Yolo\Enums\Scope;
-use Codinglabs\Yolo\Resources\Iam\YoloObserver;
+use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
 
 beforeEach(function (): void {
     writeManifest([
@@ -12,18 +12,18 @@ beforeEach(function (): void {
 /** Every action the policy grants, flattened across statements. */
 function observerActions(): array
 {
-    return collect((new YoloObserver())->document()['Statement'])
+    return collect((new ObserverPolicy())->document()['Statement'])
         ->flatMap(fn (array $statement): array => (array) $statement['Action'])
         ->all();
 }
 
 it('is an env-scoped policy named yolo-{env}-observer (shared by every app in the environment)', function (): void {
-    expect((new YoloObserver())->scope())->toBe(Scope::Env);
-    expect((new YoloObserver())->name())->toBe('yolo-testing-observer');
+    expect((new ObserverPolicy())->scope())->toBe(Scope::Env);
+    expect((new ObserverPolicy())->name())->toBe('yolo-testing-observer');
 });
 
 it('grants read-only wildcards for the services YOLO provisions, on * (unscopeable describe/list ops)', function (): void {
-    $statement = collect((new YoloObserver())->document()['Statement'])
+    $statement = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => $s['Resource'] === '*' && in_array('ecs:Describe*', (array) $s['Action'], true));
 
     expect($statement)->not->toBeNull();
@@ -56,7 +56,7 @@ it('grants no write actions — read-only by construction', function (): void {
 });
 
 it('scopes IAM document reads to YOLO-managed identities, never the whole account', function (): void {
-    $statement = collect((new YoloObserver())->document()['Statement'])
+    $statement = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => in_array('iam:GetPolicyVersion', (array) $s['Action'], true));
 
     expect($statement['Resource'])->toBe([
@@ -66,14 +66,14 @@ it('scopes IAM document reads to YOLO-managed identities, never the whole accoun
     ]);
 
     // The unscopeable IAM collection ops (list the account) are the only IAM on *.
-    $onStar = collect((new YoloObserver())->document()['Statement'])
+    $onStar = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => $s['Resource'] === '*');
 
     expect($onStar['Action'])->not->toContain('iam:GetPolicyVersion', 'iam:GetRole');
 });
 
 it('scopes s3 object reads to the env-shared config only — never secrets', function (): void {
-    $objectStatement = collect((new YoloObserver())->document()['Statement'])
+    $objectStatement = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => in_array('s3:GetObject', (array) $s['Action'], true));
 
     // GetObject is granted on exactly the env manifest + app claim files — config,
@@ -88,13 +88,13 @@ it('scopes s3 object reads to the env-shared config only — never secrets', fun
 
     // s3:GetObject is never granted on * — the boundary that keeps the observer out
     // of every other bucket's objects.
-    $onStar = collect((new YoloObserver())->document()['Statement'])
+    $onStar = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => $s['Resource'] === '*');
     expect($onStar['Action'])->not->toContain('s3:GetObject');
 });
 
 it('scopes s3 bucket-config reads to YOLO-named buckets and excludes object contents', function (): void {
-    $bucketStatement = collect((new YoloObserver())->document()['Statement'])
+    $bucketStatement = collect((new ObserverPolicy())->document()['Statement'])
         ->first(fn (array $s): bool => $s['Resource'] === 'arn:aws:s3:::yolo-*');
 
     expect($bucketStatement['Action'])->toContain('s3:GetBucket*', 's3:ListBucket');

--- a/tests/Unit/Resources/Iam/ObserverRoleTest.php
+++ b/tests/Unit/Resources/Iam/ObserverRoleTest.php
@@ -1,7 +1,7 @@
 <?php
 
 use Codinglabs\Yolo\Enums\Scope;
-use Codinglabs\Yolo\Resources\Iam\YoloObserverRole;
+use Codinglabs\Yolo\Resources\Iam\ObserverRole;
 
 beforeEach(function (): void {
     writeManifest([
@@ -10,12 +10,12 @@ beforeEach(function (): void {
 });
 
 it('is an env-scoped role named yolo-{env}-observer-role (shared by the environment)', function (): void {
-    expect((new YoloObserverRole())->scope())->toBe(Scope::Env);
-    expect((new YoloObserverRole())->name())->toBe('yolo-testing-observer-role');
+    expect((new ObserverRole())->scope())->toBe(Scope::Env);
+    expect((new ObserverRole())->name())->toBe('yolo-testing-observer-role');
 });
 
 it('trusts the account principal, so an identity granted sts:AssumeRole can assume it', function (): void {
-    $statement = (new YoloObserverRole())->assumeRolePolicyDocument()['Statement'][0];
+    $statement = (new ObserverRole())->assumeRolePolicyDocument()['Statement'][0];
 
     expect($statement)->toMatchArray([
         'Effect' => 'Allow',

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -206,7 +206,7 @@ it('attaches the deployer policy to the deployer role', function (): void {
     expect($attach['args']['PolicyArn'])->toBe('arn:aws:iam::111111111111:policy/yolo-testing-my-app-deployer-policy');
 });
 
-it('attaches the env-shared YoloObserver policy so the pre-deploy sync check can read the whole stack', function (): void {
+it('attaches the env-shared ObserverPolicy policy so the pre-deploy sync check can read the whole stack', function (): void {
     // The deploy-time `sync --check` gate plans the whole stack under the deployer
     // role; the env-shared yolo-{env}-observer policy carries the read surface for
     // exactly the services YOLO provisions, so a missing read can't AccessDenied-

--- a/tests/Unit/Steps/Iam/SyncObserverPolicyStepTest.php
+++ b/tests/Unit/Steps/Iam/SyncObserverPolicyStepTest.php
@@ -2,8 +2,8 @@
 
 use Aws\Result;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Resources\Iam\YoloObserver;
-use Codinglabs\Yolo\Steps\Sync\Environment\SyncYoloObserverPolicyStep;
+use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncObserverPolicyStep;
 
 beforeEach(function (): void {
     writeManifest([
@@ -17,7 +17,7 @@ it('creates the env-shared observer policy when absent', function (): void {
         'ListPolicies' => new Result(['Policies' => []]),
     ], $captured);
 
-    expect((new SyncYoloObserverPolicyStep())([]))->toBe(StepResult::CREATED);
+    expect((new SyncObserverPolicyStep())([]))->toBe(StepResult::CREATED);
 
     $create = collect($captured)->firstWhere('name', 'CreatePolicy');
     expect($create)->not->toBeNull();
@@ -30,7 +30,7 @@ it('would-create the observer policy on a dry-run without writing', function ():
         'ListPolicies' => new Result(['Policies' => []]),
     ], $captured);
 
-    expect((new SyncYoloObserverPolicyStep())(['dry-run' => true]))->toBe(StepResult::WOULD_CREATE);
+    expect((new SyncObserverPolicyStep())(['dry-run' => true]))->toBe(StepResult::WOULD_CREATE);
     expect(array_column($captured, 'name'))->not->toContain('CreatePolicy');
 });
 
@@ -43,7 +43,7 @@ it('stays in sync without re-versioning when the live document already matches',
             'DefaultVersionId' => 'v1',
         ]]]),
         'GetPolicyVersion' => new Result(['PolicyVersion' => [
-            'Document' => rawurlencode(json_encode((new YoloObserver())->document())),
+            'Document' => rawurlencode(json_encode((new ObserverPolicy())->document())),
         ]]),
         'ListPolicyTags' => new Result(['Tags' => [
             ['Key' => 'Name', 'Value' => 'yolo-testing-observer'],
@@ -52,6 +52,6 @@ it('stays in sync without re-versioning when the live document already matches',
         ]]),
     ], $captured);
 
-    expect((new SyncYoloObserverPolicyStep())([]))->toBe(StepResult::SYNCED);
+    expect((new SyncObserverPolicyStep())([]))->toBe(StepResult::SYNCED);
     expect(array_column($captured, 'name'))->not->toContain('CreatePolicyVersion');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Naming cleanup you OK'd: `YoloObserver` → **`ObserverPolicy`**, `YoloObserverRole` → **`ObserverRole`** (+ `SyncYoloObserverPolicyStep` → `SyncObserverPolicyStep`), matching `DeployerPolicy`/`DeployerRole`.

**What problems are you solving?**
- `YoloObserver` was the lone IAM resource with a `Yolo` prefix *and* no type suffix. This makes the observer pair read like its deployer sibling — no prefix (the `Resources/Iam/` namespace + `yolo-{env}-…` AWS name already say "Yolo"), explicit `Policy`/`Role` suffix.

**Is there anything the reviewer needs to know to deploy this?**
- **Pure class/file rename — zero runtime impact.** The AWS resource names are unchanged (the `Iam` enum values `'observer'` / `'observer-role'` are untouched), so nothing in AWS renames; only PHP identifiers move. All refs + tests updated, full suite green.
- **Prep for the reshaped Phase 0 auth** ([LPX-635](https://linear.app/codinglabsau/issue/LPX-635) / [LPX-680](https://linear.app/codinglabsau/issue/LPX-680)): the dev authenticates as themselves, then YOLO **mints a token scoped to one of the three tier *policies*** (Observer/Deployer/Admin) — effective perms = their perms ∩ the tier, so no privilege escalation. The **policies** are the core; the observer **role** (`ObserverRole`, #135) is only needed for the `sts:AssumeRole`-session-policy path, **not** the `sts:GetFederationToken` (policy-only) path — so it may be removed once the mechanism's chosen. Mechanism + `AdminPolicy` still pending your calls (see the Linear thread).

**Validation:** Rector clean · Pint clean · PHPStan L5 clean · Pest **1058 green**.

🤖 Generated with [Claude Code](https://claude.ai/code)