### PR TITLE
fix(LPX-659): enable FrankenPHP metrics via --caddyfile so burst autoscaling fires

### DIFF
--- a/docs/guide/scaling.md
+++ b/docs/guide/scaling.md
@@ -72,7 +72,7 @@ Burst adds a **step-scaling policy** driven by a **high-resolution alarm** (10s)
 How it works, and what it costs:
 
 - A tiny supervised process in the web container reads FrankenPHP's metrics endpoint and writes the saturation as an [embedded-metric-format](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/CloudWatch_Embedded_Metric_Format.html) line to stdout — **only while it's hot** (≥70%). CloudWatch Logs auto-extracts the metric, so there's no `PutMetricData`, no AWS SDK in the container and **no new IAM**.
-- YOLO turns FrankenPHP's metrics endpoint on with a single `CADDY_GLOBAL_OPTIONS` env var on the web task (it never touches your Caddyfile).
+- To turn that endpoint on, YOLO runs Octane against a Caddyfile it generates — your installed Octane stub with the `servers { metrics }` global option added, passed via `--caddyfile`. It's generated only for an autoscaling Octane web tier and is your stub untouched bar that one line (so Octane still fills its own placeholders). An env var won't do here: `octane:start` rebuilds `CADDY_GLOBAL_OPTIONS` itself, discarding any value set on the task. The endpoint binds container-loopback (`localhost:2019`) only — never the load-balanced port — so it adds no external surface.
 - Cost is dominated by the one high-resolution alarm — roughly **$0.30/month** per app; the metric and log lines are near-zero because nothing is emitted until the service is hot.
 
 ::: warning Burst is not a substitute for warm capacity

--- a/src/Commands/BuildCommand.php
+++ b/src/Commands/BuildCommand.php
@@ -30,6 +30,7 @@ class BuildCommand extends SteppedCommand
         Steps\Build\Fargate\BuildDockerImageStep::class,
         Steps\Build\Fargate\CheckSchedulerRuntimeStep::class,
         Steps\Build\Fargate\CheckSsrRuntimeStep::class,
+        Steps\Build\Fargate\CheckMetricsRuntimeStep::class,
         Steps\Build\Fargate\PushDockerImageStep::class,
     ];
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -357,6 +357,20 @@ class Manifest
     }
 
     /**
+     * Whether the build ships YOLO's metrics-enabled Caddyfile and runs Octane against
+     * it (`octane:start --caddyfile`). True only for an autoscaling web tier on Octane
+     * (worker mode): FrankenPHP's worker gauges — the burst signal — exist only there,
+     * and `octane:start` overwrites the CADDY_GLOBAL_OPTIONS env var, so the metrics
+     * global option has to ride in a Caddyfile rather than the environment. The single
+     * gate the Caddyfile generation, the `--caddyfile` flag and the build preflight all
+     * key off, so they can't drift; classic mode never reaches it (burst is inert there).
+     */
+    public static function usesMetricsCaddyfile(): bool
+    {
+        return static::isAutoscaling() && static::usesOctane();
+    }
+
+    /**
      * Which container runs the queue worker: a standalone `tasks.queue` service if
      * extracted, else bundled in the web container. The worker always runs
      * somewhere — there's no opt-out.

--- a/src/ProcessCommands.php
+++ b/src/ProcessCommands.php
@@ -49,7 +49,7 @@ class ProcessCommands
         // a custom Caddyfile: GenerateSupervisorConfigStep writes the app's own Octane stub
         // with `servers { metrics }` added to docker/Caddyfile, and --caddyfile runs it.
         // Web autoscaling only; classic mode returned above and never reaches here.
-        if (Manifest::isAutoscaling()) {
+        if (Manifest::usesMetricsCaddyfile()) {
             $command .= ' --caddyfile=/app/docker/Caddyfile';
         }
 

--- a/src/ProcessCommands.php
+++ b/src/ProcessCommands.php
@@ -40,7 +40,20 @@ class ProcessCommands
             return sprintf('frankenphp php-server --listen 0.0.0.0:%d --root public/', $port);
         }
 
-        return sprintf('php artisan octane:start --host=0.0.0.0 --port=%d', $port);
+        $command = sprintf('php artisan octane:start --host=0.0.0.0 --port=%d', $port);
+
+        // Burst autoscaling reads FrankenPHP's worker metrics, which Octane only exposes
+        // when Caddy metrics are enabled. octane:start rebuilds CADDY_GLOBAL_OPTIONS for
+        // the frankenphp child from a fixed whitelist, discarding whatever value the task
+        // sets — so a container env var can't switch metrics on. The surviving channel is
+        // a custom Caddyfile: GenerateSupervisorConfigStep writes the app's own Octane stub
+        // with `servers { metrics }` added to docker/Caddyfile, and --caddyfile runs it.
+        // Web autoscaling only; classic mode returned above and never reaches here.
+        if (Manifest::isAutoscaling()) {
+            $command .= ' --caddyfile=/app/docker/Caddyfile';
+        }
+
+        return $command;
     }
 
     public static function queue(): string

--- a/src/Resources/ApplicationAutoScaling/WebBurstPolicy.php
+++ b/src/Resources/ApplicationAutoScaling/WebBurstPolicy.php
@@ -37,9 +37,11 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * CloudWatch Logs auto-extracts), so there's no PutMetricData call, no AWS SDK in
  * the container and no new IAM — the saturation emitter ({@see
  * \Codinglabs\Yolo\Steps\Build\Fargate\GenerateSupervisorConfigStep}) just writes
- * to stdout, which already ships to CloudWatch Logs. Enabling FrankenPHP's metrics
- * endpoint is a single `CADDY_GLOBAL_OPTIONS` env var, set on the web task only
- * when burst applies (autoscaling enabled).
+ * to stdout, which already ships to CloudWatch Logs. FrankenPHP's metrics endpoint is
+ * enabled by a Caddyfile YOLO generates (the app's Octane stub plus the
+ * `servers { metrics }` global option) and runs via `octane:start --caddyfile` — Octane
+ * overwrites `CADDY_GLOBAL_OPTIONS`, so a task env var can't switch it on. Built only
+ * for an autoscaling Octane web tier (see GenerateSupervisorConfigStep).
  *
  * Scale-*in* is left entirely to the target-tracking policies (slow, safe) — this
  * is scale-out only, so it can only ever add capacity faster, never fight them.

--- a/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
@@ -39,7 +39,7 @@ class CheckMetricsRuntimeStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        if (! Manifest::isAutoscaling() || ! Manifest::usesOctane()) {
+        if (! Manifest::usesMetricsCaddyfile()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Build\Fargate;
+
+use Closure;
+use RuntimeException;
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Symfony\Component\Process\Process;
+use Codinglabs\Yolo\Resources\Ecr\EcrRepository;
+
+/**
+ * Burst autoscaling needs FrankenPHP's worker metrics, which Caddy only collects when
+ * the `servers { metrics }` global option is set. octane:start rebuilds the
+ * CADDY_GLOBAL_OPTIONS env var, so YOLO ships a custom Caddyfile carrying that option
+ * (GenerateSupervisorConfigStep) and runs it via --caddyfile (ProcessCommands::web).
+ * This probes the freshly-built image for that baked Caddyfile and hard-fails the build
+ * — before the push — if it's missing or has no metrics directive.
+ *
+ * The hard fail earns its place because the failure it prevents is silent: with metrics
+ * off FrankenPHP registers no gauges, the saturation emitter reads nothing and emits no
+ * EMF, the burst alarm sits in INSUFFICIENT_DATA, and the deploy still goes green on the
+ * target-tracking policies — burst is simply, invisibly, dark (exactly how it shipped
+ * broken in #118). Probing the actual image (`docker run … grep`, matching
+ * CheckSsrRuntimeStep / CheckSchedulerRuntimeStep) catches both a Caddyfile that never
+ * got generated and a Dockerfile that doesn't copy the build context into the image.
+ *
+ * Only autoscaling Octane apps run this: classic mode never enables worker metrics
+ * (burst is a documented no-op there) and a non-autoscaling app has no burst path.
+ */
+class CheckMetricsRuntimeStep implements Step
+{
+    public function __construct(
+        protected string $environment,
+        protected ?Closure $probe = null,
+    ) {}
+
+    public function __invoke(array $options): StepResult
+    {
+        if (! Manifest::isAutoscaling() || ! Manifest::usesOctane()) {
+            return StepResult::SKIPPED;
+        }
+
+        $image = sprintf('%s:%s', (new EcrRepository())->uri(), Arr::get($options, 'app-version'));
+
+        if (($this->probe ?? $this->imageHasMetricsCaddyfile(...))($image)) {
+            return StepResult::SUCCESS;
+        }
+
+        throw new RuntimeException(
+            'Build aborted: web autoscaling is on but the built image has no Caddyfile with '
+            . 'FrankenPHP metrics enabled at /app/docker/Caddyfile. Burst scaling reads worker '
+            . 'metrics, which need it — ensure your Dockerfile copies the build context (e.g. '
+            . '`COPY . /app`) so YOLO\'s generated Caddyfile ships, or burst will be silently dark.'
+        );
+    }
+
+    /**
+     * The `docker run` probe. `--entrypoint sh` bypasses YOLO's role-dispatch
+     * entrypoint; `grep` exits non-zero when the `metrics` directive (or the Caddyfile
+     * itself) is absent, so it needs nothing but a shell.
+     *
+     * @return array<int, string>
+     */
+    public static function command(string $image): array
+    {
+        return ['docker', 'run', '--rm', '--entrypoint', 'sh', $image, '-c', 'grep -qE "^[[:space:]]*metrics[[:space:]]*$" /app/docker/Caddyfile'];
+    }
+
+    protected function imageHasMetricsCaddyfile(string $image): bool
+    {
+        return (new Process(static::command($image)))->run() === 0;
+    }
+}

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -41,19 +41,19 @@ class GenerateSupervisorConfigStep implements Step
         // The web container always runs supervisord (the web server + whatever it hosts).
         $this->writeConfig('docker/supervisord.conf', ServerGroup::WEB);
 
-        // The burst saturation emitter rides the web container only; its
-        // supervisord program is added by config() for the same gate.
+        // The saturation emitter rides with the burst alarm — present wherever the web
+        // tier autoscales (its supervisord program is added by config() for the same
+        // gate). In classic mode no metrics ever flow, so it's an inert no-op there.
         if (Manifest::isAutoscaling()) {
             $this->writeEmitterScript();
+        }
 
-            // Octane (worker mode) only registers FrankenPHP's worker metrics when Caddy
-            // metrics are on, and octane:start ignores the container's CADDY_GLOBAL_OPTIONS
-            // — so YOLO ships its own Caddyfile (the app's Octane stub + `servers { metrics
-            // }`) that octane:start runs via --caddyfile (ProcessCommands::web). Classic
-            // mode has no Octane stub and never passes --caddyfile, so it's skipped.
-            if (Manifest::usesOctane()) {
-                $this->writeCaddyfile();
-            }
+        // The metrics Caddyfile additionally needs Octane (worker mode) — its worker
+        // gauges are the burst signal, and octane:start runs it via --caddyfile
+        // (ProcessCommands::web). The shared gate keeps generation, the flag and the
+        // build preflight (CheckMetricsRuntimeStep) in lock-step.
+        if (Manifest::usesMetricsCaddyfile()) {
+            $this->writeCaddyfile();
         }
 
         // A standalone queue only needs supervisord when it co-hosts the scheduler

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -2,6 +2,7 @@
 
 namespace Codinglabs\Yolo\Steps\Build\Fargate;
 
+use RuntimeException;
 use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
@@ -44,6 +45,15 @@ class GenerateSupervisorConfigStep implements Step
         // supervisord program is added by config() for the same gate.
         if (Manifest::isAutoscaling()) {
             $this->writeEmitterScript();
+
+            // Octane (worker mode) only registers FrankenPHP's worker metrics when Caddy
+            // metrics are on, and octane:start ignores the container's CADDY_GLOBAL_OPTIONS
+            // — so YOLO ships its own Caddyfile (the app's Octane stub + `servers { metrics
+            // }`) that octane:start runs via --caddyfile (ProcessCommands::web). Classic
+            // mode has no Octane stub and never passes --caddyfile, so it's skipped.
+            if (Manifest::usesOctane()) {
+                $this->writeCaddyfile();
+            }
         }
 
         // A standalone queue only needs supervisord when it co-hosts the scheduler
@@ -118,6 +128,64 @@ class GenerateSupervisorConfigStep implements Step
         $path = Paths::build('docker/yolo-saturation.php');
         $this->filesystem->ensureDirectoryExists(dirname($path));
         $this->filesystem->put($path, $script);
+    }
+
+    /**
+     * Write the web Caddyfile into the build context for an autoscaling Octane app.
+     * Burst scaling needs FrankenPHP's worker metrics, which Caddy only collects when
+     * the `servers { metrics }` global option is set — and octane:start rebuilds the
+     * CADDY_GLOBAL_OPTIONS env var YOLO would use to inject it, so a task env var can't
+     * turn metrics on. The surviving channel is a custom Caddyfile passed to
+     * octane:start via --caddyfile (ProcessCommands::web). Rather than carry a full copy
+     * of Octane's stub (which would drift across Octane versions), this reads the app's
+     * OWN installed stub and adds only the one metrics line, so it stays in lock-step
+     * with whatever Octane the image ships.
+     */
+    protected function writeCaddyfile(): void
+    {
+        $stub = Paths::base('vendor/laravel/octane/src/Commands/stubs/Caddyfile');
+
+        if (! $this->filesystem->exists($stub)) {
+            throw new RuntimeException(
+                'Build aborted: web autoscaling needs FrankenPHP metrics, enabled through a '
+                . 'Caddyfile built from Octane\'s stub — but '
+                . 'vendor/laravel/octane/src/Commands/stubs/Caddyfile is missing. Run '
+                . '`composer install` so laravel/octane is present before building, or turn '
+                . 'web autoscaling off.'
+            );
+        }
+
+        $path = Paths::build('docker/Caddyfile');
+        $this->filesystem->ensureDirectoryExists(dirname($path));
+        $this->filesystem->put($path, $this->injectMetrics((string) $this->filesystem->get($stub)));
+    }
+
+    /**
+     * Add the `servers { metrics }` global option to a Caddyfile. A Caddyfile's global
+     * options block is its leading block — the only one whose opener is a bare `{` — so
+     * the directive is inserted just inside it. A stub that already enables metrics (a
+     * future Octane, or a re-run) is returned untouched; a stub with no global block
+     * hard-fails rather than silently shipping a metrics-less Caddyfile that would leave
+     * burst scaling dark.
+     */
+    protected function injectMetrics(string $caddyfile): string
+    {
+        if (preg_match('/servers\s*\{[^}]*\bmetrics\b/s', $caddyfile) === 1) {
+            return $caddyfile;
+        }
+
+        $count = 0;
+        $injected = preg_replace('/^\{$/m', "{\n\tservers {\n\t\tmetrics\n\t}", $caddyfile, 1, $count);
+
+        if ($injected === null || $count !== 1) {
+            throw new RuntimeException(
+                'Build aborted: could not find the Caddyfile global options block to enable '
+                . 'FrankenPHP metrics (Octane\'s stub format may have changed). Refusing to '
+                . 'ship a build that would silently leave burst scaling dark.'
+            );
+        }
+
+        return $injected;
     }
 
     /**

--- a/src/Steps/Sync/App/SyncTaskDefinitionStep.php
+++ b/src/Steps/Sync/App/SyncTaskDefinitionStep.php
@@ -189,16 +189,6 @@ class SyncTaskDefinitionStep implements Step
                             ],
                         ],
                     ] : [],
-                    // Burst scaling reads FrankenPHP's worker metrics; switch the metrics
-                    // endpoint on additively through Octane's Caddyfile {$CADDY_GLOBAL_OPTIONS}
-                    // placeholder — Caddy reads it from the OS env (the app .env never reaches
-                    // Caddy's process), and it's never a Caddyfile takeover. Web task only, set
-                    // wherever web autoscaling is (a no-op in classic mode, which ignores it).
-                    ...$group === ServerGroup::WEB && Manifest::isAutoscaling() ? [
-                        'environment' => [
-                            ['name' => 'CADDY_GLOBAL_OPTIONS', 'value' => 'servers { metrics }'],
-                        ],
-                    ] : [],
                     'logConfiguration' => [
                         'logDriver' => 'awslogs',
                         'options' => [

--- a/stubs/yolo-saturation.php.stub
+++ b/stubs/yolo-saturation.php.stub
@@ -8,28 +8,32 @@
 // no IAM. Fails safe: if FrankenPHP's metrics endpoint isn't reachable it emits
 // nothing, and the target-tracking policies still own scaling.
 
-$service = '{{service}}';
-$floor = {{floor}};
+// The emit loop only runs when the script is executed directly (php yolo-saturation.php),
+// so the parsing functions below can be required and unit-tested without spinning it.
+if (PHP_SAPI === 'cli' && isset($argv[0]) && realpath($argv[0]) === __FILE__) {
+    $service = '{{service}}';
+    $floor = {{floor}};
 
-while (true) {
-    $saturation = yolo_worker_saturation();
+    while (true) {
+        $saturation = yolo_worker_saturation();
 
-    if ($saturation !== null && $saturation >= $floor) {
-        echo json_encode([
-            '_aws' => [
-                'Timestamp' => (int) round(microtime(true) * 1000),
-                'CloudWatchMetrics' => [[
-                    'Namespace' => '{{namespace}}',
-                    'Dimensions' => [['{{dimension}}']],
-                    'Metrics' => [['Name' => '{{metric}}', 'Unit' => 'Percent', 'StorageResolution' => 1]],
-                ]],
-            ],
-            '{{dimension}}' => $service,
-            '{{metric}}' => round($saturation, 1),
-        ]) . "\n";
+        if ($saturation !== null && $saturation >= $floor) {
+            echo json_encode([
+                '_aws' => [
+                    'Timestamp' => (int) round(microtime(true) * 1000),
+                    'CloudWatchMetrics' => [[
+                        'Namespace' => '{{namespace}}',
+                        'Dimensions' => [['{{dimension}}']],
+                        'Metrics' => [['Name' => '{{metric}}', 'Unit' => 'Percent', 'StorageResolution' => 1]],
+                    ]],
+                ],
+                '{{dimension}}' => $service,
+                '{{metric}}' => round($saturation, 1),
+            ]) . "\n";
+        }
+
+        sleep(10);
     }
-
-    sleep(10);
 }
 
 /** FrankenPHP busy-thread saturation as a percentage, or null when unavailable. */
@@ -38,10 +42,16 @@ function yolo_worker_saturation(): ?float
     $context = stream_context_create(['http' => ['timeout' => 2]]);
     $metrics = @file_get_contents('http://localhost:2019/metrics', false, $context);
 
-    if ($metrics === false) {
-        return null;
-    }
+    return $metrics === false ? null : yolo_parse_saturation($metrics);
+}
 
+/**
+ * Parse FrankenPHP's Prometheus metrics into busy/total thread saturation as a
+ * percentage, or null when the gauges are absent (metrics off, or nothing useful
+ * returned). Split from the fetch so it can be unit-tested against a real payload.
+ */
+function yolo_parse_saturation(string $metrics): ?float
+{
     // Tolerate an optional Prometheus label set (`frankenphp_busy_threads{} 5`).
     if (! preg_match('/^frankenphp_busy_threads(?:\{[^}]*\})?\s+([0-9.]+)/m', $metrics, $busy)) {
         return null;

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -196,6 +196,35 @@ describe('autoscaling', function (): void {
     });
 });
 
+describe('metrics caddyfile', function (): void {
+    it('applies for an autoscaling Octane web tier', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => ['autoscaling' => true]],
+        ]);
+
+        expect(Manifest::usesMetricsCaddyfile())->toBeTrue();
+    });
+
+    it('does not apply in classic mode, where worker metrics never exist', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => ['octane' => false, 'autoscaling' => true]],
+        ]);
+
+        expect(Manifest::usesMetricsCaddyfile())->toBeFalse();
+    });
+
+    it('does not apply without autoscaling', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => []],
+        ]);
+
+        expect(Manifest::usesMetricsCaddyfile())->toBeFalse();
+    });
+});
+
 describe('task-role-policies', function (): void {
     it('defaults to no additional policies', function (): void {
         writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);

--- a/tests/Unit/Steps/Build/Fargate/CheckMetricsRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckMetricsRuntimeStepTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Build\Fargate\CheckMetricsRuntimeStep;
+
+beforeEach(function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+});
+
+it('skips without probing the image when the web tier is not autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => []],
+    ]);
+
+    // A probe that throws proves the step short-circuits before running the image.
+    $step = new CheckMetricsRuntimeStep('testing', probe: function (): void {
+        throw new RuntimeException('probe should not run when burst is off');
+    });
+
+    expect($step(['app-version' => '26.24.1.1200']))->toBe(StepResult::SKIPPED);
+});
+
+it('skips in classic mode, where worker metrics never apply', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['octane' => false, 'autoscaling' => true]],
+    ]);
+
+    $step = new CheckMetricsRuntimeStep('testing', probe: function (): void {
+        throw new RuntimeException('probe should not run in classic mode');
+    });
+
+    expect($step(['app-version' => '26.24.1.1200']))->toBe(StepResult::SKIPPED);
+});
+
+it('passes when the built image ships a metrics Caddyfile', function (): void {
+    $step = new CheckMetricsRuntimeStep('testing', probe: fn (): true => true);
+
+    expect($step(['app-version' => '26.24.1.1200']))->toBe(StepResult::SUCCESS);
+});
+
+it('hard-fails when the built image has no metrics Caddyfile', function (): void {
+    $step = new CheckMetricsRuntimeStep('testing', probe: fn (): false => false);
+
+    expect(fn (): StepResult => $step(['app-version' => '26.24.1.1200']))
+        ->toThrow(RuntimeException::class, 'no Caddyfile with');
+});
+
+it('probes the built image tag', function (): void {
+    $image = null;
+    $step = new CheckMetricsRuntimeStep('testing', probe: function (string $tag) use (&$image): true {
+        $image = $tag;
+
+        return true;
+    });
+
+    $step(['app-version' => '26.24.1.1200']);
+
+    expect($image)->toEndWith('/my-app:26.24.1.1200');
+});
+
+it('builds a docker probe that greps the baked Caddyfile for the metrics directive', function (): void {
+    expect(CheckMetricsRuntimeStep::command('repo:26.24.1.1200'))->toBe([
+        'docker', 'run', '--rm', '--entrypoint', 'sh', 'repo:26.24.1.1200', '-c',
+        'grep -qE "^[[:space:]]*metrics[[:space:]]*$" /app/docker/Caddyfile',
+    ]);
+});

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -350,3 +350,51 @@ METRICS;
     // emitting a bogus datapoint.
     expect(yolo_parse_saturation("frankenphp_other 1\n"))->toBeNull();
 });
+
+it('does not double-inject metrics when the Octane stub already enables them', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    // A future Octane stub that already turns metrics on.
+    file_put_contents(Paths::base('vendor/laravel/octane/src/Commands/stubs/Caddyfile'), <<<'STUB'
+{
+	servers {
+		metrics
+	}
+	{$CADDY_GLOBAL_OPTIONS}
+}
+
+{$CADDY_SERVER_SERVER_NAME} {
+	route {
+		php_server
+	}
+}
+STUB);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    // Exactly one servers block — the existing one, not a second injected copy.
+    expect(substr_count(file_get_contents(Paths::build('docker/Caddyfile')), 'servers {'))->toBe(1);
+});
+
+it('hard-fails when the Octane stub has no global options block to enable metrics in', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    // A stub with no leading global-options block (only a site block) — there's nowhere
+    // safe to add the metrics option, so the build refuses rather than ship it dark.
+    file_put_contents(Paths::base('vendor/laravel/octane/src/Commands/stubs/Caddyfile'), <<<'STUB'
+{$CADDY_SERVER_SERVER_NAME} {
+	route {
+		php_server
+	}
+}
+STUB);
+
+    expect(fn (): mixed => (new GenerateSupervisorConfigStep('testing'))())
+        ->toThrow(RuntimeException::class, 'global options block');
+});

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -21,7 +21,47 @@ beforeEach(function (): void {
     if (is_file(Paths::build('docker/yolo-saturation.php'))) {
         unlink(Paths::build('docker/yolo-saturation.php'));
     }
+    if (is_file(Paths::build('docker/Caddyfile'))) {
+        unlink(Paths::build('docker/Caddyfile'));
+    }
+
+    // GenerateSupervisorConfigStep builds the metrics Caddyfile from the app's installed
+    // Octane stub; the fixture app has no real vendor/, so plant a representative one for
+    // the autoscaling cases. The stub-missing case deletes it.
+    plantOctaneCaddyfileStub();
 });
+
+function plantOctaneCaddyfileStub(): void
+{
+    $stub = Paths::base('vendor/laravel/octane/src/Commands/stubs/Caddyfile');
+
+    if (! is_dir(dirname($stub))) {
+        mkdir(dirname($stub), 0755, true);
+    }
+
+    file_put_contents($stub, <<<'STUB'
+{
+	{$CADDY_GLOBAL_OPTIONS}
+
+	admin {$CADDY_SERVER_ADMIN_HOST}:{$CADDY_SERVER_ADMIN_PORT}
+
+	frankenphp {
+		worker {
+			file "{$APP_PUBLIC_PATH}/frankenphp-worker.php"
+			{$CADDY_SERVER_WORKER_DIRECTIVE}
+			{$CADDY_SERVER_WATCH_DIRECTIVES}
+		}
+	}
+}
+
+{$CADDY_SERVER_SERVER_NAME} {
+	route {
+		root * "{$APP_PUBLIC_PATH}"
+		php_server
+	}
+}
+STUB);
+}
 
 function generatedSupervisorConfig(): string
 {
@@ -216,4 +256,97 @@ it('adds the saturation emitter program and writes its script for an Octane auto
     // breaks it is caught here, not on a deploy.
     exec('php -l ' . escapeshellarg(Paths::build('docker/yolo-saturation.php')), $output, $code);
     expect($code)->toBe(0);
+});
+
+it('generates a metrics-enabled Caddyfile from the app Octane stub for an autoscaling app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => ['min' => 2, 'max' => 8]]],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    $caddyfile = file_get_contents(Paths::build('docker/Caddyfile'));
+
+    // It's the app's own Octane stub (its placeholders intact, so Octane still fills
+    // them) with only the metrics global option added — not a takeover.
+    expect($caddyfile)
+        ->toContain('servers {')
+        ->toContain('metrics')
+        ->toContain('{$CADDY_GLOBAL_OPTIONS}')
+        ->toContain('frankenphp {');
+});
+
+it('runs octane against the metrics Caddyfile via --caddyfile when autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    expect(generatedSupervisorConfig())
+        ->toContain('command=php artisan octane:start --host=0.0.0.0 --port=8000 --caddyfile=/app/docker/Caddyfile');
+});
+
+it('writes no Caddyfile and passes no --caddyfile when the web tier is not autoscaling', function (): void {
+    // The default manifest is octane without autoscaling.
+    $config = generatedSupervisorConfig();
+
+    expect($config)->not->toContain('--caddyfile');
+    expect(is_file(Paths::build('docker/Caddyfile')))->toBeFalse();
+});
+
+it('writes no Caddyfile in classic mode even when autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['octane' => false, 'autoscaling' => true]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // Classic mode runs frankenphp php-server, not octane:start — no Caddyfile, no flag.
+    expect($config)->toContain('command=frankenphp php-server');
+    expect($config)->not->toContain('--caddyfile');
+    expect(is_file(Paths::build('docker/Caddyfile')))->toBeFalse();
+});
+
+it('hard-fails the build when the Octane Caddyfile stub is missing for an autoscaling app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    unlink(Paths::base('vendor/laravel/octane/src/Commands/stubs/Caddyfile'));
+
+    expect(fn (): mixed => (new GenerateSupervisorConfigStep('testing'))())
+        ->toThrow(RuntimeException::class, 'laravel/octane');
+});
+
+it('parses FrankenPHP thread saturation from a real metrics payload', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    // Requiring the generated emitter is safe — its loop only runs when the file is the
+    // executed script, so this just defines the parser for a direct call.
+    require_once Paths::build('docker/yolo-saturation.php');
+
+    $payload = <<<'METRICS'
+# HELP frankenphp_busy_threads Number of busy PHP threads
+# TYPE frankenphp_busy_threads gauge
+frankenphp_busy_threads 6
+# HELP frankenphp_total_threads Total number of PHP threads
+# TYPE frankenphp_total_threads gauge
+frankenphp_total_threads 8
+METRICS;
+
+    // 6 of 8 threads busy = 75%. The HELP/TYPE comment lines for the same metric names
+    // must not be mistaken for the gauge lines.
+    expect(yolo_parse_saturation($payload))->toBe(75.0);
+
+    // No gauges (metrics off) reads as null, so the emitter stays silent rather than
+    // emitting a bogus datapoint.
+    expect(yolo_parse_saturation("frankenphp_other 1\n"))->toBeNull();
 });

--- a/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
@@ -242,14 +242,20 @@ it('sets no container environment by default', function (): void {
         ->not->toHaveKey('environment');
 });
 
-it('enables the FrankenPHP metrics endpoint on the web container for an Octane autoscaling app', function (): void {
+it('sets no container environment for an Octane autoscaling app (burst metrics move to the Caddyfile)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => ['min' => 2, 'max' => 8]]],
     ]);
 
-    // The burst saturation emitter reads FrankenPHP's metrics; CADDY_GLOBAL_OPTIONS
-    // turns the endpoint on additively (Caddy reads it from the OS env).
-    expect(SyncTaskDefinitionStep::payload()['containerDefinitions'][0]['environment'])
-        ->toBe([['name' => 'CADDY_GLOBAL_OPTIONS', 'value' => 'servers { metrics }']]);
+    bindMockIamClient([
+        'yolo-testing-my-app-ecs-task-role' => 'arn:aws:iam::111111111111:role/yolo-testing-my-app-ecs-task-role',
+        'yolo-testing-ecs-execution-role' => 'arn:aws:iam::111111111111:role/yolo-testing-ecs-execution-role',
+    ]);
+
+    // Burst metrics are enabled by a custom Caddyfile (--caddyfile), not a task env var:
+    // octane:start overwrites CADDY_GLOBAL_OPTIONS, so setting it on the container is a
+    // no-op. The web container therefore carries no environment for it.
+    expect(SyncTaskDefinitionStep::payload()['containerDefinitions'][0])
+        ->not->toHaveKey('environment');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- Burst autoscaling (LPX-659 / #118) has **never fired on a real deploy**. `octane:start` rebuilds `CADDY_GLOBAL_OPTIONS` for the frankenphp child process from a fixed whitelist, discarding the `servers { metrics }` value YOLO set on the task. So Caddy never enabled metrics → FrankenPHP registered no `frankenphp_*` gauges → the saturation emitter read `null` every loop → the `YOLO/Autoscaling` namespace stayed empty → the burst alarm sat in `INSUFFICIENT_DATA` forever. It looked correct at every layer (task env, container env, Octane stub), which is why it shipped broken.
- Fix: enable metrics through the only channel Octane doesn't clobber — a Caddyfile YOLO owns, run via `octane:start --caddyfile`:
  - `GenerateSupervisorConfigStep` reads the app's **own** installed Octane stub and injects `servers { metrics }` into the global block (zero drift vs the Octane version the image ships) → `docker/Caddyfile`.
  - `ProcessCommands::web()` adds `--caddyfile` when the web tier is autoscaling + Octane; classic mode is unchanged.
  - Removed the dead `CADDY_GLOBAL_OPTIONS` task env injection.
  - New `CheckMetricsRuntimeStep` image-probes the built image and hard-fails the build if the metrics Caddyfile didn't ship — so metrics-off can't ship silently again.
  - Emitter parser made pure + unit-tested against a real FrankenPHP metrics payload.
  - `docs/guide/scaling.md` claim corrected.

**Is there anything the reviewer needs to know to deploy this?**
- **Build behaviour change:** for an autoscaling Octane web tier the build now generates `docker/Caddyfile` and hard-fails if the Octane stub is missing at build, or if the built image doesn't carry the metrics Caddyfile at `/app/docker/Caddyfile`. Apps must copy the build context into the image — the existing `COPY . /app` already does this (same requirement as `docker/supervisord.conf`).
- **No new manifest keys, no new IAM, no new external surface.** The metrics endpoint binds container-loopback (`localhost:2019`) only; `servers { metrics }` adds no route to the load-balanced port.
- **Not yet proven under load.** Metrics will now flow, but on a 0.5-vCPU task Go sees host cores, so `frankenphp_total_threads` may be oversized and saturation could sit under the 70/80 floor even with metrics on — a possible follow-up to tune the floor/threshold or switch the signal to `busy_workers/total_workers`. Only assessable once a load test runs.
- **Deploy note:** the CI deploy self-gate currently crashes for an unrelated reason (tracked in **LPX-683**); ship this via a local `yolo deploy production` until that's fixed.
- Quality stack green: Pint, PHPStan L5, Rector, **Pest 1066 passed**.

Relates to LPX-659 (burst) and LPX-683 (CI gate crash).

🤖 Generated with [Claude Code](https://claude.ai/code)