### PR TITLE
fix(LPX-635): observer tier was missing the Cost Explorer + log-filter reads its status commands need

### DIFF
--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -33,13 +33,19 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  *    action is scoped to `yolo-*`, and AttachRolePolicy is conditioned so only a
  *    `yolo-*` customer-managed policy can be attached — the holder can NOT attach
  *    AWS-managed AdministratorAccess to a role and assume it.
- *  - RESIDUAL (the open decision for review): because sync must reconcile its own
- *    yolo-* policies, the tier can rewrite a `yolo-*` policy document and re-attach
- *    it — a determined holder could self-escalate within `yolo-*`. Closing that
- *    fully needs a permissions boundary on every YOLO-created role (so nothing
- *    YOLO mints can exceed the boundary) — deliberately NOT built here; it's
- *    Steve's call whether the blast-radius cap above is sufficient or the boundary
- *    is warranted. See the PR.
+ *  - RESIDUAL (open decision for review): the cap is not airtight against a
+ *    determined holder of the tier. Two self-escalation levers remain, both
+ *    intrinsic to what sync must legitimately do within `yolo-*`:
+ *      (1) sync reconciles its own `yolo-*` policies, so the tier can rewrite a
+ *          `yolo-*` policy document and re-attach it; and
+ *      (2) sync manages `yolo-*` bucket policies (the asset bucket's CloudFront
+ *          OAC policy needs `s3:PutBucketPolicy`), so the same grant lets the tier
+ *          rewrite the config bucket's policy to grant itself `s3:GetObject` on the
+ *          env-shared `.env` it otherwise can't read.
+ *    Closing either fully needs a permissions boundary on every YOLO-created role
+ *    (so nothing YOLO mints can exceed the boundary) — deliberately NOT built here.
+ *    Whether the blast-radius cap above suffices or the boundary is warranted is a
+ *    deployment decision; see the PR.
  *
  * Per-service write *wildcards* (`ecs:Create*`, `ecs:Delete*`, …) mirror
  * ObserverPolicy's read-wildcard discipline: a new sync write within a service

--- a/src/Resources/Iam/ObserverPolicy.php
+++ b/src/Resources/Iam/ObserverPolicy.php
@@ -15,11 +15,12 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * YOLO-managed customer-managed IAM policy granting **read-only** access to exactly
- * the AWS services YOLO provisions — the inspection surface a `sync`/`audit` plan
- * pass reads to compute drift. Deliberately NOT AWS's managed ReadOnlyAccess: that
- * grants read on the entire AWS surface (~300 services) and `s3:GetObject` on every
- * bucket; this grants read on YOLO's finite service set only, with object reads
- * scoped to non-secret config.
+ * the AWS surface YOLO inspects: the services a `sync`/`audit` plan pass reads to
+ * compute drift, plus the operator-facing `status` reads (the Logs tab tails
+ * CloudWatch Logs; `status:budget` reads month-to-date spend from Cost Explorer).
+ * Deliberately NOT AWS's managed ReadOnlyAccess: that grants read on the entire AWS
+ * surface (~300 services) and `s3:GetObject` on every bucket; this grants read on
+ * YOLO's finite service set only, with object reads scoped to non-secret config.
  *
  * Env-scoped and shared: one `yolo-{env}-observer` per environment, attached to
  * every app's deployer role (AttachDeployerRolePoliciesStep) so the deploy-time
@@ -141,9 +142,19 @@ class ObserverPolicy implements Resource, SynchronisesConfiguration
                         'cloudwatch:List*',
                         'logs:Describe*',
                         'logs:Get*',
+                        // FilterLogEvents is NOT a Get* action — the Logs tab
+                        // (status:logs) tails a group's streams through it, so the
+                        // tier would AccessDenied without this.
+                        'logs:Filter*',
                         'logs:ListTagsForResource',
                         'events:Describe*',
                         'events:List*',
+                        // cost — month-to-date spend by app for the budget read
+                        // (status:budget). Cost Explorer has no resource-level
+                        // permissions, so its reads sit on "*" like the rest.
+                        'ce:Describe*',
+                        'ce:Get*',
+                        'ce:List*',
                         // waf / service discovery / tagging / identity
                         'wafv2:Get*',
                         'wafv2:List*',

--- a/src/Resources/Iam/ObserverRole.php
+++ b/src/Resources/Iam/ObserverRole.php
@@ -12,7 +12,7 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
- * YOLO-managed IAM role an operator or an agent (Claude / Leeloo) assumes for
+ * YOLO-managed IAM role an operator or an automated agent assumes for
  * **read-only** inspection of the environment — the `*-readonly` profile target
  * from LPX-635. It carries the env-shared {@see ObserverPolicy} policy (attached by
  * AttachObserverRolePolicyStep), so a profile assuming it can `describe`/`list`/

--- a/src/Resources/Iam/SynchronisesPolicyDocument.php
+++ b/src/Resources/Iam/SynchronisesPolicyDocument.php
@@ -8,9 +8,9 @@ use Codinglabs\Yolo\Aws\Iam as IamClient;
 
 /**
  * Shared document-drift reconciliation for the YOLO-managed customer-managed IAM
- * policies (DeployerPolicy, EcsTaskPolicy). IAM has no in-place document update —
- * a changed policy document is pushed by creating a new version and setting it as
- * default.
+ * policies (DeployerPolicy, EcsTaskPolicy, ObserverPolicy, AdminPolicy). IAM has no
+ * in-place document update — a changed policy document is pushed by creating a new
+ * version and setting it as default.
  *
  * This is wired through SynchronisesConfiguration — NOT a bespoke side-effect the
  * sync step calls under `! dry-run` — on purpose. SyncSteppedCommand computes a

--- a/tests/Unit/Resources/Iam/ObserverPolicyTest.php
+++ b/tests/Unit/Resources/Iam/ObserverPolicyTest.php
@@ -17,6 +17,27 @@ function observerActions(): array
         ->all();
 }
 
+/** Does the policy grant an action, honouring `service:Verb*` wildcards? */
+function observerGrants(string $action): bool
+{
+    [$service, $verb] = explode(':', $action, 2);
+
+    return collect(observerActions())->contains(function (string $granted) use ($service, $verb): bool {
+        [$grantedService, $grantedVerb] = explode(':', $granted, 2);
+
+        if ($grantedService !== $service) {
+            return false;
+        }
+
+        if ($grantedVerb === '*' || $grantedVerb === $verb) {
+            return true;
+        }
+
+        return str_ends_with($grantedVerb, '*')
+            && str_starts_with($verb, rtrim($grantedVerb, '*'));
+    });
+}
+
 it('is an env-scoped policy named yolo-{env}-observer (shared by every app in the environment)', function (): void {
     expect((new ObserverPolicy())->scope())->toBe(Scope::Env);
     expect((new ObserverPolicy())->name())->toBe('yolo-testing-observer');
@@ -41,6 +62,16 @@ it('grants read-only wildcards for the services YOLO provisions, on * (unscopeab
         'servicediscovery:List*',
         'sts:GetCallerIdentity',
     );
+});
+
+it('grants the operator-facing status reads its read-only commands invoke (logs tail + month-to-date spend)', function (): void {
+    // status:logs tails CloudWatch Logs via FilterLogEvents — NOT a logs:Get* action,
+    // so logs:Get* alone leaves the observer tier AccessDenied on the Logs tab.
+    expect(observerGrants('logs:FilterLogEvents'))->toBeTrue();
+
+    // status:budget reads month-to-date spend from Cost Explorer — its own service,
+    // granted nowhere else in the read surface.
+    expect(observerGrants('ce:GetCostAndUsage'))->toBeTrue();
 });
 
 it('grants no write actions — read-only by construction', function (): void {


### PR DESCRIPTION
## What this fixes

A 96-hour consistency/security review of the new IAM credential-minting tiers (LPX-635) against the read surface that landed alongside them (LPX-680) surfaced a concrete gap.

`ObserverPolicy` is what **every** `ReadOnlyCommand` runs capped to once the observer role is provisioned (the tier assumes `yolo-{env}-observer-role` and re-registers every AWS client against the scoped token). But it granted:

- **no Cost Explorer action at all** — `status:budget` calls `ce:GetCostAndUsage`
- **`logs:Get*` only** — `status:logs` tails CloudWatch Logs via `logs:FilterLogEvents`, which is **not** a `Get*` action

So the moment the observer tier is rolled out — the whole point of LPX-635 — both `status:budget` and `status:logs` `AccessDenied`. The two work streams shipped in the same window and were never reconciled.

I cross-checked **every** other AWS call reachable from the read-only commands (ecs / sqs / cloudwatch / elbv2 / servicediscovery / tagging) against the policy wildcards — these two were the only gaps, so this isn't a partial fix.

## Changes

- **`ObserverPolicy`**: add `ce:Describe*/Get*/List*` and `logs:Filter*`, following the per-service read-wildcard discipline already in the policy.
- **Test**: a wildcard-aware grant check asserting the exact actions the status read surface invokes are covered — red before the grant, green after.

### Bundled same-window tidy-ups (IAM tier code only)

- **`AdminPolicy` threat model**: the docblock invited review of the self-escalation residual but documented only the IAM path. Added the second one — `s3:PutBucketPolicy` on `yolo-*` (admin legitimately needs it for the asset bucket's CloudFront OAC policy) also lets the tier rewrite the **config** bucket policy and read the env-shared `.env`. Both close only with a permissions boundary. **Not a regression** (pre-tier, sync ran on the operator's full profile, which could already read `.env`) — but the doc should be honest about the cap not being airtight.
- **Public-repo hygiene**: removed two internal names from doc comments (this repo is public).
- **`SynchronisesPolicyDocument`** docstring: four policies use it now, not the two it listed.

## Verification

- `vendor/bin/pest` — **1114 passed**
- `vendor/bin/phpstan analyse` — **no errors**
- `vendor/bin/pint` — passed
- New test fails against the current policy, passes with the grant.

## Flagged, not changed (your call)

**Naming-convention flip** in `Enums\Iam`: the pre-existing deployer pair is `role = bare name / policy = -policy` (`deployer`, `deployer-policy`), but the new observer/admin pairs invert it to `policy = bare name / role = -role` (`observer` + `observer-role`, `admin` + `admin-role`). Harmless but inconsistent, and it leaks into the assume-role session names (`yolo-deployer` vs `yolo-observer-role`). I left it alone because renaming live IAM resources is real AWS churn (next sync would delete + recreate the roles) — worth a deliberate decision rather than a drive-by rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)