### PR TITLE
feat(services): config-driven enable for env-backed services + implications warnings

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -497,7 +497,7 @@ Toggling and confirming applies the membership diff — and only ever touches th
 
 ## `yolo services`
 
-View and manage the [services](/guide/provisioning#the-service-lifecycle) an environment offers — the two-key gate (the env manifest offers a service, an app claims it) made visible and editable.
+View and manage [services](/guide/provisioning#the-service-lifecycle) for an app and its environment. The interactive view is app-centric — a `Service · Description · Status` table where **Status** is whether *this app* uses each service — with enable / disable per service.
 
 ```bash
 yolo services <environment> [--json] [--add=<service>] [--set key=value] [--remove=<service>]
@@ -510,9 +510,12 @@ yolo services <environment> [--json] [--add=<service>] [--set key=value] [--remo
 | `--set` | `key=value` | An offer field for `--add`, repeatable (e.g. `--set version=29.0 --set nodes=3`). |
 | `--remove` | service | Withdraw a service offer non-interactively. |
 
-Run with no options for an interactive table — each service's offer, the running apps that claim it, and its lifecycle state — with add / edit / remove. The add/edit prompts are generated from each service's offer fields, so a new service needs no command changes. App-side-only services (`rekognition`, `mediaconvert`) are listed but not offerable at the environment tier.
+Run with no options for the interactive picker (`Cancel` is the last option). The table lists every service with a one-line description and whether **this app** has it enabled; selecting one lets you:
 
-Editing writes and uploads the [environment manifest](/reference/manifest); the next [`sync:environment`](#yolo-sync-environment) reconciles AWS to it. A service can't be withdrawn while a running app still claims it (the same guard as [`environment:manifest:push`](#yolo-environment-manifest-push)).
+- **Enable / Disable for this app** — write (or remove) the service in this app's `yolo.yml` `services` claim. The write is surgical (it preserves your manifest's comments and formatting). For an app-side service (`mediaconvert`, `rekognition`) that's the whole change, and it offers to run [`sync:app`](#yolo-run) right then.
+- For an **env-backed** service (`typesense`, `ivs`), enabling also walks you through its **environment offer** — e.g. Typesense's version / nodes / CPU / RAM, pre-filled with sensible defaults. The offer is written to a **local copy** of the [environment manifest](/reference/manifest) (not pushed straight to the bucket), the command **warns you of the cost and blast-radius implications**, and then it tells you — and offers — to run `environment:manifest:push <env>` followed by `sync <env>` to apply.
+
+The `--add` / `--set` / `--remove` flags drive the **environment offer** non-interactively (for agents/CI), uploading the env manifest directly. A service still can't be withdrawn while a running app claims it (the same guard as [`environment:manifest:push`](#yolo-environment-manifest-push)).
 
 ```bash
 yolo services production                                          # interactive

--- a/src/Commands/ServicesCommand.php
+++ b/src/Commands/ServicesCommand.php
@@ -2,8 +2,10 @@
 
 namespace Codinglabs\Yolo\Commands;
 
+use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\EnvManifest;
+use Symfony\Component\Yaml\Yaml;
 use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Services\Lifecycle;
 use Symfony\Component\Console\Input\ArrayInput;
@@ -19,6 +21,7 @@ use function Laravel\Prompts\error;
 use function Laravel\Prompts\table;
 use function Laravel\Prompts\select;
 use function Laravel\Prompts\confirm;
+use function Laravel\Prompts\warning;
 
 /**
  * The two-key service gate, made visible and editable. A table of every service
@@ -169,15 +172,34 @@ class ServicesCommand extends Command
     {
         $enabled = Manifest::usesService($service);
 
+        // App-side services (mediaconvert / rekognition) are a plain app claim —
+        // enabling adds them to yolo.yml, a per-app IAM grant on the next sync.
+        if (! $service->definition()->envBacked()) {
+            $action = select(label: $service->value, options: [
+                'toggle' => $enabled ? 'Disable for this app' : 'Enable for this app',
+                'cancel' => 'Cancel',
+            ]);
+
+            if ($action === 'toggle') {
+                $this->toggleClaim($service, $enabled);
+            }
+
+            return;
+        }
+
+        // Env-backed services (typesense / ivs) carry an env-shared offer (sizing)
+        // in the environment manifest alongside the per-app claim.
         $action = select(label: $service->value, options: array_filter([
-            'toggle' => $enabled ? 'Disable for this app' : 'Enable for this app',
-            'offer' => $service->definition()->envBacked() ? 'Configure environment offer…' : null,
+            'enable' => $enabled ? null : 'Enable for this app',
+            'configure' => $enabled ? 'Reconfigure the environment offer (CPU / RAM / nodes)' : null,
+            'disable' => $enabled ? 'Disable for this app' : null,
             'cancel' => 'Cancel',
         ]));
 
         match ($action) {
-            'toggle' => $this->toggleClaim($service, $enabled),
-            'offer' => $this->manageOffer($service),
+            'enable' => $this->enableEnvBacked($service),
+            'configure' => $this->configureOffer($service),
+            'disable' => $this->toggleClaim($service, true),
             default => null,
         };
     }
@@ -227,46 +249,103 @@ class ServicesCommand extends Command
         );
     }
 
-    /** Configure the environment-tier offer (shape) of an env-backed service. */
-    protected function manageOffer(Service $service): void
+    /**
+     * Enable an env-backed service for THIS app: claim it in yolo.yml, then walk
+     * the operator through its environment offer (sizing) and how to apply it.
+     */
+    protected function enableEnvBacked(Service $service): void
     {
-        $offered = EnvManifest::has($service->envManifestKey());
+        $next = array_values(array_unique([...Manifest::services(), $service->value]));
 
-        $action = select(label: $service->value . ' · environment offer', options: array_filter([
-            'edit' => $offered ? 'Edit the offer' : 'Offer in this environment',
-            'remove' => $offered ? 'Withdraw the offer' : null,
-            'cancel' => 'Cancel',
-        ]));
+        if (! Manifest::setServiceList($next)) {
+            error(sprintf(
+                "Couldn't edit yolo.yml automatically — add \"%s\" to environments.%s.services by hand, then run `yolo sync %s`.",
+                $service->value,
+                $this->argument('environment'),
+                $this->argument('environment'),
+            ));
 
-        match ($action) {
-            'edit' => $this->editOffer($service),
-            'remove' => $this->applyRemove($service->value, interactive: true),
-            default => null,
-        };
+            return;
+        }
+
+        info(sprintf("Enabled %s in this app's yolo.yml.", $service->value));
+
+        $this->configureOffer($service);
     }
 
-    protected function editOffer(Service $service): void
+    /**
+     * Configure an env-backed service's offer (its env-shared sizing) on a LOCAL
+     * copy of the environment manifest — pulled fresh from the bucket when one
+     * isn't already on disk. The result is written locally, never straight to the
+     * bucket, so the operator reviews it and applies it explicitly via
+     * environment:manifest:push + sync (or lets us run those now).
+     */
+    protected function configureOffer(Service $service): void
     {
-        $current = (array) EnvManifest::get($service->envManifestKey(), []);
+        $local = EnvManifest::localPath();
+
+        if (! file_exists($local)) {
+            $this->download(EnvManifest::filename(), $local);   // false → no remote yet; start empty
+        }
+
+        $manifest = file_exists($local) ? (array) (Yaml::parse((string) file_get_contents($local)) ?? []) : [];
+        $current = (array) Arr::get($manifest, $service->envManifestKey(), []);
+        $defaults = $service->definition()->offerDefaults();
+
         $offer = [];
 
         foreach ($service->definition()->offerKeys() as $key) {
-            $value = text(label: $key, default: (string) ($current[$key] ?? ''));
+            $value = trim(text(label: $key, default: (string) ($current[$key] ?? $defaults[$key] ?? '')));
 
             if ($value !== '') {
                 $offer[$key] = static::coerce($value);
             }
         }
 
+        $manifest['services'] ??= [];
+        $manifest['services'][$service->value] = $offer;
+
         try {
-            $this->writeOffer($service, $offer);
+            EnvManifest::parse(Yaml::dump($manifest, 6, 2));
         } catch (IntegrityCheckException $exception) {
             error($exception->getMessage());
 
             return;
         }
 
-        info(sprintf('Offered %s. Run `yolo sync:environment %s` to provision it.', $service->value, $this->argument('environment')));
+        file_put_contents($local, Yaml::dump($manifest, 6, 2));
+
+        info(sprintf('Wrote the %s offer (%s) to %s.', $service->value, static::offerSummary($offer), EnvManifest::filename()));
+
+        if (($implications = $service->definition()->implications()) !== '') {
+            warning($implications);
+        }
+
+        $this->offerToApply();
+    }
+
+    /**
+     * Spell out how to apply an environment-manifest change — and offer to run
+     * those steps now. Defaults to no: pushing + syncing provisions real, billed
+     * infrastructure, so it stays an explicit opt-in.
+     */
+    protected function offerToApply(): void
+    {
+        $environment = $this->argument('environment');
+
+        note(sprintf(
+            "To apply:\n  1. Review this app's yolo.yml and %s.\n  2. `yolo environment:manifest:push %s`  — publish the environment manifest.\n  3. `yolo sync %s`  — provision the change.",
+            EnvManifest::filename(),
+            $environment,
+            $environment,
+        ));
+
+        if (! confirm(label: sprintf('Apply now — push the manifest and run `yolo sync %s`?', $environment), default: false)) {
+            return;
+        }
+
+        $this->getApplication()?->find('environment:manifest:push')->run(new ArrayInput(['environment' => $environment]), $this->output);
+        $this->getApplication()?->find('sync')->run(new ArrayInput(['environment' => $environment]), $this->output);
     }
 
     protected function applyAdd(string $name): int

--- a/src/Services/Ivs.php
+++ b/src/Services/Ivs.php
@@ -27,6 +27,12 @@ class Ivs extends ServiceDefinition
         return 'Live, low-latency video streaming (Amazon IVS)';
     }
 
+    #[\Override]
+    public function implications(): string
+    {
+        return 'IVS provisions a shared event-logging pipeline for the environment (an EventBridge rule + CloudWatch log group) — negligible cost; the app drives IVS channels itself at runtime.';
+    }
+
     public function envBacked(): bool
     {
         return true;

--- a/src/Services/ServiceDefinition.php
+++ b/src/Services/ServiceDefinition.php
@@ -30,6 +30,29 @@ abstract class ServiceDefinition
     abstract public function description(): string;
 
     /**
+     * Sensible defaults for the env-manifest offer keys, pre-filled when an
+     * operator first configures the service (e.g. Typesense's 256 vCPU / 1024 MB
+     * per node, 3 nodes). A required decision with no safe default (the Typesense
+     * version) is simply absent.
+     *
+     * @return array<string, int|string>
+     */
+    public function offerDefaults(): array
+    {
+        return [];
+    }
+
+    /**
+     * A short warning of the immediate, real-world implications of turning the
+     * service on — cost, blast radius, provisioning time — shown before the
+     * operator commits. Empty when there's nothing material to flag.
+     */
+    public function implications(): string
+    {
+        return '';
+    }
+
+    /**
      * Whether this service has an environment-manifest half — env-shared
      * infrastructure that sync:environment provisions when the environment
      * offers `services.{name}` and a live app claims it. App-side-only

--- a/src/Services/Typesense.php
+++ b/src/Services/Typesense.php
@@ -85,6 +85,18 @@ class Typesense extends ServiceDefinition
         return ['version', 'nodes', 'cpu', 'memory'];
     }
 
+    #[\Override]
+    public function offerDefaults(): array
+    {
+        return ['nodes' => 3, 'cpu' => 256, 'memory' => 1024];
+    }
+
+    #[\Override]
+    public function implications(): string
+    {
+        return 'Typesense runs a 3- or 5-node search cluster on Fargate, shared by every app in this environment — one task per node, billed continuously while provisioned. It comes up over a few minutes on the next sync, and changing the node count rolls the cluster one node at a time.';
+    }
+
     /**
      * The manifest entry follows the tasks.* conventions: `version` is the
      * one required decision (an environment never runs an implicit search

--- a/tests/Unit/Services/ServiceDefinitionTest.php
+++ b/tests/Unit/Services/ServiceDefinitionTest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Enums\Service;
+
+it('gives typesense its sizing defaults and an implications warning', function (): void {
+    $typesense = Service::TYPESENSE->definition();
+
+    expect($typesense->offerDefaults())->toBe(['nodes' => 3, 'cpu' => 256, 'memory' => 1024])
+        ->and($typesense->implications())->toContain('cluster')->toContain('Fargate');
+});
+
+it('gives every service a one-line description', function (): void {
+    foreach (Service::cases() as $service) {
+        expect($service->definition()->description())->not->toBe('');
+    }
+});
+
+it('leaves app-side services without env offer defaults or implications', function (): void {
+    foreach ([Service::MEDIA_CONVERT, Service::REKOGNITION] as $service) {
+        expect($service->definition()->offerDefaults())->toBe([])
+            ->and($service->definition()->implications())->toBe('');
+    }
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

Enabling Typesense (and other env-backed services) from `yolo services` didn't let you configure the cluster sizing, and gave no sense of the cost/impact. This makes enabling an env-backed service a guided flow:

- **Pull the environment manifest locally**, then **prompt the offer keys pre-filled with sensible defaults** (Typesense: version, nodes `3`, CPU `256`, RAM `1024` per node) via Laravel Prompts.
- Validate and **write the offer to a *local* copy** of the env manifest (`yolo-environment-<env>.yml`) — **not** straight to the bucket — so you review before it ships.
- **Warn of the immediate implications** (a 3–5 node Fargate cluster, shared, billed continuously, minutes to provision).
- **Spell out the apply steps** — `environment:manifest:push <env>` then `sync <env>` — and **offer to run them now** (a confirm, defaulting to *no*).
- App-side services (`mediaconvert` / `rekognition`) keep the simpler app-claim toggle + offer to run `sync:app`.

New `ServiceDefinition::offerDefaults()` / `implications()` (Typesense + IVS override); everything else hangs off the existing per-service definition.

**Anything the reviewer needs to know to deploy this?**

- **No infra change in this PR** — it's CLI/Prompts plus a *local* manifest write. The only AWS-affecting path is the explicit "Apply now?" confirm, which **defaults to no** and runs the normal `environment:manifest:push` + `sync` (admin-tier, MFA-gated) commands.
- The app-claim write is **surgical** (`Manifest::setServiceList`) — it preserves your `yolo.yml` comments/formatting and parse-verifies before committing, falling back to a manual instruction rather than risk corruption.
- Quality stack green: **1170 tests**, PHPStan L5, Rector, Pint.
- This builds on the services-gate clean-up already on `main` (`a606cac`, `3b9e003`).

🤖 Generated with [Claude Code](https://claude.ai/code)
