### PR TITLE
fix(permissions): nested runs inherit the parent tier cap, never re-mint

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -410,6 +410,15 @@ abstract class Command extends SymfonyCommand
      * deliberate escape is --dangerously-skip-permissions, which skips the cap and
      * runs on the full profile identity (bootstrap / break-glass / diagnostics).
      *
+     * A nested in-process run inherits the parent's already-minted cap rather than
+     * re-minting: the deploy → `sync --check` gate runs an admin-tier SyncCommand
+     * inside a deployer-capped deploy, and re-minting would try to climb deployer →
+     * admin — an escalation the tier model forbids by construction, and one that
+     * can't even resolve an MFA device from inside a role session, turning the
+     * read-only drift check into an auth refusal. The parent tier is the ceiling
+     * and the deployer cap already carries the per-app observer read surface the
+     * check needs, so the nested run proceeds on the inherited credentials.
+     *
      * Returns null to proceed, or an exit code to abort the command.
      */
     protected function mintTierCredentials(): ?int
@@ -423,6 +432,12 @@ abstract class Command extends SymfonyCommand
         if ($this->skipsPermissions()) {
             warning('--dangerously-skip-permissions: running UNCAPPED as your full AWS identity. The YOLO permission tier is bypassed.');
 
+            return null;
+        }
+
+        // Already capped by a parent run (the deploy → `sync --check` gate): inherit
+        // those credentials instead of re-minting and escalating past the cap.
+        if (Helpers::app()->bound('yoloAssumedCredentials')) {
             return null;
         }
 

--- a/tests/Unit/Commands/MintTierCredentialsTest.php
+++ b/tests/Unit/Commands/MintTierCredentialsTest.php
@@ -372,3 +372,25 @@ it('break-glass: --dangerously-skip-permissions skips the cap and runs on the fu
     expect(Helpers::app()->bound('yoloAssumedCredentials'))->toBeFalse();
     expect(test()->promptOutput->fetch())->toContain('UNCAPPED');
 });
+
+it('inherits a parent run\'s cap when nested — never re-mints or escalates to its own tier', function (): void {
+    // The deploy → `sync --check` gate: a parent deploy has already minted (and
+    // capped to) the deployer tier, binding its credentials in the shared container.
+    Helpers::app()->instance('yoloAssumedCredentials', new Credentials('ASIA-DEPLOYER', 'deployer-secret', 'deployer-session'));
+
+    // The nested run is an admin command. Without the inherit guard it would try to
+    // climb deployer → admin (MFA-gated, and unresolvable from inside a role session)
+    // and turn the read-only drift check into an auth refusal. With it, the nested
+    // run proceeds on the parent's credentials — the parent tier is the ceiling.
+    bindMockIamClient(['yolo-testing-admin-role' => 'arn:aws:iam::111111111111:role/yolo-testing-admin-role']);
+
+    $captured = [];
+    bindAssumeRoleStsClient($captured, assumeRoleResult());
+
+    expect(mint(new SyncEnvironmentCommand()))->toBeNull();
+
+    // No assume attempted, no MFA prompt, and the parent's credentials stand untouched.
+    expect($captured)->toBeEmpty();
+    expect(test()->promptOutput->fetch())->not->toContain('MFA');
+    expect(Helpers::app('yoloAssumedCredentials')->getAccessKeyId())->toBe('ASIA-DEPLOYER');
+});


### PR DESCRIPTION
## The bug

`yolo deploy` refuses with **"production is not in sync"** even immediately after a clean `yolo sync` — and prints `Refusing to mint the admin tier: no MFA device found` just above it. It's not drift; it's the gate failing to authenticate and mislabelling it.

`DeployCommand` mints the **deployer** tier, then its first step (`EnsureInSyncStep`) runs the drift check by instantiating a full `SyncCommand` and calling `->run()` in-process. `SyncCommand` is an `AdminCommand`, so that nested run re-enters `mintTierCredentials()` and tries to climb **deployer → admin**:

- admin is MFA-gated, and
- MFA-serial auto-discovery (`callerMfaSerial()`) only matches `…:user/…` ARNs — but by then the caller is the deployer **role session** (`…:assumed-role/…`), so it can *never* resolve a device, regardless of whether one is attached to the IAM user.

The admin mint returns `FAILURE`, `EnsureInSyncStep` sees a non-zero exit and throws `Refusing to deploy — <env> is not in sync`, pointing at `yolo sync` — which doesn't help, so the operator loops. This also blocks CI deploys (a CI deployer role session can't satisfy MFA either).

## The fix

The documented contract already says the in-sync check reads under the **deployer** role, whose attached per-app observer policy carries exactly the read surface it needs (`docs/guide/ci-cd.md`, `docs/reference/commands.md:217`). The admin-mint was a regression against that.

`mintTierCredentials()` now early-returns when credentials are already minted and bound — a nested in-process run **inherits the parent's cap** instead of re-minting. The parent tier is the ceiling; escalating past it by nesting is the exact privilege jump the tier model forbids, so this is correct by construction, not a deploy-only patch. Standalone `yolo sync` / `scale` still mint admin + MFA normally (nothing is bound yet at the start of a fresh run).

## Tests

Adds coverage that an admin-tier command nested inside an already-capped run proceeds on the inherited credentials and attempts no assume. Full suite (1171) + PHPStan L5 + Rector + Pint all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)