### PR TITLE
fix(rbac): skip the redundant self-assume when CI already runs as the tier role

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,7 +24,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-version: ['8.3', '8.4']
+        php-version: ['8.3', '8.4', '8.5']
 
     name: PHP ${{ matrix.php-version }}
 

--- a/docs/guide/ci-cd.md
+++ b/docs/guide/ci-cd.md
@@ -53,7 +53,7 @@ steps:
   - run: vendor/bin/yolo deploy production --no-progress
 ```
 
-In CI, YOLO defers to the AWS SDK's default credential chain, so the assumed-role credentials are picked up automatically — no `YOLO_PRODUCTION_AWS_PROFILE` needed.
+In CI, YOLO defers to the AWS SDK's default credential chain, so the assumed-role credentials are picked up automatically — no `YOLO_PRODUCTION_AWS_PROFILE` needed. Because the workflow has **already** assumed the deployer role via OIDC, the run is already capped to the Deployer tier: YOLO recognises it's running as exactly that role and proceeds as-is, rather than redundantly re-assuming the role it already is (a self-assume the role's own policy doesn't grant). Locally it's the reverse — you authenticate as your own identity, so YOLO mints the deployer role on top of it. Either way the run is capped to the tier.
 
 ::: tip Strongest production gate
 Pair `tag: 'v*'` with a GitHub protected-tag ruleset (only maintainers may cut `v*` tags). The AWS trust then just confirms "a tag push from this repo", and GitHub enforces who can trigger it.

--- a/src/Aws.php
+++ b/src/Aws.php
@@ -620,6 +620,17 @@ class Aws
     }
 
     /**
+     * The ARN of the current AWS caller (`sts:GetCallerIdentity` — implicitly
+     * allowed for any principal, so it needs no grant). Lets YOLO detect when
+     * it's already running as a tier role (the CI/OIDC path) and skip a redundant
+     * self-assume.
+     */
+    public static function callerArn(): string
+    {
+        return static::sts()->getCallerIdentity()['Arn'] ?? '';
+    }
+
+    /**
      * The MFA device serial of the calling IAM user, for the admin-tier assume —
      * resolved from the caller's identity then their first attached device, or
      * null when the caller isn't an IAM user or has no device (the operator then

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -445,9 +445,13 @@ abstract class Command extends SymfonyCommand
             return null;
         }
 
-        // Already capped by a parent run (the deploy → `sync --check` gate): inherit
-        // those credentials instead of re-minting and escalating past the cap.
-        if (Helpers::app()->bound('yoloAssumedCredentials')) {
+        // Already capped — a parent in-process run (the deploy → `sync --check`
+        // gate) applied a tier, or this process is already running as a tier role
+        // (the CI/OIDC skip below). Inherit it rather than re-minting and
+        // escalating past the cap. Keyed off a dedicated marker, not the minted
+        // credentials, because the CI path caps without minting any (it runs on
+        // the ambient OIDC role).
+        if (Helpers::app()->bound('yoloTierApplied')) {
             return null;
         }
 
@@ -459,6 +463,20 @@ abstract class Command extends SymfonyCommand
         };
 
         if (! $role instanceof Resource) {
+            return null;
+        }
+
+        // The canonical CI path: a GitHub Actions workflow assumes the tier role
+        // via OIDC before yolo runs, so the process is already capped to exactly
+        // this tier. Re-assuming the role we already are is a redundant
+        // self-assume the role's own permission policy doesn't grant (and
+        // shouldn't) — detect it and proceed on the ambient role credentials.
+        // Gated to CI: a local run authenticates as the developer's own identity
+        // and always mints through the assume path (skipping the extra
+        // GetCallerIdentity call).
+        if (static::detectCiEnvironment() && $this->callerIsTierRole($role)) {
+            Helpers::app()->instance('yoloTierApplied', true);
+
             return null;
         }
 
@@ -489,6 +507,7 @@ abstract class Command extends SymfonyCommand
                 $credentials['SecretAccessKey'],
                 $credentials['SessionToken'] ?? null,
             ));
+            Helpers::app()->instance('yoloTierApplied', true);
 
             static::forgetAwsClients();
             $this->registerAwsServices();
@@ -505,6 +524,23 @@ abstract class Command extends SymfonyCommand
 
             return self::FAILURE;
         }
+    }
+
+    /**
+     * Whether the AWS caller is already running as exactly this tier's role — the
+     * CI/OIDC path, where the workflow assumes the role before yolo runs. An STS
+     * assumed-role ARN is `arn:aws:sts::<account>:assumed-role/<role-name>/<session>`;
+     * YOLO roles carry no IAM path, so the role name alone identifies the role. A
+     * match means the process is already capped to the tier, so there is nothing
+     * to mint and a self-assume would be a no-op the role's own policy denies.
+     */
+    protected function callerIsTierRole(Resource $role): bool
+    {
+        if (preg_match('#:assumed-role/([^/]+)/#', Aws::callerArn(), $matches) !== 1) {
+            return false;
+        }
+
+        return $matches[1] === $role->name();
     }
 
     /**

--- a/tests/Unit/Commands/MintTierCredentialsTest.php
+++ b/tests/Unit/Commands/MintTierCredentialsTest.php
@@ -113,6 +113,7 @@ beforeEach(function (): void {
     // The container is a process singleton with no global reset, so a minted
     // binding from one case would otherwise leak into the next — forget it.
     Helpers::app()->forgetInstance('yoloAssumedCredentials');
+    Helpers::app()->forgetInstance('yoloTierApplied');
 
     $buffer = new BufferedOutput();
     Prompt::setOutput($buffer);
@@ -133,6 +134,10 @@ afterEach(function (): void {
     }
 
     Helpers::app()->forgetInstance('yoloAssumedCredentials');
+    Helpers::app()->forgetInstance('yoloTierApplied');
+
+    putenv('CI');
+    unset($_ENV['CI'], $_SERVER['CI']);
 });
 
 it('returns the assumed-role Credentials and sends the role ARN + session name', function (): void {
@@ -375,8 +380,10 @@ it('break-glass: --dangerously-skip-permissions skips the cap and runs on the fu
 
 it('inherits a parent run\'s cap when nested — never re-mints or escalates to its own tier', function (): void {
     // The deploy → `sync --check` gate: a parent deploy has already minted (and
-    // capped to) the deployer tier, binding its credentials in the shared container.
+    // capped to) the deployer tier, binding its credentials and the tier-applied
+    // marker in the shared container.
     Helpers::app()->instance('yoloAssumedCredentials', new Credentials('ASIA-DEPLOYER', 'deployer-secret', 'deployer-session'));
+    Helpers::app()->instance('yoloTierApplied', true);
 
     // The nested run is an admin command. Without the inherit guard it would try to
     // climb deployer → admin (MFA-gated, and unresolvable from inside a role session)
@@ -393,4 +400,61 @@ it('inherits a parent run\'s cap when nested — never re-mints or escalates to 
     expect($captured)->toBeEmpty();
     expect(test()->promptOutput->fetch())->not->toContain('MFA');
     expect(Helpers::app('yoloAssumedCredentials')->getAccessKeyId())->toBe('ASIA-DEPLOYER');
+});
+
+it('skips the redundant self-assume when CI is already running as the tier role (OIDC)', function (): void {
+    // The CI/OIDC path: a GitHub Actions workflow assumes the deployer role before
+    // yolo runs, so the process is already the role. Re-assuming the role we are is
+    // a no-op the role's own policy denies — yolo must detect it and proceed, not
+    // refuse fail-closed (the regression the Lever A guard introduced).
+    putenv('CI=true');
+    $_ENV['CI'] = $_SERVER['CI'] = 'true';
+
+    // GetCallerIdentity returns this app's deployer role as an assumed-role session.
+    // A single mock response: a second STS call (a self-assume) would throw.
+    $mock = new MockHandler();
+    $mock->append(new Result(['Arn' => 'arn:aws:sts::111111111111:assumed-role/yolo-testing-my-app-deployer/GitHubActions']));
+    Helpers::app()->instance('sts', new StsClient([
+        'region' => 'ap-southeast-2', 'version' => 'latest', 'credentials' => false, 'handler' => $mock,
+    ]));
+
+    expect(mint(new DeployCommand()))->toBeNull();
+
+    // No minted credentials (the run stays on the ambient OIDC role), but the
+    // tier-applied marker is set so a nested `sync --check` inherits rather than
+    // trying to climb to admin. And it did not refuse.
+    expect(Helpers::app()->bound('yoloAssumedCredentials'))->toBeFalse();
+    expect(Helpers::app()->bound('yoloTierApplied'))->toBeTrue();
+    expect(test()->promptOutput->fetch())->not->toContain('Refusing to run');
+});
+
+it('still mints in CI when the caller is not yet the tier role (e.g. static-key / SSO CI)', function (): void {
+    // A CI runner authenticated as an IAM user (not the tier role) — there's a role
+    // to assume, so the self-assume skip must NOT fire: yolo mints as usual.
+    putenv('CI=true');
+    $_ENV['CI'] = $_SERVER['CI'] = 'true';
+
+    bindMockIamClient(['yolo-testing-my-app-deployer' => 'arn:aws:iam::111111111111:role/yolo-testing-my-app-deployer']);
+
+    $captured = [];
+    $mock = new MockHandler();
+    // GetCallerIdentity: an IAM user, not an assumed role → no skip.
+    $mock->append(new Result(['Arn' => 'arn:aws:iam::111111111111:user/ci-deployer']));
+    // AssumeRole: the real mint.
+    $mock->append(function ($command, $request) use (&$captured): Result {
+        $captured[] = ['name' => $command->getName(), 'args' => $command->toArray()];
+
+        return assumeRoleResult();
+    });
+    Helpers::app()->instance('sts', new StsClient([
+        'region' => 'ap-southeast-2', 'version' => 'latest', 'credentials' => false, 'handler' => $mock,
+    ]));
+
+    expect(mint(new DeployCommand()))->toBeNull();
+
+    expect(Helpers::app()->bound('yoloAssumedCredentials'))->toBeTrue();
+    expect(Helpers::app()->bound('yoloTierApplied'))->toBeTrue();
+    expect($captured)->toHaveCount(1)
+        ->and($captured[0]['name'])->toBe('AssumeRole')
+        ->and($captured[0]['args']['RoleArn'])->toBe('arn:aws:iam::111111111111:role/yolo-testing-my-app-deployer');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- **The Lever A fail-closed guard (#145) broke GitHub OIDC deploys.** CI assumes `yolo-{env}-{app}-deployer` via OIDC, then yolo tried to assume that *same* role again. The role's own permission policy doesn't grant `sts:AssumeRole` on itself, so the AccessDenied — previously fail-open and harmless — now fails closed and refuses the whole deploy (`Refusing to run 'deploy' on your full AWS identity…`).
- **Two walls, not one.** Even with the top-level self-assume skipped, the nested deploy → `sync --check` gate runs an **admin-tier** `SyncCommand` inside the deployer-capped deploy; in CI it would then try to climb deployer → admin (MFA-gated, impossible in CI) and refuse all the same.

**What changed**
- `mintTierCredentials()` now detects when the caller is *already* exactly the target tier role (via the assumed-role ARN from a new `Aws::callerArn()`) and proceeds on the ambient role credentials instead of re-minting. **Gated to CI** — the local mint path is byte-for-byte unchanged and pays no extra `GetCallerIdentity` call.
- The nested-inherit gate now keys off a dedicated `yoloTierApplied` marker rather than the minted credentials, because the CI path caps *without* minting any (it rides the OIDC role). So the nested `sync --check` inherits the ambient deployer creds (which carry the per-app observer read surface the drift check needs) instead of re-minting admin.
- Docs: added the CI tier behaviour to `docs/guide/ci-cd.md` — the page detailed the *local* mint but was silent on CI, which is exactly the gap that bit us.

**Is there anything the reviewer needs to know to deploy this?**
- **Fail-closed is preserved for the real failure modes** — a genuinely missing/broken role still refuses. The skip only fires when the caller *provably is* the role. A test pins that static-key/SSO CI (authenticated as an IAM user, not the role) still mints normally, so the CI gate can't become a blanket bypass.
- **codinglabs runs its vendored yolo copy** — merging here does **not** unblock prod until codinglabs bumps its vendored yolo past this commit (`composer update codinglabsau/yolo`). Same gotcha as the capped-sync 403.
- Verified locally: full Pest suite **1189 passing**, Pint / PHPStan L5 / Rector all clean. 2 new tier-mint test cases (CI self-assume skip · still-mints-when-not-the-role) plus an updated nested-inherit case.

🤖 Generated with [Claude Code](https://claude.ai/code)