### PR TITLE
fix(rbac): grant admin tier s3:PutObject on the app claim prefix

### DIFF
--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -198,11 +198,17 @@ class AdminPolicy implements Resource, SynchronisesConfiguration
                     ],
                 ],
                 [
-                    // The one object sync writes: seeding the env manifest into the
-                    // env config bucket (SeedEnvManifestStep). Scoped to exactly that
-                    // key — never the env-shared `.env` or any other secret.
+                    // The two objects sync writes into the env config bucket: the
+                    // env manifest (SeedEnvManifestStep) and each app's claim file
+                    // (PublishAppManifestStep writes `apps/{app}.yml` on every
+                    // sync:app — env-scoped admin syncs every app, so the whole
+                    // `apps/*` prefix). Scoped to exactly these keys — never the
+                    // env-shared `.env` or any other secret.
                     'Effect' => 'Allow',
-                    'Resource' => sprintf('arn:aws:s3:::%s/%s', $envConfigBucket, EnvManifest::filename()),
+                    'Resource' => [
+                        sprintf('arn:aws:s3:::%s/%s', $envConfigBucket, EnvManifest::filename()),
+                        sprintf('arn:aws:s3:::%s/apps/*', $envConfigBucket),
+                    ],
                     'Action' => ['s3:PutObject'],
                 ],
                 [

--- a/tests/Unit/Resources/Iam/AdminPolicyTest.php
+++ b/tests/Unit/Resources/Iam/AdminPolicyTest.php
@@ -136,12 +136,18 @@ it('limits service-linked-role creation to the three services that need it', fun
     ]);
 });
 
-it('grants S3 object write only to the env manifest key, never the env-shared .env', function (): void {
+it('grants S3 object write to the env manifest + app claim keys, never the env-shared .env', function (): void {
     $objectWrite = collect((new AdminPolicy())->document()['Statement'])
         ->first(fn (array $statement): bool => (array) $statement['Action'] === ['s3:PutObject']);
 
     expect($objectWrite)->not->toBeNull();
-    expect($objectWrite['Resource'])
+
+    $resources = implode(' ', (array) $objectWrite['Resource']);
+
+    // Both objects sync writes — the env manifest (SeedEnvManifestStep) and the
+    // per-app claim prefix (PublishAppManifestStep) — but never the env-shared `.env`.
+    expect($resources)
         ->toContain('yolo-environment-testing.yml')
+        ->toContain('/apps/*')
         ->not->toContain('.env');
 });


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**
- `yolo sync <env>` running as the **admin tier** 403'd on the first apply step (`PublishAppManifestStep`): the admin policy only granted `s3:PutObject` on the env manifest key, but sync also writes each app's claim file `apps/{app}.yml` on every `sync:app`. The deployer policy already carried this grant — admin drifted when the claim-file step was introduced and was never widened.
- Hit live on `yolo sync production` for convictrecords:
  > User: `arn:aws:sts::…:assumed-role/yolo-production-admin-role/…` is not authorized to perform: `s3:PutObject` on `…/apps/convictrecords.yml`

**The fix**
- Widen the admin S3 object-write statement to `apps/*` (env-scoped admin syncs *every* app, mirroring the existing `apps/*` read grant in `ObserverPolicy`). Still scoped to claim keys only — never the env-shared `.env` or any other secret.
- Updated `AdminPolicyTest` to assert both the env-manifest and `apps/*` write grants. Full suite green (1192 passed), Pint clean.

**Is there anything the reviewer needs to know to deploy this?**
- The crash was on the first *mutating* step, so the failed prod sync applied nothing — env state is unchanged.
- Recovery is a normal sync, **no break-glass**: order is account → env → app, so the env-tier `SyncAdminPolicyStep` rewrites the admin policy (admin can `CreatePolicyVersion` on `yolo-*`) before the app-tier `PublishAppManifestStep` runs.
- Apps run the **vendored** yolo copy → consuming apps need `composer update codinglabsau/yolo` past this commit before the fix takes effect.
- One watch-point: the admin policy is rewritten mid-sync and used a few steps later in the same assumed-role session; IAM usually propagates in seconds, but if it 403s again immediately a second `yolo sync` run is guaranteed clean.

🤖 Generated with [Claude Code](https://claude.ai/code)