### PR TITLE
LPX-691: consistent task-group API (true|false|object) + unified autoscaling

### DIFF
--- a/docs/guide/domains.md
+++ b/docs/guide/domains.md
@@ -51,7 +51,7 @@ environments:
   production:
     # no domain / apex / tenants → headless
     tasks:
-      web: {}
+      web: true
 ```
 
 It still declares `tasks.web`. That's the container the app runs — the queue worker and scheduler ride inside it by default ([where each role runs](/reference/manifest#where-each-role-runs)) — so "headless" isn't about dropping the web tier, it's about not exposing it. With no domain to route, YOLO skips the hosted zone, certificate, ALB attachment, and DNS; the container still deploys and still processes queued and scheduled work, it just has no public URL.

--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -45,7 +45,7 @@ During `yolo build`, YOLO writes two files into the build context that your Dock
 | File | Purpose |
 |---|---|
 | `.yolo-entrypoint.sh` | The container entrypoint. Runs your `deploy-all` hooks (e.g. `php artisan optimize`) on startup, then dispatches on the container command: a role (`web` / `queue` / `scheduler`) is supervised and traps `SIGTERM` so the web tier keeps serving across the ALB drain window before forwarding the stop; any other command — a one-off task such as a deploy migration — is `exec`'d directly (no supervise, no drain). ECS can override the command, not the entrypoint, which is why the dispatch lives here. |
-| `docker/supervisord.conf` | The web container's supervisord program tree — FrankenPHP/Octane, plus the `queue:work` worker and the scheduler unless you've extracted them into their own services. A crontab is generated alongside it (the scheduler always runs somewhere). A standalone queue that also hosts the scheduler gets a second `docker/supervisord.queue.conf`. |
+| `docker/supervisord.conf` | The web container's supervisord program tree — FrankenPHP/Octane, plus the `queue:work` worker and the scheduler unless you've extracted them into their own services (or switched them off with `tasks.queue` / `tasks.scheduler: false`). A crontab is generated wherever cron runs (skipped when the scheduler is disabled). A standalone queue that also hosts the scheduler gets a second `docker/supervisord.queue.conf`. |
 
 Because these are generated, your Dockerfile doesn't need to know how to run Octane, the queue, or the scheduler — it just copies the config and runs the entrypoint.
 
@@ -76,7 +76,7 @@ For your image to work with YOLO, the Dockerfile must:
 `yolo build` runs three preflights so a deploy can't ship an image that won't run:
 
 - **Octane** — *before* the build, it reads `composer.lock` and fails if `laravel/octane` isn't in the production requirements, since the web role runs `octane:start`. Skipped when [`tasks.web.octane: false`](/reference/manifest#tasks-web): classic mode runs `frankenphp php-server` and needs no octane package.
-- **Scheduler (supercronic)** — it runs the freshly-built image and fails if `supercronic` isn't on the `PATH`. Every app hosts the scheduler somewhere (there's no opt-out), and the failure this prevents is **silent**: busybox `crond` — the obvious fallback already in the base image — ignores crontabs not owned by root without logging a word, so an image without supercronic deploys green, stays healthy, and simply never fires a scheduled job.
+- **Scheduler (supercronic)** — it runs the freshly-built image and fails if `supercronic` isn't on the `PATH`. The scheduler runs in almost every app (the check is skipped only when cron is switched off with [`tasks.scheduler: false`](/reference/manifest#tasks-scheduler)), and the failure this prevents is **silent**: busybox `crond` — the obvious fallback already in the base image — ignores crontabs not owned by root without logging a word, so an image without supercronic deploys green, stays healthy, and simply never fires a scheduled job.
 - **SSR (Node)** — when [`tasks.web.ssr`](/reference/manifest#tasks-web) is on, it runs the freshly-built image and fails if `node` isn't on the `PATH`. Like the scheduler check, this matters because a missing SSR runtime is otherwise **silent** — Inertia falls back to client-side rendering and the web tier stays healthy on `/up`, so the deploy goes green with SSR quietly off.
 
 The image probes run the image (rather than grepping the Dockerfile), so they see the resolved base image and multi-stage `COPY --from` layers too — no false negatives.
@@ -85,7 +85,7 @@ YOLO doesn't assert the image's base runtime (e.g. that PHP is present) — Dock
 
 ## Processes in the container
 
-Every app runs three roles — web, the queue worker, and the scheduler — and by default they all share the one web container:
+Every app runs three roles — web, the queue worker, and the scheduler — and by default they all share the one web container (each can be extracted into its own service, or switched off with `tasks.queue` / `tasks.scheduler: false`):
 
 ```yaml
 tasks:

--- a/docs/guide/scaling.md
+++ b/docs/guide/scaling.md
@@ -35,10 +35,10 @@ The scaffolded shorthand takes the defaults (`min: 1`, `max: 4`):
 ```yaml
 tasks:
   web:
-    autoscaling: true       # shorthand; `false` (or no key) = a fixed single task
+    autoscaling: true       # shorthand for the defaults — on by default; `false` = a fixed single task
 ```
 
-On the next `yolo sync` / `yolo sync:app`, YOLO registers an [Application Auto Scaling](https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html) **scalable target** on the ECS service (bounded by `min`/`max`) and attaches **target-tracking policies** to it. Without it, the service stays at a fixed single task.
+Autoscaling is **on by default** for any enabled web tier — an omitted `autoscaling` key behaves like `true`. On the next `yolo sync` / `yolo sync:app`, YOLO registers an [Application Auto Scaling](https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html) **scalable target** on the ECS service (bounded by `min`/`max`) and attaches **target-tracking policies** to it. Set `autoscaling: false` to keep the service a fixed single task instead.
 
 ### Two metrics, composed
 
@@ -49,7 +49,7 @@ YOLO runs two target-tracking policies at once. Application Auto Scaling takes t
 | **Request concurrency** | in-flight requests per task (derived) | The default, leading signal — concurrency climbs the instant traffic does, ahead of CPU. Scales the web tier under normal HTTP load. No tuning: its target comes from the task's memory. |
 | **CPU** | `ECSServiceAverageCPUUtilization` | The safety net. Catches load that pegs the CPU without raising request concurrency — a few heavy, low-rate requests. Target defaults to 65%. |
 
-Both are on the moment you add the block — there's nothing to seed from a load test first. Scaling on the requests a task is actively serving rather than trailing CPU means faster responses need fewer tasks for the same traffic, and a spike is caught as it arrives.
+Both are on the moment the web tier is enabled (autoscaling is on by default) — there's nothing to seed from a load test first. Scaling on the requests a task is actively serving rather than trailing CPU means faster responses need fewer tasks for the same traffic, and a spike is caught as it arrives.
 
 ### How the concurrency target is derived
 
@@ -79,7 +79,7 @@ How it works, and what it costs:
 Even instant detection still waits ~55s for the new task to boot and pass ALB health. So reactive scaling — burst included — bottoms out at ~1 min to relief; below that you need a task that's already running (`min ≥ N`). Burst makes the spike that *exceeds* your warm headroom land faster; it doesn't remove the need for the headroom.
 :::
 
-The burst alarm and step policy aren't taggable, so (like the target-tracking policies) they don't appear in [`yolo audit`](/reference/commands#yolo-audit); dropping the autoscaling block (or switching the web tier to classic mode) deletes both on the next sync.
+The burst alarm and step policy aren't taggable, so (like the target-tracking policies) they don't appear in [`yolo audit`](/reference/commands#yolo-audit); setting `autoscaling: false` (or switching the web tier to classic mode) deletes both on the next sync.
 
 ### Turning autoscaling off
 
@@ -103,7 +103,7 @@ yolo scale production --queue --min=0 --max=20     # queue bounds (min 0 = scale
 
 Under autoscaling you set the **bounds** (`--min`/`--max`), never a desired count — the policies own desired count and would override it. Crucially, `scale` **writes the bounds back to the manifest** (surgically — your comments and formatting survive), so the manifest stays the single source of truth and the next `yolo sync` reconciles to the same values rather than clobbering your change.
 
-For a fixed web service (no `autoscaling` block) a positional `count` sets the ECS desired count directly. A standalone queue is always autoscaling-managed, so it only takes `--min`/`--max`. The scheduler is a singleton and can't be scaled (`--scheduler` errors out).
+For a fixed service (`autoscaling: false` — web or queue) a positional `count` sets the ECS desired count directly. An autoscaling service (the default for web and queue) only takes `--min`/`--max`. The scheduler is a singleton and can't be scaled (`--scheduler` errors out).
 
 ### Reducing capacity is guarded
 
@@ -121,17 +121,18 @@ Add a top-level `tasks.queue` block to give the queue worker its own ECS service
 
 ```yaml
 tasks:
-  web: {}
+  web: true
   queue:
-    min: 0          # scale to zero when idle (the default)
-    max: 20
-    backlog-per-task: 100
-    spot: true      # optional: ~70% cheaper interruptible capacity
+    autoscaling:
+      min: 0          # scale to zero when idle (opt-in; the default floor is 1)
+      max: 20
+      backlog-per-task: 100
+    spot: true        # optional: ~70% cheaper interruptible capacity
 ```
 
-It scales on **backlog per task** — `ApproximateNumberOfMessagesVisible / RunningTaskCount`, computed with CloudWatch metric math (no Lambda) and held at `backlog-per-task` messages per running task. As the backlog grows it scales out toward `max`; as it drains it scales back in toward `min`.
+Like web, the queue **autoscales by default** (`min: 1`, `max: 10`) — set `autoscaling: false` for a fixed single task. It scales on **backlog per task** — `ApproximateNumberOfMessagesVisible / RunningTaskCount`, computed with CloudWatch metric math (no Lambda) and held at `backlog-per-task` messages per running task. As the backlog grows it scales out toward `max`; as it drains it scales back in toward `min`.
 
-With `min: 0` the queue **scales to zero**: no tasks and no compute cost when idle. Target tracking can't lift it off zero (dividing by zero running tasks is undefined), so YOLO also attaches a step-scaling alarm that sets the service to exactly one task the instant a message becomes visible; target tracking owns it from one upward. The cost is a **~30–60s cold start** (image pull + boot) on the first message after idle.
+With `autoscaling.min: 0` the queue **scales to zero**: no tasks and no compute cost when idle. Target tracking can't lift it off zero (dividing by zero running tasks is undefined), so YOLO also attaches a step-scaling alarm that sets the service to exactly one task the instant a message becomes visible; target tracking owns it from one upward. The cost is a **~30–60s cold start** (image pull + boot) on the first message after idle.
 
 That makes the choice of *where* the queue lives a latency decision:
 
@@ -173,5 +174,5 @@ tasks:
 YOLO pins it at exactly one task (never a scalable target) and deploys it **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout stops the old cron before starting the new one — a deploy never briefly runs two schedulers (a missed cron minute is harmless; a double-run isn't). This removes the `onOneServer()` *requirement* entirely — it's genuinely a singleton now — though leaving `onOneServer()` on is harmless. The web tier then scales without any scheduler concern.
 
 ::: tip
-When the scheduler is bundled into a host that runs more than one task — an autoscaling web task, or the standalone queue (which always autoscales) — `yolo sync` lists an advisory under the plan's **Warnings** section pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
+When the scheduler is bundled into a host that runs more than one task — an autoscaling web task, or a standalone queue (both autoscale by default) — `yolo sync` lists an advisory under the plan's **Warnings** section pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
 :::

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -452,14 +452,14 @@ yolo scale <environment> [count] [--web] [--min=<n>] [--max=<n>] [--queue] [--sc
 | Option | Value | Description |
 |---|---|---|
 | `--web` | flag | Target the web service (the default). |
-| `--queue` | flag | Target the standalone queue service. Always autoscaling-managed — takes `--min`/`--max` (min may be `0`), never a count. |
+| `--queue` | flag | Target the standalone queue service. Autoscaling-managed by default — takes `--min`/`--max` (min may be `0`); a fixed (`autoscaling: false`) queue takes a count instead. |
 | `--scheduler` | flag | Always errors — the scheduler is a singleton and can't be scaled. |
 | `--min` / `--max` | int | Autoscaling bounds — the autoscaled form. |
 
 There are two forms, picked by what you pass:
 
-- **Autoscaled** — `--min`/`--max` set the bounds. The values are written back to the manifest (surgically — comments and formatting are preserved): web → [`tasks.web.autoscaling.min/max`](/reference/manifest#tasks-web-autoscaling), queue → [`tasks.queue.min/max`](/reference/manifest#tasks-queue). The scalable target is then registered, so the **manifest stays the source of truth** and the next sync reconciles to the same values. A desired count is never set under autoscaling (the policies would override it).
-- **Fixed** — a positional `count` sets the ECS desired count directly (`UpdateService`), for a **web** service with no `autoscaling` block. A standalone queue is always autoscaling-managed, so passing it a count errors and points you to `--min/--max`.
+- **Autoscaled** — `--min`/`--max` set the bounds. The values are written back to the manifest (surgically — comments and formatting are preserved) under [`tasks.{group}.autoscaling.min/max`](/reference/manifest#tasks-web-autoscaling) for both web and queue. The scalable target is then registered, so the **manifest stays the source of truth** and the next sync reconciles to the same values. A desired count is never set under autoscaling (the policies would override it).
+- **Fixed** — a positional `count` sets the ECS desired count directly (`UpdateService`), for a service with `autoscaling: false` (web or queue). An autoscaling service (the default) errors and points you to `--min/--max`.
 
 Lowering a live bound is guarded the same as [reducing capacity](/guide/scaling#reducing-capacity-is-guarded) — an explicit confirm defaulting to no.
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -80,7 +80,8 @@ environments:
         #   unhealthy-threshold: 5        # default: 5 — cushion for a slow-but-alive task
         #   grace-period: 60              # default: 60 (ECS health-check grace period)
         #
-        # autoscaling:                    # omit the whole block for a fixed single task
+        # autoscaling: false             # on by default (min 1, max 4); `false` = fixed single task
+        # autoscaling:                    # …or tune it (web min must be ≥ 1)
         #   min: 1                        # default: 1
         #   max: 4                        # default: 4
         #   cpu-utilization: 65           # default: 65 — the CPU safety-net policy
@@ -90,13 +91,15 @@ environments:
         #   # (~10s spike detection) is unconditional for octane — neither has a knob
 
       # Extract the queue into its own ECS service (scale independently of web).
-      # Presence is the opt-in. A standalone queue scales to zero by default —
-      # unless it also hosts the scheduler (no `scheduler` block below), where the
-      # floor is pinned at min 1 so cron isn't killed when it idles.
+      # `true` extracts with defaults; `false` switches the worker off entirely.
+      # Autoscales by default (min 1, max 10); set autoscaling.min: 0 to scale to zero
+      # when idle — except when it also hosts the scheduler (no `scheduler` block below),
+      # where min 0 is rejected so cron isn't killed when it idles.
       # queue:
-      #   min: 0                          # default: 0 — 0 = scale to zero when idle
-      #   max: 10                         # default: 10
-      #   backlog-per-task: 100           # default: 100 — target messages per running task
+      #   autoscaling:                    # on by default; `false` = fixed single task
+      #     min: 0                        # default: 1 — 0 = scale to zero when idle
+      #     max: 10                       # default: 10
+      #     backlog-per-task: 100         # default: 100 — target messages per running task
       #   cpu: '256'                      # default: '256'
       #   memory: '512'                   # default: '512'
       #   spot: false                     # default: false — true = Fargate Spot (~70% cheaper)
@@ -364,21 +367,27 @@ The budget block is **two-tier**: the same `budget` shape can also be declared i
 
 ## `tasks.web.*`
 
-Declaring `tasks.web` makes the app a Fargate web service. Omit `tasks` entirely for a build-only / headless app with no container.
+Declaring `tasks.web` (as `true` or a config object) makes the app a Fargate web service; it **autoscales by default** (see [`tasks.web.autoscaling`](#tasks-web-autoscaling)). `tasks.web: false` — or omitting `tasks` entirely — is a build-only / headless app with no web container.
 
 ### Where each role runs
 
-Every app runs three roles — **web**, the **queue worker**, and the **scheduler** (cron + `schedule:run`). The web tier runs Octane (FrankenPHP worker mode) by default; set [`tasks.web.octane: false`](#tasks-web) to run FrankenPHP in classic mode instead (per-request boot, no resident app). The queue worker and scheduler have no opt-out — the only choice is *where* each runs. By default all three share the one web container — the cheap single-task floor.
+Every app runs three roles — **web**, the **queue worker**, and the **scheduler** (cron + `schedule:run`). The web tier runs Octane (FrankenPHP worker mode) by default; set [`tasks.web.octane: false`](#tasks-web) to run FrankenPHP in classic mode instead (per-request boot, no resident app). By default the queue worker and scheduler both share the one web container — the cheap single-task floor. Each can be **extracted** into its own service, or **switched off** entirely.
 
 To run web in isolation, **extract the worker tier**: add a top-level [`tasks.queue`](#tasks-queue) block and the queue worker *and* the scheduler move out to their own service, leaving the web container running just the web server. Add [`tasks.scheduler`](#tasks-scheduler) as well to give cron its own pinned-singleton task. Placement is derived from which blocks are present — there are no `tasks.web.queue` / `tasks.web.scheduler` flags.
+
+Each block is **`true | false | {config}`** (the same boolean-or-object form as [`tasks.web.ssr`](#tasks-web)): `true` extracts the role with default sizing, a config object extracts it with overrides, and `false` switches it off so the role runs **nowhere** — neither bundled nor extracted. An empty block (`queue:`) or empty object (`{}`) is rejected — write `true` for defaults so the intent is never ambiguous.
 
 | Manifest | web container | worker container | scheduler container |
 | --- | --- | --- | --- |
 | `web` only | web + queue + scheduler | — | — |
-| `web` + `queue` | web | queue + scheduler | — |
-| `web` + `queue` + `scheduler` | web | queue | scheduler |
+| `web` + `queue: true` | web | queue + scheduler | — |
+| `web` + `queue: true` + `scheduler: true` | web | queue | scheduler |
+| `web` + `queue: false` | web (no worker) | — | — |
+| `web` + `scheduler: false` | web + queue (no cron) | — | — |
 
-The scheduler rides the worker container (the `web` + `queue` row) rather than getting its own task — there's no point paying for a separate one-task service for cron when the queue is already a managed tier. Because cron then runs on the autoscaling queue, guard scheduled tasks with `->onOneServer()`, or add `tasks.scheduler` for a true singleton. A queue that hosts the scheduler can't scale to zero — cron would stop when it idled — so its floor is pinned at `min: 1` (an explicit `tasks.queue.min: 0` there is rejected).
+The scheduler rides the worker container (the `web` + `queue` row) rather than getting its own task — there's no point paying for a separate one-task service for cron when the queue is already a managed tier. Because cron then runs on the autoscaling queue, guard scheduled tasks with `->onOneServer()`, or add `tasks.scheduler` for a true singleton. A queue that hosts the scheduler can't scale to zero — cron would stop when it idled — so its floor stays at `1` (an explicit `tasks.queue.autoscaling.min: 0` there is rejected).
+
+**Disabling the queue (`queue: false`)** means no worker runs anywhere, so jobs can't be processed off-request: YOLO bakes `QUEUE_CONNECTION=sync` (jobs run inline at dispatch) and **fails the build** if your `.env` pins it to anything else, rather than ship an app that black-holes queued work. **Disabling the scheduler (`scheduler: false`)** stops `schedule:run` running anywhere — framework and package maintenance that rides cron (model pruning, `auth:clear-resets`, Telescope/Pulse pruning, …) silently stops, so `sync` surfaces a warning. Reach for these only when the app genuinely has no background work.
 
 | Key | Default | Description |
 |---|---|---|
@@ -411,11 +420,12 @@ The other defaults are tuned to avoid false-positive failures on a Laravel/Octan
 
 ### `tasks.web.autoscaling.*`
 
-Add an `autoscaling` block to turn on [Application Auto Scaling](/guide/scaling) for the web service — or `autoscaling: true` for the defaults (`min: 1`, `max: 4`); `false` or no key leaves a fixed single task. With it, YOLO scales on **request concurrency** — the default, leading signal, with its target derived from the task's memory so there's nothing to tune — and composes a **CPU** policy alongside as a safety net. The only knobs are the bounds and cooldowns.
+[Application Auto Scaling](/guide/scaling) is **on by default** for the web service (`min: 1`, `max: 4`) — `autoscaling` is `true | false | {config}`, the same boolean-or-object form as the group itself. An omitted key or `autoscaling: true` takes the defaults; **`autoscaling: false`** pins a fixed single task (no scalable target); a `{min, max, …}` object sets bespoke bounds. An empty object (`{}`) is rejected — write `true` or `false`. Web **`min` must be ≥ 1** (it serves traffic and can't idle to zero). With autoscaling on, YOLO scales on **request concurrency** — the default, leading signal, with its target derived from the task's memory so there's nothing to tune — and composes a **CPU** policy alongside as a safety net. The only knobs are the bounds and cooldowns.
 
 | Key | Default | Description |
 |---|---|---|
-| `autoscaling.min` | `1` | Minimum number of tasks. |
+| `autoscaling` | *(on)* | `false` for a fixed single task; `true` / object to tune. On by default. |
+| `autoscaling.min` | `1` | Minimum number of tasks (must be ≥ 1). |
 | `autoscaling.max` | `4` | Maximum number of tasks. |
 | `autoscaling.cpu-utilization` | `65` | Target average CPU % — the safety-net policy composed alongside concurrency. |
 | `autoscaling.scale-out-cooldown` | `60` | Seconds between scale-out steps (both policies). |
@@ -435,24 +445,25 @@ tasks:
 ```
 
 ::: warning Bundled scheduler
-A plain web app bundles the scheduler in the web container, so scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). The `sync` plan lists an advisory under its **Warnings** section whenever the scheduler is bundled into an autoscaling host (the web task, or the standalone queue, which always autoscales). See [Scaling → the scheduler](/guide/scaling#the-scheduler).
+A plain web app bundles the scheduler in the web container, so scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). The `sync` plan lists an advisory under its **Warnings** section whenever the scheduler is bundled into an autoscaling host (the web task, or a standalone queue — both autoscale by default). See [Scaling → the scheduler](/guide/scaling#the-scheduler).
 :::
 
 ---
 
 ## `tasks.queue.*`
 
-A top-level `tasks.queue` block extracts the queue worker into its **own** ECS service, so it scales independently of web. Presence is the opt-in — an empty block (`queue:`) gives a scale-to-zero worker on default sizing. Without it, the worker stays bundled in the web container (see [Where each role runs](#where-each-role-runs)).
+`tasks.queue` is **`true | false | {config}`**. `true` (or a config object) extracts the queue worker into its **own** ECS service, so it scales independently of web; `false` switches the worker off entirely (it runs nowhere, and YOLO enforces `QUEUE_CONNECTION=sync` — see [Where each role runs](#where-each-role-runs)); omitting the block leaves the worker bundled in the web container. An empty block (`queue:`) or empty object (`{}`) is rejected — write `true` for a scale-to-zero worker on default sizing.
 
-A standalone queue **scales to zero by default** (`min: 0`): zero tasks — and zero compute cost — when the queue is empty, scaling up on backlog. The trade-off is a ~30–60s Fargate cold start on the first message after idle, so it suits bursty, latency-tolerant work. For latency-sensitive jobs that must start instantly, leave the queue bundled in the warm web container or set a standing floor (`min: 1`). One caveat: when the queue also hosts the scheduler (a `tasks.queue` block with no [`tasks.scheduler`](#tasks-scheduler)), it can't scale to zero — the floor is pinned at `min: 1`, and an explicit `tasks.queue.min: 0` is rejected.
+A standalone queue **autoscales by default** (`min: 1`, `max: 10`) — the same `autoscaling: true | false | {min, max, backlog-per-task}` knob as web, on unless you set `autoscaling: false` (a fixed single task — no scalable target, no backlog policy). Set **`autoscaling.min: 0`** to opt into **scale to zero**: zero tasks — and zero compute cost — when the queue is empty, at the cost of a ~30–60s Fargate cold start on the first message after idle (so it suits bursty, latency-tolerant work). The queue `min` may be `0` (unlike web); but when the queue also hosts the scheduler (a `tasks.queue` block with no [`tasks.scheduler`](#tasks-scheduler)) it can't scale to zero — cron would stop — so an explicit `tasks.queue.autoscaling.min: 0` is rejected there.
 
-Scaling is **backlog-per-task** target tracking (`ApproximateNumberOfMessagesVisible / RunningTaskCount`, CloudWatch metric math — no Lambda). A scale-to-zero queue (`min: 0`) also gets a step-scaling alarm that lifts it 0→1 the instant a message arrives (target tracking can't divide by zero running tasks).
+Scaling is **backlog-per-task** target tracking (`ApproximateNumberOfMessagesVisible / RunningTaskCount`, CloudWatch metric math — no Lambda). A scale-to-zero queue (`autoscaling.min: 0`) also gets a step-scaling alarm that lifts it 0→1 the instant a message arrives (target tracking can't divide by zero running tasks).
 
 | Key | Default | Description |
 |---|---|---|
-| `tasks.queue.min` | `0` | Minimum tasks. `0` = scale to zero when idle. |
-| `tasks.queue.max` | `10` | Maximum tasks. |
-| `tasks.queue.backlog-per-task` | `100` | Target visible messages per running task — the scale-out trigger. |
+| `tasks.queue.autoscaling` | *(on)* | `false` for a fixed single task; `true` / object to tune. On by default. |
+| `tasks.queue.autoscaling.min` | `1` | Minimum tasks. `0` = scale to zero when idle. |
+| `tasks.queue.autoscaling.max` | `10` | Maximum tasks. |
+| `tasks.queue.autoscaling.backlog-per-task` | `100` | Target visible messages per running task — the scale-out trigger. |
 | `tasks.queue.cpu` | `'256'` | Fargate CPU units. |
 | `tasks.queue.memory` | `'512'` | Fargate memory (MB). |
 | `tasks.queue.spot` | `false` | `true` runs the queue on Fargate Spot (~70% cheaper, interruptible — fine for a worker whose jobs retry). |
@@ -465,7 +476,7 @@ See [Scaling → the queue](/guide/scaling#the-queue-scale-to-zero).
 
 ## `tasks.scheduler.*`
 
-A top-level `tasks.scheduler` block extracts the scheduler ([supercronic](https://github.com/aptible/supercronic) firing `schedule:run`) into its **own** ECS service, pinned at exactly one task — a genuine singleton, so `->onOneServer()` is no longer required. It deploys **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout never briefly runs two crons; a missed cron minute is harmless, a double-run isn't. Without this block the scheduler rides the standalone queue if there is one, else the web container (see [Where each role runs](#where-each-role-runs)).
+`tasks.scheduler` is **`true | false | {config}`**. `true` (or a config object) extracts the scheduler ([supercronic](https://github.com/aptible/supercronic) firing `schedule:run`) into its **own** ECS service, pinned at exactly one task — a genuine singleton, so `->onOneServer()` is no longer required. It deploys **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout never briefly runs two crons; a missed cron minute is harmless, a double-run isn't. `false` switches cron off entirely — `schedule:run` runs nowhere, so framework/package maintenance that rides the scheduler silently stops (`sync` warns); use it only for an app with no scheduled work. Omitting the block leaves the scheduler riding the standalone queue if there is one, else the web container (see [Where each role runs](#where-each-role-runs)). An empty block (`scheduler:`) or empty object (`{}`) is rejected — write `true` for default sizing.
 
 The scheduler never scales (a per-minute cron can't tolerate a cold start), so it has no `min`/`max`.
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -133,24 +133,23 @@ abstract class Command extends SymfonyCommand
 
     /**
      * When the scheduler rides the standalone queue (a `tasks.queue` block but no
-     * dedicated `tasks.scheduler` service), the queue can't scale to zero — cron
-     * would stop the moment it idled to no tasks. The floor defaults to 1 in that
-     * topology, but an explicit `tasks.queue.min: 0` is a contradiction, so
-     * hard-fail and point at the two ways out.
+     * dedicated `tasks.scheduler` service), an autoscaling queue can't scale to zero
+     * — cron would stop the moment it idled to no tasks. The floor defaults to 1, so
+     * only an explicit `tasks.queue.autoscaling.min: 0` is a contradiction; hard-fail
+     * and point at the ways out. A fixed (autoscaling: false) queue never idles to
+     * zero, so it's exempt.
      */
     protected function ensureSchedulerHostNotScaleToZero(): bool
     {
-        if (Manifest::schedulerHost() !== ServerGroup::QUEUE) {
+        if (Manifest::schedulerHost() !== ServerGroup::QUEUE || ! Manifest::autoscales(ServerGroup::QUEUE)) {
             return true;
         }
 
-        $min = Manifest::get('tasks.queue.min');
-
-        if ($min !== null && is_numeric($min) && (int) $min === 0) {
+        if (Manifest::autoscalingMin(ServerGroup::QUEUE) === 0) {
             error(
                 "yolo.yml runs the scheduler inside the standalone queue (there's no `tasks.scheduler` service), "
                 . "so the queue can't scale to zero — cron would stop when it idles to 0 tasks.\n"
-                . 'Set `tasks.queue.min` to 1 or more, or extract the scheduler into its own `tasks.scheduler` service.'
+                . 'Set `tasks.queue.autoscaling.min` to 1 or more, or extract the scheduler into its own `tasks.scheduler` service.'
             );
 
             return false;

--- a/src/Commands/ScaleCommand.php
+++ b/src/Commands/ScaleCommand.php
@@ -79,11 +79,12 @@ class ScaleCommand extends Command implements AdminCommand
             return;
         }
 
-        // A standalone queue is always autoscaling-managed, as is any web service
-        // with a registered target. Setting a fixed desired count there is futile
-        // (the policies override it), so redirect to the bounds form rather than
-        // quietly no-op. Only a fixed web service falls through to desired count.
-        if ($group === ServerGroup::QUEUE || $live !== null) {
+        // A service the manifest autoscales — or one with a registered target — is
+        // autoscaling-managed: a fixed desired count there is futile (the policies
+        // override it), so redirect to the bounds form rather than quietly no-op.
+        // Only a truly fixed service (autoscaling: false, no live target — web or
+        // queue) falls through to desired count.
+        if (Manifest::autoscales($group) || $live !== null) {
             error('This service is autoscaling-managed — use --min/--max to change its bounds, not a desired count.');
 
             return;
@@ -188,17 +189,16 @@ class ScaleCommand extends Command implements AdminCommand
     }
 
     /**
-     * The manifest min/max key paths for a group — web autoscaling bounds live
-     * under tasks.web.autoscaling, the queue's directly under tasks.queue (a
-     * standalone queue is always autoscaled).
+     * The manifest min/max key paths for a group — both groups' autoscaling bounds
+     * live under `tasks.{group}.autoscaling.{min,max}`.
      *
      * @return array{0: string, 1: string}
      */
     public static function boundsKeys(ServerGroup $group): array
     {
-        return $group === ServerGroup::QUEUE
-            ? ['tasks.queue.min', 'tasks.queue.max']
-            : ['tasks.web.autoscaling.min', 'tasks.web.autoscaling.max'];
+        $prefix = "tasks.{$group->value}.autoscaling";
+
+        return ["$prefix.min", "$prefix.max"];
     }
 
     /**

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -43,7 +43,27 @@ class SyncAppCommand extends SyncSteppedCommand
     #[\Override]
     public function warnings(): array
     {
-        return array_filter([static::schedulerAdvisory()]);
+        return array_filter([
+            static::schedulerDisabledWarning(),
+            static::schedulerAdvisory(),
+        ]);
+    }
+
+    /**
+     * A loud warning when cron is switched off entirely (`tasks.scheduler: false`):
+     * the Laravel scheduler runs nowhere, so scheduled work and the framework/package
+     * maintenance that rides the scheduler (model pruning, auth:clear-resets,
+     * telescope/pulse pruning, …) silently stop firing. Rarely intended, so it's
+     * surfaced on every sync as a deliberate choice rather than a quiet default.
+     */
+    public static function schedulerDisabledWarning(): ?string
+    {
+        if (! Manifest::schedulerDisabled()) {
+            return null;
+        }
+
+        return 'The scheduler is disabled (tasks.scheduler: false) — `schedule:run` runs nowhere. '
+            . 'Scheduled tasks and framework/package maintenance (model pruning, auth:clear-resets, etc.) will not fire.';
     }
 
     /**
@@ -51,16 +71,18 @@ class SyncAppCommand extends SyncSteppedCommand
      * host that can run more than one task — the autoscaling web container, or the
      * standalone queue (which always autoscales). Cron then fires on every replica,
      * so every scheduled task must use ->onOneServer(). A dedicated tasks.scheduler
-     * service is a pinned singleton and needs no nudge.
+     * service is a pinned singleton and needs no nudge; a disabled scheduler (null
+     * host) never fires at all, so it gets the separate warning above, not this one.
      */
     public static function schedulerAdvisory(): ?string
     {
         $host = Manifest::schedulerHost();
 
         $hostAutoscales = match ($host) {
-            ServerGroup::WEB => Manifest::isAutoscaling(),
-            ServerGroup::QUEUE => true, // a standalone queue is always autoscaled (min↔max)
+            ServerGroup::WEB => Manifest::autoscales(ServerGroup::WEB),
+            ServerGroup::QUEUE => Manifest::autoscales(ServerGroup::QUEUE), // a fixed (autoscaling: false) queue won't multi-fire
             ServerGroup::SCHEDULER => false, // dedicated singleton — never multi-fires
+            null => false, // disabled — surfaced by schedulerDisabledWarning instead
         };
 
         if (! $hostAutoscales) {
@@ -126,7 +148,7 @@ class SyncAppCommand extends SyncSteppedCommand
                         Steps\Sync\App\Solo\SyncQueueAlarmStep::class,
                     ],
                 // Fargate + CDN (web tasks only)
-                ...Manifest::has('tasks.web')
+                ...Manifest::hasWeb()
                     ? [
                         Steps\Sync\App\SyncEcrRepositoryStep::class,
                         Steps\Sync\App\SyncEcsClusterStep::class,

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -51,7 +51,7 @@ class Manifest
         'tasks.web.ssr', 'tasks.web.ssr.*',
         'tasks.web.health-check.*', 'tasks.web.autoscaling.*',
         'tasks.queue',
-        'tasks.queue.min', 'tasks.queue.max', 'tasks.queue.backlog-per-task',
+        'tasks.queue.autoscaling.*',
         'tasks.queue.cpu', 'tasks.queue.memory', 'tasks.queue.spot',
         'tasks.queue.shutdown-grace-period', 'tasks.queue.enable-execute-command',
         'tasks.scheduler',
@@ -430,7 +430,7 @@ class Manifest
      */
     public static function cacheStore(): ?string
     {
-        return static::get('cache.store', static::has('tasks.web') ? 'redis' : null);
+        return static::get('cache.store', static::hasWeb() ? 'redis' : null);
     }
 
     /**
@@ -442,7 +442,28 @@ class Manifest
      */
     public static function sessionDriver(): ?string
     {
-        return static::get('session.driver', static::has('tasks.web') ? 'redis' : null);
+        return static::get('session.driver', static::hasWeb() ? 'redis' : null);
+    }
+
+    /**
+     * Whether the app runs a web (Fargate) service — `tasks.web: true` or a config
+     * object. Absent ⇒ build-only/worker app; `tasks.web: false` ⇒ explicitly
+     * headless (no web service), same as absent. The single gate for the ALB / CDN /
+     * Route 53 / web-task provisioning (the value-aware replacement for
+     * `has('tasks.web')`).
+     */
+    public static function hasWeb(): bool
+    {
+        return static::has('tasks.web') && self::taskExtraction('web') !== false;
+    }
+
+    /**
+     * Whether the web service is switched off explicitly (`tasks.web: false`) — a
+     * headless app. Distinct from absent (also headless) only in being self-documenting.
+     */
+    public static function webDisabled(): bool
+    {
+        return static::has('tasks.web') && self::taskExtraction('web') === false;
     }
 
     /**
@@ -477,16 +498,85 @@ class Manifest
     }
 
     /**
-     * Whether the web tier autoscales — the single gate every scaling resource keys
-     * off (the scalable target, the concurrency/CPU policies, burst). Two manifest
-     * forms turn it on: the block `tasks.web.autoscaling: {min, max, …}` for explicit
-     * bounds, or the shorthand `tasks.web.autoscaling: true` to take the defaults
-     * (min 1, max 4). An explicit `false` — or no key — leaves the web service a
-     * fixed single task. Off ⇒ everything scaling tears down (or never provisions).
+     * Whether a group autoscales. Autoscaling is **bolted on by default** for an
+     * enabled web or queue tier — an omitted `autoscaling` key, `autoscaling: true`,
+     * or an `autoscaling: {min, max, …}` block all mean ON; only an explicit
+     * `autoscaling: false` turns it off (a fixed single task). The scheduler is a
+     * pinned singleton and never autoscales. This is the single gate every scaling
+     * resource keys off (scalable target, concurrency/CPU/backlog policies, burst,
+     * scale-to-zero) — off ⇒ those tear down or never provision.
+     */
+    public static function autoscales(ServerGroup $group): bool
+    {
+        $enabled = match ($group) {
+            ServerGroup::WEB => static::hasWeb(),
+            ServerGroup::QUEUE => static::hasStandaloneQueue(),
+            ServerGroup::SCHEDULER => false,
+        };
+
+        return $enabled && self::autoscalingValue($group) !== false;
+    }
+
+    /**
+     * Web-tier autoscaling — the common gate, kept as a named shorthand for
+     * `autoscales(ServerGroup::WEB)` (most scaling code is web).
      */
     public static function isAutoscaling(): bool
     {
-        return static::get('tasks.web.autoscaling', false) !== false;
+        return static::autoscales(ServerGroup::WEB);
+    }
+
+    /**
+     * Validate and resolve a group's `autoscaling` value — the three-state knob,
+     * defaulting to ON when the key is omitted on an enabled group. `true` (or an
+     * omitted key) and a non-empty config object both mean ON; `false` means off.
+     * An empty object (`{}`) or null hard-fails — write `true` / `false`.
+     *
+     * @return bool|array<string, mixed>
+     */
+    private static function autoscalingValue(ServerGroup $group): bool|array
+    {
+        $key = "tasks.{$group->value}.autoscaling";
+        $value = static::get($key, true);
+
+        if (is_array($value) && $value !== [] && ! array_is_list($value)) {
+            return $value;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        throw new IntegrityCheckException(sprintf(
+            '%s must be `true`, `false`, or a non-empty config object (got %s). Omit it for autoscaling on with defaults, or set `false` for a fixed single task.',
+            $key,
+            json_encode($value),
+        ));
+    }
+
+    /**
+     * The autoscaling floor for a group. Both default to 1 (no accidental
+     * scale-to-zero); web is validated ≥ 1 (it serves traffic, can't idle to zero),
+     * the queue ≥ 0 (0 opts into scale-to-zero, with a 0→1 bootstrap alarm).
+     */
+    public static function autoscalingMin(ServerGroup $group): int
+    {
+        $key = "tasks.{$group->value}.autoscaling.min";
+        $value = static::get($key, 1);
+
+        return $group === ServerGroup::WEB
+            ? Helpers::validatePositiveInt($value, $key)
+            : Helpers::validateNonNegativeInt($value, $key);
+    }
+
+    /**
+     * The autoscaling ceiling for a group — web defaults to 4, the queue to 10.
+     */
+    public static function autoscalingMax(ServerGroup $group): int
+    {
+        $key = "tasks.{$group->value}.autoscaling.max";
+
+        return Helpers::validatePositiveInt(static::get($key, $group === ServerGroup::QUEUE ? 10 : 4), $key);
     }
 
     /**
@@ -504,43 +594,50 @@ class Manifest
     }
 
     /**
-     * Which container runs the queue worker: a standalone `tasks.queue` service if
-     * extracted, else bundled in the web container. The worker always runs
-     * somewhere — there's no opt-out.
+     * Which container runs the queue worker, or null when no worker runs anywhere.
+     * A standalone `tasks.queue` service if extracted; else the web container
+     * (bundled); else null — `tasks.queue: false` (disabled) or a worker-less app
+     * with no web tier to bundle into. Null ⇒ jobs run inline (QUEUE_CONNECTION=sync).
      */
-    public static function queueHost(): ServerGroup
-    {
-        return static::hasStandaloneQueue() ? ServerGroup::QUEUE : ServerGroup::WEB;
-    }
-
-    /**
-     * Which container runs the scheduler (supercronic + schedule:run): a dedicated
-     * `tasks.scheduler` service if extracted, else the standalone queue if there is
-     * one, else the web container. The cron always runs somewhere — there's no
-     * opt-out — so management work lands on the least request-facing service that
-     * exists. This is also the deploy/management tier (see deployGroup).
-     */
-    public static function schedulerHost(): ServerGroup
+    public static function queueHost(): ?ServerGroup
     {
         return match (true) {
-            static::hasStandaloneScheduler() => ServerGroup::SCHEDULER,
+            static::queueDisabled() => null,
             static::hasStandaloneQueue() => ServerGroup::QUEUE,
-            default => ServerGroup::WEB,
+            static::hasWeb() => ServerGroup::WEB,
+            default => null,
         };
     }
 
     /**
-     * The autoscaling/desired-count floor for the standalone queue. A scale-to-zero
-     * queue (`min: 0`, the default) idles to no tasks — but when the queue also
-     * hosts the scheduler (no dedicated `tasks.scheduler` service), it can't scale
-     * to zero or cron would stop, so the floor defaults to 1. An explicit
-     * `tasks.queue.min: 0` in that topology is rejected by the validator.
+     * Which container runs the scheduler (supercronic + schedule:run), or null when
+     * cron runs nowhere (`tasks.scheduler: false`, or no host exists): a dedicated
+     * `tasks.scheduler` service if extracted, else the standalone queue if there is
+     * one, else the web container. Bundled cron lands on the least request-facing
+     * service that exists. Distinct from the deploy/management tier (see deployGroup),
+     * which always resolves to a real group even when the scheduler is disabled.
+     */
+    public static function schedulerHost(): ?ServerGroup
+    {
+        return match (true) {
+            static::schedulerDisabled() => null,
+            static::hasStandaloneScheduler() => ServerGroup::SCHEDULER,
+            static::hasStandaloneQueue() => ServerGroup::QUEUE,
+            static::hasWeb() => ServerGroup::WEB,
+            default => null,
+        };
+    }
+
+    /**
+     * The autoscaling/desired-count floor for the standalone queue — its
+     * `autoscaling.min` (default 1). `0` opts into scale-to-zero (idle to no tasks,
+     * zero cost), except when the queue also hosts the scheduler, where cron can't
+     * ride a task that idles to zero — `ensureSchedulerHostNotScaleToZero` rejects an
+     * explicit `0` there.
      */
     public static function queueMin(): int
     {
-        $default = static::schedulerHost() === ServerGroup::QUEUE ? 1 : 0;
-
-        return Helpers::validateNonNegativeInt(static::get('tasks.queue.min', $default), 'tasks.queue.min');
+        return static::autoscalingMin(ServerGroup::QUEUE);
     }
 
     /**
@@ -573,22 +670,80 @@ class Manifest
     }
 
     /**
-     * Whether the queue runs as its own ECS service (a top-level `tasks.queue`
-     * block) rather than bundled in the web container. Presence is the opt-in —
-     * an empty block extracts the queue with default sizing and scale-to-zero.
+     * Whether the queue runs as its own ECS service (`tasks.queue: true` or a
+     * config object) rather than bundled in the web container. Absent ⇒ bundled;
+     * `false` ⇒ disabled (see queueDisabled), so neither counts as standalone.
      */
     public static function hasStandaloneQueue(): bool
     {
-        return static::has('tasks.queue');
+        return static::has('tasks.queue') && self::taskExtraction('queue') !== false;
     }
 
     /**
-     * Whether the scheduler runs as its own pinned-singleton ECS service (a
-     * top-level `tasks.scheduler` block) rather than bundled in the web container.
+     * Whether the scheduler runs as its own pinned-singleton ECS service
+     * (`tasks.scheduler: true` or a config object) rather than bundled in the web
+     * container. Absent ⇒ bundled; `false` ⇒ disabled (see schedulerDisabled).
      */
     public static function hasStandaloneScheduler(): bool
     {
-        return static::has('tasks.scheduler');
+        return static::has('tasks.scheduler') && self::taskExtraction('scheduler') !== false;
+    }
+
+    /**
+     * Whether the queue worker is switched off entirely (`tasks.queue: false`) —
+     * it runs nowhere, neither bundled nor extracted. Jobs must run inline
+     * (QUEUE_CONNECTION=sync, enforced at build).
+     */
+    public static function queueDisabled(): bool
+    {
+        return static::has('tasks.queue') && self::taskExtraction('queue') === false;
+    }
+
+    /**
+     * Whether the scheduler is switched off entirely (`tasks.scheduler: false`) —
+     * cron runs nowhere. Dangerous (framework + packages lean on the scheduler), so
+     * sync surfaces a warning; see SyncAppCommand::schedulerAdvisory.
+     */
+    public static function schedulerDisabled(): bool
+    {
+        return static::has('tasks.scheduler') && self::taskExtraction('scheduler') === false;
+    }
+
+    /**
+     * Validate and resolve a top-level task role's block value — the three-state
+     * opt-in shared by `tasks.queue` and `tasks.scheduler`, mirroring the
+     * boolean-or-object form of `tasks.web.ssr` (see bundles()):
+     *
+     *   - `true`               extract a standalone service with default sizing
+     *   - non-empty config map extract a standalone service with overrides
+     *   - `false`              disabled — runs nowhere
+     *
+     * Callers confirm presence first (has()); an absent block is the bundled
+     * default, not a value. An empty block (`tasks.queue:` → null), an empty map
+     * (`{}`), a list, or any non-boolean scalar hard-fails — write `true` for
+     * defaults rather than leaving the value ambiguous.
+     *
+     * @return bool|array<string, mixed>
+     */
+    private static function taskExtraction(string $task): bool|array
+    {
+        $value = static::get("tasks.$task");
+
+        if (is_array($value) && $value !== [] && ! array_is_list($value)) {
+            return $value;
+        }
+
+        if (is_bool($value)) {
+            return $value;
+        }
+
+        throw new IntegrityCheckException(sprintf(
+            'tasks.%s must be `true`, `false`, or a non-empty config object (got %s). '
+            . 'Write `tasks.%s: true` to extract it with default sizing, or omit it to bundle it in the web container.',
+            $task,
+            json_encode($value),
+            $task,
+        ));
     }
 
     /**
@@ -603,7 +758,7 @@ class Manifest
     public static function serverGroups(): array
     {
         return array_values(array_filter([
-            static::has('tasks.web') ? ServerGroup::WEB : null,
+            static::hasWeb() ? ServerGroup::WEB : null,
             static::hasStandaloneQueue() ? ServerGroup::QUEUE : null,
             static::hasStandaloneScheduler() ? ServerGroup::SCHEDULER : null,
         ]));
@@ -611,13 +766,19 @@ class Manifest
 
     /**
      * The service group a one-off deploy/management task (the `deploy:` hooks,
-     * e.g. migrations) templates its task definition on. It's the same least
-     * request-facing tier the scheduler rides — a dedicated scheduler if extracted,
-     * else a standalone queue, else web — so the one-off lands off the request path.
+     * e.g. migrations) templates its task definition on — the least request-facing
+     * tier that exists: a dedicated scheduler if extracted, else a standalone queue,
+     * else web. Unlike schedulerHost this always resolves to a real group (it picks
+     * a tier to run on, independent of whether cron is enabled), so a disabled
+     * scheduler still leaves migrations a home.
      */
     public static function deployGroup(): ServerGroup
     {
-        return static::schedulerHost();
+        return match (true) {
+            static::hasStandaloneScheduler() => ServerGroup::SCHEDULER,
+            static::hasStandaloneQueue() => ServerGroup::QUEUE,
+            default => ServerGroup::WEB,
+        };
     }
 
     public static function apex(): string

--- a/src/Resources/ApplicationAutoScaling/QueueBacklogPolicy.php
+++ b/src/Resources/ApplicationAutoScaling/QueueBacklogPolicy.php
@@ -15,7 +15,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 /**
  * The queue service's target-tracking scaling policy, scaling on **backlog per
  * task** — `ApproximateNumberOfMessagesVisible / RunningTaskCount` via CloudWatch
- * metric math (no Lambda) — held at `tasks.queue.backlog-per-task` messages per
+ * metric math (no Lambda) — held at `tasks.queue.autoscaling.backlog-per-task` messages per
  * task. This is what scales the queue 1→N under load and back down to its floor.
  *
  * It deliberately can't scale 0→1: when the service is at zero the running-task
@@ -45,8 +45,8 @@ class QueueBacklogPolicy
     public function targetValue(): float
     {
         return (float) Helpers::validatePositiveInt(
-            Manifest::get('tasks.queue.backlog-per-task', 100),
-            'tasks.queue.backlog-per-task',
+            Manifest::get('tasks.queue.autoscaling.backlog-per-task', 100),
+            'tasks.queue.autoscaling.backlog-per-task',
         );
     }
 

--- a/src/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrap.php
+++ b/src/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrap.php
@@ -25,7 +25,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * across policies, so asserting "at least one while there's backlog" never fights
  * the backlog policy's higher number and never ratchets up on a long backlog.
  *
- * Only provisioned when the queue's floor is zero (`tasks.queue.min: 0`); a queue
+ * Only provisioned when the queue's floor is zero (`tasks.queue.autoscaling.min: 0`); a queue
  * with a standing floor never sits at zero, so it needs no bootstrap. Both the
  * policy and the alarm are pure upserts, so this is a reconciler, not a Resource.
  */

--- a/src/Resources/ApplicationAutoScaling/ScalableTarget.php
+++ b/src/Resources/ApplicationAutoScaling/ScalableTarget.php
@@ -4,7 +4,6 @@ namespace Codinglabs\Yolo\Resources\ApplicationAutoScaling;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Change;
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Resources\Ecs\EcsCluster;
@@ -14,10 +13,9 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * The Application Auto Scaling scalable target that hands an ECS service's
- * desired count to scaling policies. Group-aware: the web target's bounds come
- * from `tasks.web.autoscaling.min/max` (autoscaling is opt-in for web), the queue
- * target's from `tasks.queue.min/max` (a standalone queue is always autoscaled,
- * and its floor may be 0 — scale to zero).
+ * desired count to scaling policies. Group-aware: both groups' bounds come from
+ * their own `tasks.{group}.autoscaling.min/max` (Manifest::autoscalingMin/Max) —
+ * web defaults 1/4 (min always ≥ 1), the queue 1/10 (min may be 0 to scale to zero).
  *
  * Like Dashboard this is a standalone reconciler, NOT a Resource:
  * App Auto Scaling targets aren't RGT-taggable (so they carry none of the
@@ -52,23 +50,12 @@ class ScalableTarget
 
     public function min(): int
     {
-        if ($this->group === ServerGroup::QUEUE) {
-            // A standalone queue's floor may be 0 (scale to zero) — that's the opt-in
-            // — unless it also hosts the scheduler, where Manifest::queueMin floors it
-            // at 1 so cron isn't killed when the queue idles to zero.
-            return Manifest::queueMin();
-        }
-
-        return Helpers::validatePositiveInt(Manifest::get('tasks.web.autoscaling.min', 1), 'tasks.web.autoscaling.min');
+        return Manifest::autoscalingMin($this->group);
     }
 
     public function max(): int
     {
-        if ($this->group === ServerGroup::QUEUE) {
-            return Helpers::validatePositiveInt(Manifest::get('tasks.queue.max', 10), 'tasks.queue.max');
-        }
-
-        return Helpers::validatePositiveInt(Manifest::get('tasks.web.autoscaling.max', 4), 'tasks.web.autoscaling.max');
+        return Manifest::autoscalingMax($this->group);
     }
 
     /**

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -165,7 +165,7 @@ class Dashboard
      */
     public function resolveContext(): array
     {
-        $web = Manifest::has('tasks.web');
+        $web = Manifest::hasWeb();
 
         return [
             'region' => Manifest::get('region'),

--- a/src/Resources/Ecs/EcsService.php
+++ b/src/Resources/Ecs/EcsService.php
@@ -252,14 +252,14 @@ class EcsService implements Resource
     }
 
     /**
-     * The desired count to create the service at. The queue starts at its
-     * autoscaling floor (Manifest::queueMin) — 0 when it scales to zero, so a fresh
-     * idle queue costs nothing, but ≥1 when the queue also hosts the scheduler (cron
-     * can't ride a task that idles to zero). Web and the scheduler start at one task.
+     * The desired count to create the service at. An autoscaling queue starts at its
+     * floor (Manifest::queueMin) — 0 when it scales to zero, so a fresh idle queue
+     * costs nothing; a fixed queue (autoscaling: false) and web and the scheduler all
+     * start at one task.
      */
     protected function initialDesiredCount(): int
     {
-        if ($this->group === ServerGroup::QUEUE) {
+        if ($this->group === ServerGroup::QUEUE && Manifest::autoscales(ServerGroup::QUEUE)) {
             return Manifest::queueMin();
         }
 

--- a/src/ShutdownTimings.php
+++ b/src/ShutdownTimings.php
@@ -112,8 +112,9 @@ final class ShutdownTimings
      * graceful-stop window. Placement is by task presence, not flags: the web
      * server and (when enabled) ssr are always web; the queue worker and the
      * scheduler ride whichever container hosts them (Manifest::queueHost /
-     * schedulerHost). Every app runs all three roles somewhere, so a plain web
-     * app's web container runs web + queue + scheduler. The `web` program is
+     * schedulerHost), or nowhere when switched off (tasks.queue / tasks.scheduler:
+     * false → a null host). A plain web app's web container runs web + queue +
+     * scheduler; disabling either drops it from every container. The `web` program is
      * Octane by default, or FrankenPHP classic mode when tasks.web.octane is off
      * (ProcessCommands::web) — its grace is the same either way.
      *

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -14,6 +14,8 @@ use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Illuminate\Filesystem\Filesystem;
+use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Resources\ElastiCache\CacheCluster;
 use Codinglabs\Yolo\Resources\CloudFront\AssetDistribution;
 
@@ -72,15 +74,18 @@ class ConfigureEnvAndVersionStep implements Step
             'AWS_DEFAULT_REGION' => Manifest::get('region'),
         ];
 
-        // Every web app runs a queue worker somewhere — bundled in the web container
-        // or its own standalone service (queue:work always runs; there's no opt-out)
-        // — so wire the connection to the queue YOLO provisions for it (it owns the
-        // name + URL, so the app can't point at the wrong one); the task role carries
-        // the access. Solo has one queue; multitenancy resolves the per-tenant queue
-        // at runtime, so SQS_QUEUE is not pinned for it. A non-web app has no worker,
-        // so force `sync` rather than route to a queue nothing consumes (the framework
-        // default of `database` has the same no-worker pitfall).
-        if (Manifest::has('tasks.web')) {
+        // QUEUE_CONNECTION is one value baked into the one image every task shares
+        // (web + queue + scheduler), so it follows WORKER presence, not web presence:
+        // wherever a queue:work runs — bundled in the web container, a standalone
+        // tasks.queue, or a headless worker — point the connection at the SQS queue
+        // YOLO provisions (it owns the name + URL so the app can't target the wrong
+        // one; the task role carries access), so producers (web requests, scheduled
+        // jobs) and the worker share one queue. Solo pins SQS_QUEUE; multitenancy
+        // resolves the per-tenant queue at runtime, so it isn't pinned. With no worker
+        // anywhere (tasks.queue: false, or a worker-less app) jobs would pile into a
+        // queue nothing drains, so force `sync` (run inline at dispatch) — and ENFORCE
+        // it: a non-sync override would silently break, so hard-fail rather than ship.
+        if (Manifest::queueHost() instanceof ServerGroup) {
             $defaults['QUEUE_CONNECTION'] = 'sqs';
             $defaults['SQS_PREFIX'] = sprintf('https://sqs.%s.amazonaws.com/%s', Manifest::get('region'), Aws::accountId());
 
@@ -88,6 +93,8 @@ class ConfigureEnvAndVersionStep implements Step
                 $defaults['SQS_QUEUE'] = Helpers::keyedResourceName();
             }
         } else {
+            $this->ensureSyncQueueConnection($envPath);
+
             $defaults['QUEUE_CONNECTION'] = 'sync';
         }
 
@@ -172,6 +179,47 @@ class ConfigureEnvAndVersionStep implements Step
         }
 
         return preg_match('/^' . preg_quote($key, '/') . '=/m', (string) $this->filesystem->get($path)) === 1;
+    }
+
+    /**
+     * Hard-fail the build when no queue worker runs (tasks.queue: false, or a
+     * worker-less app) yet the app's own .env pins QUEUE_CONNECTION to anything but
+     * `sync`. With no worker, any other connection dispatches into a queue nothing
+     * drains; YOLO can't fix it by injecting `sync` (its default is skipped once the
+     * key is set, and phpdotenv is first-wins), so it would otherwise ship a silently
+     * broken build. The usual intent is a bundled worker — point the way out.
+     */
+    protected function ensureSyncQueueConnection(string $envPath): void
+    {
+        $connection = $this->envValue($envPath, 'QUEUE_CONNECTION');
+
+        if ($connection !== null && $connection !== 'sync') {
+            throw new IntegrityCheckException(sprintf(
+                'QUEUE_CONNECTION is "%s" but no queue worker runs (tasks.queue: false, or no worker tier). '
+                . 'Jobs dispatched to "%s" would never be processed. Set QUEUE_CONNECTION=sync, or omit '
+                . 'tasks.queue to bundle a worker in the web container.',
+                $connection,
+                $connection,
+            ));
+        }
+    }
+
+    /**
+     * The value the app's staged .env defines for $key, or null when the key is
+     * absent (or the file doesn't exist yet). Surrounding quotes and whitespace are
+     * stripped so the comparison is on the bare value.
+     */
+    protected function envValue(string $path, string $key): ?string
+    {
+        if (! $this->filesystem->exists($path)) {
+            return null;
+        }
+
+        if (preg_match('/^' . preg_quote($key, '/') . '=(.*)$/m', (string) $this->filesystem->get($path), $matches) === 1) {
+            return trim($matches[1], " \t\"'");
+        }
+
+        return null;
     }
 
     protected function generateValues(array $values): string

--- a/src/Steps/Build/Fargate/CheckOctaneInstalledStep.php
+++ b/src/Steps/Build/Fargate/CheckOctaneInstalledStep.php
@@ -44,7 +44,7 @@ class CheckOctaneInstalledStep implements Step
         // worker-only app has no web role, and an app that opts out with
         // `tasks.web.octane: false` runs FrankenPHP classic mode, which needs no
         // octane package — so neither requires this check.
-        if (! Manifest::has('tasks.web') || ! Manifest::usesOctane()) {
+        if (! Manifest::hasWeb() || ! Manifest::usesOctane()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Build/Fargate/CheckSchedulerRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckSchedulerRuntimeStep.php
@@ -5,16 +5,19 @@ namespace Codinglabs\Yolo\Steps\Build\Fargate;
 use Closure;
 use RuntimeException;
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Enums\ServerGroup;
 use Symfony\Component\Process\Process;
 use Codinglabs\Yolo\Resources\Ecr\EcrRepository;
 
 /**
- * Every app hosts the scheduler somewhere (Manifest::schedulerHost — there's no
- * opt-out), and the scheduler program is supercronic (ProcessCommands::scheduler).
- * This probes the freshly-built image for the supercronic binary and hard-fails
- * the build — before the push — if it can't find one.
+ * The scheduler runs somewhere in almost every app (Manifest::schedulerHost),
+ * driven by supercronic (ProcessCommands::scheduler). This probes the freshly-built
+ * image for the supercronic binary and hard-fails the build — before the push — if
+ * it can't find one. Skipped only when cron is switched off entirely
+ * (tasks.scheduler: false → a null host), where no container runs supercronic.
  *
  * The hard fail earns its place because the failure it prevents is silent:
  * busybox crond, the cron the base image ships for free, can't run as a non-root
@@ -35,6 +38,12 @@ class CheckSchedulerRuntimeStep implements Step
 
     public function __invoke(array $options): StepResult
     {
+        // No host runs the scheduler (tasks.scheduler: false) → the image needn't carry
+        // supercronic, so there's nothing to probe.
+        if (! Manifest::schedulerHost() instanceof ServerGroup) {
+            return StepResult::SKIPPED;
+        }
+
         $image = sprintf('%s:%s', (new EcrRepository())->uri(), Arr::get($options, 'app-version'));
 
         if (($this->probe ?? $this->imageHasSupercronic(...))($image)) {

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -63,9 +63,12 @@ class GenerateSupervisorConfigStep implements Step
             $this->writeConfig('docker/supervisord.queue.conf', ServerGroup::QUEUE);
         }
 
-        // The scheduler runs cron in some container of every app, so the crontab it
-        // reads is always generated (the standalone scheduler service runs supercronic too).
-        $this->writeCrontab();
+        // The crontab supercronic reads is generated wherever the scheduler runs —
+        // every app unless cron is switched off entirely (tasks.scheduler: false), where
+        // schedulerHost() is null and no container runs supercronic, so it's skipped.
+        if (Manifest::schedulerHost() instanceof ServerGroup) {
+            $this->writeCrontab();
+        }
 
         return StepResult::SUCCESS;
     }

--- a/src/Steps/Sync/App/SyncQueueScalableTargetStep.php
+++ b/src/Steps/Sync/App/SyncQueueScalableTargetStep.php
@@ -8,7 +8,7 @@ use Codinglabs\Yolo\Enums\ServerGroup;
 
 /**
  * Registers and reconciles the standalone queue service's scalable target — the
- * 0→N capacity bounds (`tasks.queue.min`/`max`, min default 0) the queue's
+ * 0→N capacity bounds (`tasks.queue.autoscaling.min`/`max`, min default 1) the queue's
  * policies move within. Wired into sync:app only when tasks.queue extracts the
  * queue into its own service.
  */

--- a/src/Steps/Sync/App/SyncQueueScaleToZeroAlarmStep.php
+++ b/src/Steps/Sync/App/SyncQueueScaleToZeroAlarmStep.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Enums\ServerGroup;
@@ -14,7 +15,7 @@ use Codinglabs\Yolo\Resources\ApplicationAutoScaling\QueueScaleToZeroBootstrap;
 /**
  * Provisions the queue's 0→1 bootstrap (a step-scaling policy + a "queue has
  * messages" alarm) — but only when the queue actually scales to zero
- * (`tasks.queue.min: 0`). A queue with a standing floor never sits at zero, so it
+ * (`tasks.queue.autoscaling.min: 0`). A queue with a standing floor never sits at zero, so it
  * needs no bootstrap and this step skips. Wired into sync:app only when
  * tasks.queue is set.
  */
@@ -24,9 +25,12 @@ class SyncQueueScaleToZeroAlarmStep implements Step
 
     public function __invoke(array $options): StepResult
     {
-        // Only meaningful for a scale-to-zero queue, and only once its scalable
-        // target exists (the bootstrap policy attaches to it).
-        if ((new ScalableTarget(ServerGroup::QUEUE))->min() !== 0 || ! (new EcsService(ServerGroup::QUEUE))->exists()) {
+        // Only meaningful for a scale-to-zero queue: the queue must autoscale
+        // (a fixed single task never idles to zero), its floor must be 0, and its
+        // scalable target must exist (the bootstrap policy attaches to it).
+        if (! Manifest::autoscales(ServerGroup::QUEUE)
+            || (new ScalableTarget(ServerGroup::QUEUE))->min() !== 0
+            || ! (new EcsService(ServerGroup::QUEUE))->exists()) {
             return StepResult::SKIPPED;
         }
 

--- a/src/Steps/Sync/App/SyncQueueScalingPolicyStep.php
+++ b/src/Steps/Sync/App/SyncQueueScalingPolicyStep.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Enums\ServerGroup;
@@ -24,6 +25,12 @@ class SyncQueueScalingPolicyStep implements Step
 
     public function __invoke(array $options): StepResult
     {
+        // Off when the queue runs a fixed single task (autoscaling: false) — the
+        // scalable target's deregistration cascades this policy away, so just skip.
+        if (! Manifest::autoscales(ServerGroup::QUEUE)) {
+            return StepResult::SKIPPED;
+        }
+
         if (! (new EcsService(ServerGroup::QUEUE))->exists()) {
             return StepResult::SKIPPED;
         }

--- a/src/Steps/Sync/App/SyncScalableTargetStep.php
+++ b/src/Steps/Sync/App/SyncScalableTargetStep.php
@@ -62,12 +62,12 @@ class SyncScalableTargetStep implements Step
         $target = new ScalableTarget($this->group());
         $live = $target->current();
 
-        if (! Manifest::isAutoscaling()) {
+        if (! Manifest::autoscales($this->group())) {
             if ($live === null) {
                 return StepResult::SKIPPED;
             }
 
-            $this->recordChanges([Change::make('web autoscaling', sprintf('%d-%d', $live['min'], $live['max']), null)]);
+            $this->recordChanges([Change::make($this->group()->value . ' autoscaling', sprintf('%d-%d', $live['min'], $live['max']), null)]);
 
             if (! $dryRun) {
                 $target->deregister();

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -228,9 +228,9 @@ it('accepts the known shape of every task group', function (): void {
                 'health-check' => ['timeout' => 8], 'autoscaling' => ['min' => 1, 'max' => 4],
             ],
             'queue' => [
-                'min' => 1, 'max' => 10, 'backlog-per-task' => 100, 'cpu' => '256',
-                'memory' => '512', 'spot' => true, 'shutdown-grace-period' => 70,
-                'enable-execute-command' => false,
+                'autoscaling' => ['min' => 1, 'max' => 10, 'backlog-per-task' => 100],
+                'cpu' => '256', 'memory' => '512', 'spot' => true,
+                'shutdown-grace-period' => 70, 'enable-execute-command' => false,
             ],
             'scheduler' => [
                 'cpu' => '256', 'memory' => '512', 'shutdown-grace-period' => 10,
@@ -255,20 +255,20 @@ it('bails on an unrecognised key inside a task group', function (): void {
 it('bails when the scheduler rides a queue explicitly set to scale to zero', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 0]],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeFalse();
 
     $output = test()->promptOutput->fetch();
-    expect($output)->toContain('tasks.queue.min');
+    expect($output)->toContain('tasks.queue.autoscaling.min');
     expect($output)->toContain('tasks.scheduler');
 });
 
 it('accepts a scheduler-hosting queue with a standing floor of one', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 1]],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 1]]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();
@@ -277,7 +277,7 @@ it('accepts a scheduler-hosting queue with a standing floor of one', function ()
 it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();
@@ -286,7 +286,7 @@ it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)',
 it('accepts a scale-to-zero queue when the scheduler is its own service', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 0], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]], 'scheduler' => true],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();

--- a/tests/Unit/Commands/RollbackCommandTest.php
+++ b/tests/Unit/Commands/RollbackCommandTest.php
@@ -50,7 +50,7 @@ function queueOnlyManifest(): void
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['queue' => []],
+        'tasks' => ['queue' => true],
     ]);
 }
 

--- a/tests/Unit/Commands/ScaleCommandTest.php
+++ b/tests/Unit/Commands/ScaleCommandTest.php
@@ -68,7 +68,7 @@ it('queue: writes tasks.queue bounds and registers, allowing a zero floor', func
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     $ecs = [];
@@ -84,15 +84,15 @@ it('queue: writes tasks.queue bounds and registers, allowing a zero floor', func
     invokeScale(options: ['queue' => true, 'min' => '0', 'max' => '20']);
 
     expect(collect($aa)->firstWhere('name', 'RegisterScalableTarget')['args'])->toMatchArray(['MinCapacity' => 0, 'MaxCapacity' => 20]);
-    expect(Manifest::get('tasks.queue.min'))->toBe(0);
-    expect(Manifest::get('tasks.queue.max'))->toBe(20);
+    expect(Manifest::get('tasks.queue.autoscaling.min'))->toBe(0);
+    expect(Manifest::get('tasks.queue.autoscaling.max'))->toBe(20);
 });
 
-it('queue: rejects a fixed desired count (always autoscaling-managed)', function (): void {
+it('queue: rejects a fixed desired count (autoscaling-managed)', function (): void {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     $ecs = [];
@@ -109,7 +109,7 @@ it('fixed: sets the ECS desired count directly when no scalable target exists', 
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     $ecs = [];

--- a/tests/Unit/Commands/ServicesCommandTest.php
+++ b/tests/Unit/Commands/ServicesCommandTest.php
@@ -63,7 +63,7 @@ it('summarises an offer for the table', function (): void {
 });
 
 it('reports the service state as json', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld(offeringTypesense(claims: ['convict' => ['typesense']], clusters: ['convict' => true]), $captured);
@@ -78,7 +78,7 @@ it('reports the service state as json', function (): void {
 });
 
 it('adds a service offer and uploads the env manifest', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld(['manifest' => "domain: example.com\nservices: {}\n", 'claims' => [], 'clusters' => []], $captured);
@@ -93,7 +93,7 @@ it('adds a service offer and uploads the env manifest', function (): void {
 });
 
 it('refuses to withdraw a service a running app still uses', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld(offeringTypesense(claims: ['convict' => ['typesense']], clusters: ['convict' => true]), $captured);
@@ -105,7 +105,7 @@ it('refuses to withdraw a service a running app still uses', function (): void {
 });
 
 it('withdraws an unused service offer', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld(offeringTypesense(claims: [], clusters: []), $captured);
@@ -119,7 +119,7 @@ it('withdraws an unused service offer', function (): void {
 });
 
 it('rejects offering an app-side-only service', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld(['manifest' => "domain: example.com\nservices: {}\n", 'claims' => [], 'clusters' => []], $captured);

--- a/tests/Unit/Commands/SyncAppSchedulerAdvisoryTest.php
+++ b/tests/Unit/Commands/SyncAppSchedulerAdvisoryTest.php
@@ -8,7 +8,7 @@ it('gives no advisory for a dedicated scheduler service', function (): void {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['autoscaling' => ['max' => 4]], 'scheduler' => []],
+        'tasks' => ['web' => ['autoscaling' => ['max' => 4]], 'scheduler' => true],
     ]);
 
     expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
@@ -18,7 +18,7 @@ it('gives no advisory when the web host that bundles the scheduler does not auto
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
@@ -40,10 +40,42 @@ it('advises onOneServer when the scheduler rides the standalone queue (always au
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     expect(SyncAppCommand::schedulerAdvisory())
         ->toContain('onOneServer()')
         ->toContain('queue');
+});
+
+it('gives no onOneServer advisory when the scheduler is disabled', function (): void {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => ['max' => 4]], 'scheduler' => false],
+    ]);
+
+    expect(SyncAppCommand::schedulerAdvisory())->toBeNull();
+});
+
+it('warns that cron runs nowhere when the scheduler is disabled', function (): void {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'scheduler' => false],
+    ]);
+
+    expect(SyncAppCommand::schedulerDisabledWarning())
+        ->toContain('scheduler is disabled')
+        ->toContain('runs nowhere');
+});
+
+it('gives no disabled warning when the scheduler runs', function (): void {
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true],
+    ]);
+
+    expect(SyncAppCommand::schedulerDisabledWarning())->toBeNull();
 });

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -73,7 +73,7 @@ it('constructs every declared step with just the environment string', function (
             expect(new $stepName('testing'))->toBeInstanceOf(Step::class);
         });
 })->with([
-    'solo web app' => [['domain' => 'codinglabs.com.au', 'tasks' => ['web' => []]]],
+    'solo web app' => [['domain' => 'codinglabs.com.au', 'tasks' => ['web' => true]]],
     'multi-tenant app' => [['tenants' => ['alpha' => []]]],
 ]);
 
@@ -139,7 +139,7 @@ it('keys each scope distinctly so no scope is dropped on merge', function (): vo
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'domain' => 'codinglabs.com.au',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     $scopes = array_keys((new SyncCommand())->scopes());

--- a/tests/Unit/Concerns/ResolvesServerGroupsTest.php
+++ b/tests/Unit/Concerns/ResolvesServerGroupsTest.php
@@ -27,7 +27,7 @@ beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -102,7 +102,7 @@ describe('cache + session defaults', function (): void {
     it('defaults web apps to the shared redis cache and redis sessions', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
 
         expect(Manifest::cacheStore())->toBe('redis');
@@ -119,7 +119,7 @@ describe('cache + session defaults', function (): void {
     it('respects explicit cache.store and session.driver overrides', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
             'cache' => ['store' => 'file'],
             'session' => ['driver' => 'cookie'],
         ]);
@@ -133,7 +133,7 @@ describe('octane', function (): void {
     it('defaults to running octane when tasks.web.octane is unset', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
 
         expect(Manifest::usesOctane())->toBeTrue();
@@ -186,13 +186,22 @@ describe('autoscaling', function (): void {
         expect(Manifest::isAutoscaling())->toBeFalse();
     });
 
-    it('is off without an autoscaling key', function (): void {
+    it('is on by default for an enabled web tier with no autoscaling key', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
 
-        expect(Manifest::isAutoscaling())->toBeFalse();
+        expect(Manifest::isAutoscaling())->toBeTrue();
+    });
+
+    it('rejects an empty autoscaling object', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => ['autoscaling' => []]],
+        ]);
+
+        expect(fn (): bool => Manifest::isAutoscaling())->toThrow(IntegrityCheckException::class);
     });
 });
 
@@ -215,10 +224,19 @@ describe('metrics caddyfile', function (): void {
         expect(Manifest::usesMetricsCaddyfile())->toBeFalse();
     });
 
-    it('does not apply without autoscaling', function (): void {
+    it('applies by default for an Octane web tier (autoscaling on by default)', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
+        ]);
+
+        expect(Manifest::usesMetricsCaddyfile())->toBeTrue();
+    });
+
+    it('does not apply when autoscaling is explicitly off', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'tasks' => ['web' => ['autoscaling' => false]],
         ]);
 
         expect(Manifest::usesMetricsCaddyfile())->toBeFalse();
@@ -326,19 +344,19 @@ describe('apex', function (): void {
 
 describe('server groups', function (): void {
     it('lists only web for a plain web app', function (): void {
-        writeManifest(['tasks' => ['web' => []]]);
+        writeManifest(['tasks' => ['web' => true]]);
 
         expect(Manifest::serverGroups())->toBe([ServerGroup::WEB]);
     });
 
     it('lists web, queue and scheduler when both are extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true, 'scheduler' => true]]);
 
         expect(Manifest::serverGroups())->toBe([ServerGroup::WEB, ServerGroup::QUEUE, ServerGroup::SCHEDULER]);
     });
 
     it('does not list a bundled queue as its own group', function (): void {
-        writeManifest(['tasks' => ['web' => []]]);
+        writeManifest(['tasks' => ['web' => true]]);
 
         expect(Manifest::serverGroups())->toBe([ServerGroup::WEB]);
         expect(Manifest::hasStandaloneQueue())->toBeFalse();
@@ -346,7 +364,7 @@ describe('server groups', function (): void {
     });
 
     it('detects a standalone queue and lists it as its own group', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
 
         expect(Manifest::hasStandaloneQueue())->toBeTrue();
         expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
@@ -355,28 +373,28 @@ describe('server groups', function (): void {
 
 describe('queue and scheduler hosts', function (): void {
     it('bundles both the queue worker and the scheduler into web for a plain web app', function (): void {
-        writeManifest(['tasks' => ['web' => []]]);
+        writeManifest(['tasks' => ['web' => true]]);
 
         expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
         expect(Manifest::schedulerHost())->toBe(ServerGroup::WEB);
     });
 
     it('rides the scheduler on the standalone queue when only the queue is extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
 
         expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
         expect(Manifest::schedulerHost())->toBe(ServerGroup::QUEUE);
     });
 
     it('keeps the queue worker in web but gives the scheduler its own service when only the scheduler is extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'scheduler' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'scheduler' => true]]);
 
         expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
         expect(Manifest::schedulerHost())->toBe(ServerGroup::SCHEDULER);
     });
 
     it('gives each role its own container when both are extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true, 'scheduler' => true]]);
 
         expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
         expect(Manifest::schedulerHost())->toBe(ServerGroup::SCHEDULER);
@@ -384,20 +402,20 @@ describe('queue and scheduler hosts', function (): void {
 });
 
 describe('queue floor', function (): void {
-    it('defaults a standalone queue to scale to zero when the scheduler is extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
-
-        expect(Manifest::queueMin())->toBe(0);
-    });
-
-    it('defaults a scheduler-hosting queue to a floor of one', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+    it('defaults a standalone queue floor to one (no accidental scale-to-zero)', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => true, 'scheduler' => true]]);
 
         expect(Manifest::queueMin())->toBe(1);
     });
 
-    it('honours an explicit queue min', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => ['min' => 3], 'scheduler' => []]]);
+    it('opts into scale-to-zero with an explicit autoscaling min of zero', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]], 'scheduler' => true]]);
+
+        expect(Manifest::queueMin())->toBe(0);
+    });
+
+    it('honours an explicit queue autoscaling min', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 3]], 'scheduler' => true]]);
 
         expect(Manifest::queueMin())->toBe(3);
     });
@@ -405,32 +423,173 @@ describe('queue floor', function (): void {
 
 describe('deploy group', function (): void {
     it('runs deploy hooks on web for a plain web app', function (): void {
-        writeManifest(['tasks' => ['web' => []]]);
+        writeManifest(['tasks' => ['web' => true]]);
 
         expect(Manifest::deployGroup())->toBe(ServerGroup::WEB);
     });
 
     it('runs deploy hooks on a standalone queue when there is no standalone scheduler', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
 
         expect(Manifest::deployGroup())->toBe(ServerGroup::QUEUE);
     });
 
     it('runs deploy hooks on a standalone scheduler when one is extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'scheduler' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'scheduler' => true]]);
 
         expect(Manifest::deployGroup())->toBe(ServerGroup::SCHEDULER);
     });
 
     it('prefers the scheduler over the queue when both are extracted', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => [], 'scheduler' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true, 'scheduler' => true]]);
 
         expect(Manifest::deployGroup())->toBe(ServerGroup::SCHEDULER);
     });
 
     it('tracks the scheduler host — deploy hooks run on the management tier', function (): void {
-        writeManifest(['tasks' => ['web' => [], 'queue' => []]]);
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
 
         expect(Manifest::deployGroup())->toBe(Manifest::schedulerHost());
+    });
+
+    it('still resolves a deploy group when the scheduler is disabled', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => true, 'scheduler' => false]]);
+
+        expect(Manifest::schedulerHost())->toBeNull();
+        expect(Manifest::deployGroup())->toBe(ServerGroup::QUEUE);
+    });
+});
+
+describe('three-state queue and scheduler', function (): void {
+    it('extracts a standalone queue with `true`', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
+
+        expect(Manifest::hasStandaloneQueue())->toBeTrue();
+        expect(Manifest::queueDisabled())->toBeFalse();
+        expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
+    });
+
+    it('extracts a standalone queue with a config object', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => ['cpu' => 512]]]);
+
+        expect(Manifest::hasStandaloneQueue())->toBeTrue();
+        expect(Manifest::queueHost())->toBe(ServerGroup::QUEUE);
+    });
+
+    it('disables the queue with `false` — it runs nowhere', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => false]]);
+
+        expect(Manifest::queueDisabled())->toBeTrue();
+        expect(Manifest::hasStandaloneQueue())->toBeFalse();
+        expect(Manifest::queueHost())->toBeNull();
+        expect(Manifest::serverGroups())->toBe([ServerGroup::WEB]);
+    });
+
+    it('keeps the scheduler in web when only the queue is disabled', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => false]]);
+
+        expect(Manifest::schedulerHost())->toBe(ServerGroup::WEB);
+    });
+
+    it('disables the scheduler with `false` — cron runs nowhere', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'scheduler' => false]]);
+
+        expect(Manifest::schedulerDisabled())->toBeTrue();
+        expect(Manifest::hasStandaloneScheduler())->toBeFalse();
+        expect(Manifest::schedulerHost())->toBeNull();
+        expect(Manifest::queueHost())->toBe(ServerGroup::WEB);
+    });
+
+    it('returns a null queue host for a worker-less headless app', function (): void {
+        writeManifest(['tasks' => ['scheduler' => true]]);
+
+        expect(Manifest::queueHost())->toBeNull();
+    });
+
+    it('rejects an empty queue block', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => []]]);
+
+        expect(fn (): bool => Manifest::hasStandaloneQueue())
+            ->toThrow(IntegrityCheckException::class);
+    });
+
+    it('rejects an empty scheduler block', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'scheduler' => []]]);
+
+        expect(fn (): bool => Manifest::hasStandaloneScheduler())
+            ->toThrow(IntegrityCheckException::class);
+    });
+
+    it('rejects a non-boolean scalar queue value', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => 'yes']]);
+
+        expect(fn (): bool => Manifest::hasStandaloneQueue())
+            ->toThrow(IntegrityCheckException::class);
+    });
+
+    it('treats web: false as a headless app with no web service', function (): void {
+        writeManifest(['tasks' => ['web' => false, 'queue' => true]]);
+
+        expect(Manifest::hasWeb())->toBeFalse();
+        expect(Manifest::webDisabled())->toBeTrue();
+        expect(Manifest::serverGroups())->toBe([ServerGroup::QUEUE]);
+    });
+
+    it('rejects an empty web block', function (): void {
+        writeManifest(['tasks' => ['web' => []]]);
+
+        expect(fn (): bool => Manifest::hasWeb())
+            ->toThrow(IntegrityCheckException::class);
+    });
+});
+
+describe('unified autoscaling', function (): void {
+    it('autoscales an enabled web tier by default — min 1, max 4', function (): void {
+        writeManifest(['tasks' => ['web' => true]]);
+
+        expect(Manifest::autoscales(ServerGroup::WEB))->toBeTrue();
+        expect(Manifest::autoscalingMin(ServerGroup::WEB))->toBe(1);
+        expect(Manifest::autoscalingMax(ServerGroup::WEB))->toBe(4);
+    });
+
+    it('autoscales an enabled standalone queue by default — min 1, max 10', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => true]]);
+
+        expect(Manifest::autoscales(ServerGroup::QUEUE))->toBeTrue();
+        expect(Manifest::autoscalingMin(ServerGroup::QUEUE))->toBe(1);
+        expect(Manifest::autoscalingMax(ServerGroup::QUEUE))->toBe(10);
+    });
+
+    it('turns autoscaling off for either group with autoscaling: false', function (): void {
+        writeManifest(['tasks' => ['web' => ['autoscaling' => false], 'queue' => ['autoscaling' => false]]]);
+
+        expect(Manifest::autoscales(ServerGroup::WEB))->toBeFalse();
+        expect(Manifest::autoscales(ServerGroup::QUEUE))->toBeFalse();
+    });
+
+    it('honours bespoke bounds from an autoscaling object', function (): void {
+        writeManifest(['tasks' => ['web' => ['autoscaling' => ['min' => 3, 'max' => 9]]]]);
+
+        expect(Manifest::autoscalingMin(ServerGroup::WEB))->toBe(3);
+        expect(Manifest::autoscalingMax(ServerGroup::WEB))->toBe(9);
+    });
+
+    it('rejects a web autoscaling min below one', function (): void {
+        writeManifest(['tasks' => ['web' => ['autoscaling' => ['min' => 0]]]]);
+
+        expect(fn (): int => Manifest::autoscalingMin(ServerGroup::WEB))
+            ->toThrow(IntegrityCheckException::class);
+    });
+
+    it('allows a queue autoscaling min of zero (scale to zero)', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]]]]);
+
+        expect(Manifest::autoscalingMin(ServerGroup::QUEUE))->toBe(0);
+    });
+
+    it('never autoscales the scheduler', function (): void {
+        writeManifest(['tasks' => ['web' => true, 'scheduler' => true]]);
+
+        expect(Manifest::autoscales(ServerGroup::SCHEDULER))->toBeFalse();
     });
 });

--- a/tests/Unit/Resources/ApplicationAutoScaling/QueueBacklogPolicyTest.php
+++ b/tests/Unit/Resources/ApplicationAutoScaling/QueueBacklogPolicyTest.php
@@ -6,7 +6,7 @@ use Codinglabs\Yolo\Resources\ApplicationAutoScaling\QueueBacklogPolicy;
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 });
 
@@ -33,7 +33,7 @@ it('tracks backlog-per-task with metric math dividing visible messages by runnin
 it('reads the backlog-per-task target from the manifest', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['backlog-per-task' => 40]],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['backlog-per-task' => 40]]],
     ]);
 
     expect((new QueueBacklogPolicy())->configuration()['TargetValue'])->toBe(40.0);

--- a/tests/Unit/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrapTest.php
+++ b/tests/Unit/Resources/ApplicationAutoScaling/QueueScaleToZeroBootstrapTest.php
@@ -6,7 +6,7 @@ use Codinglabs\Yolo\Resources\ApplicationAutoScaling\QueueScaleToZeroBootstrap;
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 0]],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]]],
     ]);
 });
 

--- a/tests/Unit/Resources/ApplicationAutoScaling/ScalableTargetTest.php
+++ b/tests/Unit/Resources/ApplicationAutoScaling/ScalableTargetTest.php
@@ -87,21 +87,21 @@ it('reports drift but does not register on a dry-run', function (): void {
     expect(collect($captured)->pluck('name'))->not->toContain('RegisterScalableTarget');
 });
 
-it('builds the queue service resource id and defaults its floor to zero when the scheduler is extracted', function (): void {
+it('builds the queue service resource id and defaults its bounds to 1/10', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     expect(ScalableTarget::resourceId(ServerGroup::QUEUE))->toBe('service/yolo-testing-my-app/yolo-testing-my-app-queue');
-    expect((new ScalableTarget(ServerGroup::QUEUE))->min())->toBe(0);
+    expect((new ScalableTarget(ServerGroup::QUEUE))->min())->toBe(1);
     expect((new ScalableTarget(ServerGroup::QUEUE))->max())->toBe(10);
 });
 
 it('floors the queue at one task when it also hosts the scheduler', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     // No dedicated scheduler service → the scheduler rides the queue, so it can't
@@ -112,7 +112,7 @@ it('floors the queue at one task when it also hosts the scheduler', function ():
 it('registers the queue target with a zero floor (scale to zero)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['min' => 0, 'max' => 20], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0, 'max' => 20]], 'scheduler' => true],
     ]);
 
     $captured = [];

--- a/tests/Unit/Resources/Iam/DeployerPolicyTest.php
+++ b/tests/Unit/Resources/Iam/DeployerPolicyTest.php
@@ -14,7 +14,7 @@ function statementFor(array $document, string $action): array
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 
@@ -82,7 +82,7 @@ it('scopes UpdateService and RunTask to this app\'s cluster resources', function
 it('widens UpdateService scope to the standalone queue and scheduler services when extracted', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     $statement = statementFor((new DeployerPolicy())->document(), 'ecs:UpdateService');

--- a/tests/Unit/ShutdownTimingsTest.php
+++ b/tests/Unit/ShutdownTimingsTest.php
@@ -12,7 +12,7 @@ beforeEach(function (): void {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 
@@ -49,7 +49,7 @@ it('runs the web server alone in the web container when both queue and scheduler
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     expect(ShutdownTimings::programGraces(ServerGroup::WEB))->toBe(['web' => 10]);
@@ -69,7 +69,7 @@ it('runs the scheduler and queue worker together in a standalone queue container
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     // Queue extracted, scheduler not — so the scheduler rides the queue container,
@@ -82,7 +82,7 @@ it('runs the queue worker alone in its container when the scheduler is its own s
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     expect(ShutdownTimings::programGraces(ServerGroup::QUEUE))->toBe(['queue' => 70]);
@@ -93,7 +93,7 @@ it('honours a standalone scheduler shutdown-grace-period override', function ():
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => ['shutdown-grace-period' => 30]],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => ['shutdown-grace-period' => 30]],
     ]);
 
     expect(ShutdownTimings::programGraces(ServerGroup::SCHEDULER))->toBe(['scheduler' => 30]);
@@ -104,7 +104,7 @@ it('honours a standalone queue shutdown-grace-period override', function (): voi
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => true],
     ]);
 
     expect(ShutdownTimings::programGraces(ServerGroup::QUEUE))->toBe(['queue' => 90]);
@@ -141,7 +141,7 @@ it('drops the ALB drain window from the web stop timeout when headless', functio
     // Scheduler extracted so the drain track is what sizes the budget.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'scheduler' => true],
     ]);
 
     // no drain window: 0 + max(web 10, queue 70) + 5 buffer.
@@ -188,7 +188,7 @@ describe('standalone services', function (): void {
     it('sizes a queue-only stop timeout as the grace plus buffer (no ALB drain, no scheduler)', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+            'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
         ]);
 
         // 70 (default queue grace) + 5 buffer; no ALB drain, no co-hosted scheduler.
@@ -198,7 +198,7 @@ describe('standalone services', function (): void {
     it('sizes a queue+scheduler stop timeout as the slower of the two overlapped stops', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => []],
+            'tasks' => ['web' => true, 'queue' => true],
         ]);
 
         // supervisord signals queue:work and supercronic together; the budget is
@@ -209,7 +209,7 @@ describe('standalone services', function (): void {
     it('sizes a scheduler-only stop timeout as its grace plus buffer', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+            'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
         ]);
 
         expect(ShutdownTimings::stopTimeoutFor(ServerGroup::SCHEDULER))->toBe(120);
@@ -218,7 +218,7 @@ describe('standalone services', function (): void {
     it('rejects a standalone grace that overcommits the Fargate stop ceiling', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 200], 'scheduler' => []],
+            'tasks' => ['web' => true, 'queue' => ['shutdown-grace-period' => 200], 'scheduler' => true],
         ]);
 
         expect(fn (): int => ShutdownTimings::stopTimeoutFor(ServerGroup::QUEUE))

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -6,6 +6,7 @@ use Codinglabs\Yolo\Paths;
 use GuzzleHttp\Psr7\Response;
 use Aws\Command as AwsCommand;
 use Aws\S3\Exception\S3Exception;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Steps\Build\ConfigureEnvAndVersionStep;
 
 function rebuildEnvFixture(array $config): void
@@ -107,7 +108,7 @@ it('does not inject AWS_BUCKET when the manifest does not define one', function 
 it('wires the SQS connection for every web app (the worker always runs somewhere)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     if (! is_dir(Paths::build())) {
@@ -140,7 +141,12 @@ it('forces QUEUE_CONNECTION=sync for a non-web app (no worker to consume)', func
     expect($env)->toContain('AWS_DEFAULT_REGION=ap-southeast-2');
 });
 
-it('respects a QUEUE_CONNECTION already set in the .env', function (): void {
+it('respects a QUEUE_CONNECTION already set in the .env when a worker runs', function (): void {
+    // A worker exists (web app), so YOLO's sqs default yields to a developer override.
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true],
+    ]);
     file_put_contents(Paths::build('.env.testing'), "QUEUE_CONNECTION=redis\n");
 
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
@@ -152,10 +158,53 @@ it('respects a QUEUE_CONNECTION already set in the .env', function (): void {
     expect($env)->not->toContain('QUEUE_CONNECTION=sync');
 });
 
+it('forces QUEUE_CONNECTION=sync when the queue is disabled (tasks.queue: false)', function (): void {
+    // A worker would otherwise be bundled in web, but tasks.queue: false switches it
+    // off entirely — so jobs must run inline.
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => false],
+    ]);
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=sync');
+    expect($env)->not->toContain('QUEUE_CONNECTION=sqs');
+    expect($env)->not->toContain('SQS_PREFIX=');
+});
+
+it('wires the SQS connection for a headless standalone queue (a worker with no web tier)', function (): void {
+    // The connection follows the worker, not the web tier: a headless app whose only
+    // service is a standalone queue still consumes SQS.
+    rebuildEnvFixture([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['queue' => true],
+    ]);
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=sqs');
+    expect($env)->toContain('SQS_PREFIX=https://sqs.ap-southeast-2.amazonaws.com/111111111111');
+    expect($env)->toContain('SQS_QUEUE=yolo-testing-my-app');
+});
+
+it('hard-fails when QUEUE_CONNECTION is non-sync but no worker runs', function (): void {
+    // No worker (the default no-tasks manifest) + a non-sync override = jobs black-holed,
+    // so the build refuses rather than shipping a silently broken image.
+    file_put_contents(Paths::build('.env.testing'), "QUEUE_CONNECTION=redis\n");
+
+    expect(fn (): mixed => (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']))
+        ->toThrow(IntegrityCheckException::class);
+});
+
 it('does not pin SQS_QUEUE for a multitenant app (worker resolves it per tenant)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
         'tenants' => ['acme' => ['domain' => 'acme.test']],
     ]);
 
@@ -230,7 +279,7 @@ it('does not wire cache or session for a non-web app (no tasks.web)', function (
 it('defaults a web app to the shared redis cache and redis sessions when neither is set', function (): void {
     rebuildEnvFixture([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
@@ -249,7 +298,7 @@ it('defaults a web app to the shared redis cache and redis sessions when neither
 it('does not inject OCTANE_SERVER — the app owns it (seeded by yolo init)', function (): void {
     rebuildEnvFixture([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
@@ -290,7 +339,7 @@ it('enables Inertia SSR when tasks.web.ssr is on', function (): void {
 it('does not enable Inertia SSR when tasks.web.ssr is off', function (): void {
     rebuildEnvFixture([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);

--- a/tests/Unit/Steps/Build/Fargate/BuildDockerImageStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/BuildDockerImageStepTest.php
@@ -7,7 +7,7 @@ use Codinglabs\Yolo\Steps\Build\Fargate\BuildDockerImageStep;
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 

--- a/tests/Unit/Steps/Build/Fargate/CheckMetricsRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckMetricsRuntimeStepTest.php
@@ -13,7 +13,7 @@ beforeEach(function (): void {
 it('skips without probing the image when the web tier is not autoscaling', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     // A probe that throws proves the step short-circuits before running the image.

--- a/tests/Unit/Steps/Build/Fargate/CheckOctaneInstalledStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckOctaneInstalledStepTest.php
@@ -20,7 +20,7 @@ function writeComposerLock(array $packages, array $devPackages = []): void
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 
@@ -33,7 +33,7 @@ afterEach(function (): void {
 it('skips without reading composer.lock for a worker-only app', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['queue' => []],
+        'tasks' => ['queue' => true],
     ]);
 
     // No composer.lock on disk — proof the step short-circuits before touching it.

--- a/tests/Unit/Steps/Build/Fargate/CheckSchedulerRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckSchedulerRuntimeStepTest.php
@@ -6,7 +6,7 @@ use Codinglabs\Yolo\Steps\Build\Fargate\CheckSchedulerRuntimeStep;
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 
@@ -17,12 +17,25 @@ it('passes when the built image has supercronic', function (): void {
 });
 
 it('hard-fails when the built image has no supercronic', function (): void {
-    // Every app hosts the scheduler somewhere (there's no opt-out), so the check
-    // is unconditional — no manifest key turns it off.
+    // The scheduler runs in the web container here (the default), so supercronic
+    // is required — a missing binary fails the build.
     $step = new CheckSchedulerRuntimeStep('testing', probe: fn (): false => false);
 
     expect(fn (): StepResult => $step(['app-version' => '26.24.1.1200']))
         ->toThrow(RuntimeException::class, 'no supercronic binary');
+});
+
+it('skips the supercronic probe when the scheduler is disabled', function (): void {
+    // tasks.scheduler: false → cron runs nowhere, so the image needn't carry
+    // supercronic; the probe never runs (a failing probe would otherwise throw).
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'scheduler' => false],
+    ]);
+
+    $step = new CheckSchedulerRuntimeStep('testing', probe: fn (): false => false);
+
+    expect($step(['app-version' => '26.24.1.1200']))->toBe(StepResult::SKIPPED);
 });
 
 it('probes the built image tag', function (): void {

--- a/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckSsrRuntimeStepTest.php
@@ -13,7 +13,7 @@ beforeEach(function (): void {
 it('skips without probing the image when ssr is off', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     // A probe that throws proves the step short-circuits before running the image.

--- a/tests/Unit/Steps/Build/Fargate/CheckYoloInstalledStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/CheckYoloInstalledStepTest.php
@@ -25,7 +25,7 @@ function writeYoloComposerLock(array $packages, array $devPackages = []): void
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 });
 

--- a/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
@@ -7,7 +7,7 @@ beforeEach(function (): void {
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     if (is_file(Paths::build('.yolo-entrypoint.sh'))) {
@@ -26,7 +26,7 @@ it('starts with a shebang and fails fast through the deploy-all hooks', function
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
         'deploy-all' => ['php artisan migrate --force', 'php artisan config:cache'],
     ]);
 
@@ -75,7 +75,7 @@ it('runs a standalone queue under supervisord when it co-hosts the scheduler', f
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     $script = generatedEntrypointScript();
@@ -94,7 +94,7 @@ it('runs a standalone queue as a single worker process when the scheduler is its
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     $script = generatedEntrypointScript();
@@ -109,7 +109,7 @@ it('adds a scheduler branch running cron when the scheduler is its own service',
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'scheduler' => true],
     ]);
 
     $script = generatedEntrypointScript();
@@ -128,7 +128,7 @@ it('drains for the web shutdown-grace-period before forwarding the stop', functi
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'scheduler' => true],
     ]);
 
     expect(generatedEntrypointScript())->toContain("sleep 10\n");
@@ -138,7 +138,7 @@ it('tracks the manifest web shutdown-grace-period for the drain duration', funct
     writeManifest([
         'apex' => 'example.com',
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => []],
+        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => true],
     ]);
 
     expect(generatedEntrypointScript())->toContain("sleep 45\n");
@@ -147,7 +147,7 @@ it('tracks the manifest web shutdown-grace-period for the drain duration', funct
 it('omits the ALB drain window when headless — no target to drain', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => []],
+        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => true],
     ]);
 
     $script = generatedEntrypointScript();

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -6,7 +6,9 @@ use Codinglabs\Yolo\Steps\Build\Fargate\GenerateSupervisorConfigStep;
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        // The process-tree baseline is a fixed web tier; the autoscaling cases
+        // (saturation emitter, metrics Caddyfile) opt in explicitly below.
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     if (is_file(Paths::build('docker/supervisord.conf'))) {
@@ -115,7 +117,7 @@ it('bundles octane, the scheduler and the queue worker into the web config for a
 it('runs octane alone in the web config when both queue and scheduler are extracted', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -128,7 +130,7 @@ it('runs octane alone in the web config when both queue and scheduler are extrac
 it('drops the scheduler from the web config when it has its own service, keeping the bundled queue', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'scheduler' => true],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -141,7 +143,7 @@ it('drops the scheduler from the web config when it has its own service, keeping
 it('writes a second supervisord config for a standalone queue that hosts the scheduler', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => []],
+        'tasks' => ['web' => true, 'queue' => true],
     ]);
 
     (new GenerateSupervisorConfigStep('testing'))();
@@ -162,7 +164,7 @@ it('writes a second supervisord config for a standalone queue that hosts the sch
 it('writes no queue supervisord config when the standalone queue is a single process', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     (new GenerateSupervisorConfigStep('testing'))();
@@ -171,7 +173,7 @@ it('writes no queue supervisord config when the standalone queue is a single pro
     expect(is_file(Paths::build('docker/supervisord.queue.conf')))->toBeFalse();
 });
 
-it('writes a crontab firing schedule:run each minute (the scheduler always runs somewhere)', function (): void {
+it('writes a crontab firing schedule:run each minute wherever the scheduler runs', function (): void {
     (new GenerateSupervisorConfigStep('testing'))();
 
     $crontab = file_get_contents(Paths::build('docker/crontab'));
@@ -181,10 +183,23 @@ it('writes a crontab firing schedule:run each minute (the scheduler always runs 
     expect($crontab)->toContain("* * * * * cd /app && php artisan schedule:run\n");
 });
 
+it('writes no crontab when the scheduler is disabled', function (): void {
+    // tasks.scheduler: false → cron runs nowhere, so the crontab the image would
+    // never read is not generated.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'scheduler' => false],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    expect(is_file(Paths::build('docker/crontab')))->toBeFalse();
+});
+
 it('uses the web shutdown-grace-period for octanes stop wait', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 25], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => ['shutdown-grace-period' => 25], 'queue' => true, 'scheduler' => true],
     ]);
 
     // Octane is the only program in the web config here (queue + scheduler extracted),
@@ -195,7 +210,7 @@ it('uses the web shutdown-grace-period for octanes stop wait', function (): void
 it('honours a standalone queue shutdown-grace-period override', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => ['shutdown-grace-period' => 90], 'scheduler' => true],
     ]);
 
     (new GenerateSupervisorConfigStep('testing'))();

--- a/tests/Unit/Steps/Deploy/EnsureInSyncStepTest.php
+++ b/tests/Unit/Steps/Deploy/EnsureInSyncStepTest.php
@@ -34,7 +34,7 @@ function inSyncStep(int $exitCode, string $planOutput = ''): EnsureInSyncStep
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     Helpers::app()->instance('output', new BufferedOutput());

--- a/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
@@ -10,7 +10,7 @@ describe('serviceNeedsUpdate', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
             'domain' => 'codinglabs.com.au',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
     });
 
@@ -60,7 +60,7 @@ describe('serviceNeedsUpdate when headless', function (): void {
     beforeEach(function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
     });
 
@@ -86,7 +86,7 @@ describe('updatePayload', function (): void {
     it('omits healthCheckGracePeriodSeconds when headless', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
 
         // which require live AWS lookups, so we can't fully invoke it here. updatePayload is
@@ -118,7 +118,7 @@ describe('updatePayload', function (): void {
     it('never includes desiredCount — capacity is set once at create, never reset on update', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => []],
+            'tasks' => ['web' => true],
         ]);
 
         expect((new EcsService())->updatePayload())->not->toHaveKey('desiredCount');
@@ -129,7 +129,7 @@ describe('deploymentConfiguration', function (): void {
     beforeEach(function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+            'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
         ]);
     });
 

--- a/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskDefinitionStepTest.php
@@ -81,7 +81,7 @@ it('maps no port for a headless worker group (queue/scheduler)', function (): vo
 it('sizes queue and scheduler smaller by default than web', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => [], 'queue' => [], 'scheduler' => []],
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
     ]);
 
     bindMockIamClient([

--- a/tests/Unit/Steps/Iam/EcsTaskRolePoliciesStepTest.php
+++ b/tests/Unit/Steps/Iam/EcsTaskRolePoliciesStepTest.php
@@ -20,7 +20,7 @@ function attachedPolicies(array $arns): Result
 beforeEach(function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
         'task-role-policies' => [EXTRA_POLICY],
     ]);
 });
@@ -54,7 +54,7 @@ it('detaches a policy dropped from the manifest, never the baseline', function (
     // must detach it (and leave the baseline alone).
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => true],
     ]);
 
     $captured = [];

--- a/tests/Unit/Steps/Sync/App/SyncQueueScaleToZeroAlarmStepTest.php
+++ b/tests/Unit/Steps/Sync/App/SyncQueueScaleToZeroAlarmStepTest.php
@@ -1,0 +1,60 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\SyncQueueScaleToZeroAlarmStep;
+
+it('skips and provisions nothing when the queue is not autoscaling', function (): void {
+    // tasks.queue.autoscaling: false → a fixed single task that never idles to zero,
+    // so there is no 0→1 deadlock to bootstrap.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => false]],
+    ]);
+
+    $aa = [];
+    $cw = [];
+    bindMockApplicationAutoScalingClient(['DescribeScalingPolicies' => new Result(['ScalingPolicies' => []])], $aa);
+    bindMockCloudWatchClient(['DescribeAlarms' => new Result(['MetricAlarms' => []])], $cw);
+
+    expect((new SyncQueueScaleToZeroAlarmStep())([]))->toBe(StepResult::SKIPPED);
+    expect(collect($aa)->pluck('name'))->not->toContain('PutScalingPolicy');
+    expect(collect($cw)->pluck('name'))->not->toContain('PutMetricAlarm');
+});
+
+it('skips a queue with a standing floor (not scale-to-zero)', function (): void {
+    // queue: true → autoscaling on with the default floor of 1, so it never sits at
+    // zero and needs no bootstrap.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => true],
+    ]);
+
+    expect((new SyncQueueScaleToZeroAlarmStep())([]))->toBe(StepResult::SKIPPED);
+});
+
+it('provisions the 0→1 bootstrap for a scale-to-zero queue whose service exists', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]]],
+    ]);
+
+    $alarmArn = 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-queue-has-messages';
+    $ecs = [];
+    $aa = [];
+    $cw = [];
+    bindRoutedEcsClient(['DescribeServices' => new Result(['services' => [['status' => 'ACTIVE', 'serviceArn' => 'arn']]])], $ecs);
+    bindMockApplicationAutoScalingClient([
+        'DescribeScalingPolicies' => new Result(['ScalingPolicies' => []]),
+        'PutScalingPolicy' => new Result(['PolicyARN' => 'arn:aws:autoscaling:ap-southeast-2:111111111111:scalingPolicy:x']),
+    ], $aa);
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => [
+            ['AlarmName' => 'yolo-testing-my-app-queue-has-messages', 'AlarmArn' => $alarmArn],
+        ]]),
+        'ListTagsForResource' => new Result(['Tags' => []]),
+    ], $cw);
+
+    expect((new SyncQueueScaleToZeroAlarmStep())([]))->toBe(StepResult::CREATED);
+    expect(collect($aa)->pluck('name'))->toContain('PutScalingPolicy');
+});

--- a/tests/Unit/Steps/Sync/App/SyncQueueScalingPolicyStepTest.php
+++ b/tests/Unit/Steps/Sync/App/SyncQueueScalingPolicyStepTest.php
@@ -1,0 +1,47 @@
+<?php
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\SyncQueueScalingPolicyStep;
+
+beforeEach(function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => true],
+    ]);
+});
+
+it('skips and provisions nothing when the queue is not autoscaling', function (): void {
+    // tasks.queue.autoscaling: false → a fixed single task; the backlog policy is
+    // torn down by the scalable target's deregistration, so this step just skips.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => ['autoscaling' => false]],
+    ]);
+
+    $aa = [];
+    bindMockApplicationAutoScalingClient(['DescribeScalingPolicies' => new Result(['ScalingPolicies' => []])], $aa);
+
+    expect((new SyncQueueScalingPolicyStep())([]))->toBe(StepResult::SKIPPED);
+    expect(collect($aa)->pluck('name'))->not->toContain('PutScalingPolicy');
+});
+
+it('skips when the queue service does not exist yet', function (): void {
+    $ecs = [];
+    bindRoutedEcsClient(['DescribeServices' => new Result(['services' => []])], $ecs);
+
+    expect((new SyncQueueScalingPolicyStep())([]))->toBe(StepResult::SKIPPED);
+});
+
+it('creates the backlog policy when the queue autoscales and its service exists', function (): void {
+    $ecs = [];
+    $aa = [];
+    bindRoutedEcsClient(['DescribeServices' => new Result(['services' => [['status' => 'ACTIVE', 'serviceArn' => 'arn']]])], $ecs);
+    bindMockApplicationAutoScalingClient([
+        'DescribeScalingPolicies' => new Result(['ScalingPolicies' => []]),
+        'PutScalingPolicy' => new Result(['PolicyARN' => 'arn:aws:autoscaling:ap-southeast-2:111111111111:scalingPolicy:x']),
+    ], $aa);
+
+    expect((new SyncQueueScalingPolicyStep())([]))->toBe(StepResult::CREATED);
+    expect(collect($aa)->pluck('name'))->toContain('PutScalingPolicy');
+});

--- a/tests/Unit/Steps/Sync/App/SyncScalableTargetStepTest.php
+++ b/tests/Unit/Steps/Sync/App/SyncScalableTargetStepTest.php
@@ -74,7 +74,7 @@ it('deregisters the target when the autoscaling block is removed', function (): 
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     $ecs = [];
@@ -93,7 +93,7 @@ it('would-deregister on a dry-run without deregistering', function (): void {
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     $ecs = [];
@@ -112,7 +112,7 @@ it('skips when autoscaling is removed and no target is registered', function ():
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     $ecs = [];

--- a/tests/Unit/Steps/Sync/App/SyncScalingPoliciesStepTest.php
+++ b/tests/Unit/Steps/Sync/App/SyncScalingPoliciesStepTest.php
@@ -139,7 +139,7 @@ it('skips entirely when autoscaling is removed from the manifest', function (): 
     writeManifest([
         'account-id' => '111111111111',
         'region' => 'ap-southeast-2',
-        'tasks' => ['web' => []],
+        'tasks' => ['web' => ['autoscaling' => false]],
     ]);
 
     $aa = [];

--- a/tests/Unit/Steps/Sync/App/SyncWebBurstStepTest.php
+++ b/tests/Unit/Steps/Sync/App/SyncWebBurstStepTest.php
@@ -6,11 +6,11 @@ use Codinglabs\Yolo\Steps\Sync\App\SyncWebBurstStep;
 
 function burstManifest(bool $on): void
 {
-    // Burst is part of web autoscaling — "off" is a web tier with no autoscaling block
-    // (no scalable target), which is what triggers a teardown.
+    // Burst is part of web autoscaling — "off" is an explicit `autoscaling: false`
+    // web tier (no scalable target), which is what triggers a teardown.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => $on ? ['autoscaling' => ['min' => 2, 'max' => 8]] : []],
+        'tasks' => ['web' => $on ? ['autoscaling' => ['min' => 2, 'max' => 8]] : ['autoscaling' => false]],
     ]);
 }
 

--- a/tests/Unit/Tui/ServicesPanelTest.php
+++ b/tests/Unit/Tui/ServicesPanelTest.php
@@ -15,7 +15,7 @@ it('maps lifecycle states to theme colours', function (): void {
 });
 
 it('renders the gate as a themed table, with the live typesense cluster detail', function (): void {
-    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => []]]);
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'tasks' => ['web' => true]]);
 
     $captured = [];
     bindServiceLifecycleWorld([


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Resolves [LPX-691](https://linear.app/codinglabsau/issue/LPX-691) and [LPX-693](https://linear.app/codinglabsau/issue/LPX-693) — one coherent change: **a consistent `true | false | {config}` API across all three task groups, plus a unified `autoscaling` knob for web & queue.**

**What problems are you solving?**

- **Consistent group API.** `tasks.web`, `tasks.queue`, `tasks.scheduler` all now accept `true | false | {config}` (the boolean-or-object form of `tasks.web.ssr`). `false` switches a group off: `web: false` = headless, `queue: false` / `scheduler: false` = the role runs nowhere. An empty block (`queue:`) or empty object (`{}`) is **rejected** — write `true`. Previously detection was presence-based (`Arr::has`), so `tasks.queue: false` silently did the *opposite* of intent.
- **Unified autoscaling (web + queue).** Both share `autoscaling: true | false | {min, max, …}`, **bolted on by default** — opt out with `autoscaling: false` (a fixed single task). Bounds unify under `tasks.{group}.autoscaling.{min,max}` (the queue's top-level `min`/`max`/`backlog-per-task` move there, killing the web-vs-queue key asymmetry). Web `min` must be ≥ 1; queue `min` ≥ 0 (0 = scale-to-zero + 0→1 bootstrap).
- **Fixed a latent `QUEUE_CONNECTION` bug.** It's one value baked into the one shared image, so it must follow **worker presence, not web presence** — `sqs` wherever a worker runs (incl. headless worker/scheduler apps that previously baked `sync` and black-holed jobs), `sync` only when nothing drains the queue. When the queue is disabled, `sync` is **enforced** (a non-sync override hard-fails the build).
- **Scheduler-disable guarded.** `sync` warns (cron runs nowhere → framework/package maintenance silently stops); the supercronic preflight + crontab generation are skipped.

**Is there anything the reviewer needs to know to deploy this?**

- ⚠️ **Web autoscales by default now** (was opt-in). Any web app without `autoscaling: false` will provision a scalable target + concurrency/CPU policies + burst on its **next `yolo sync`**. This is the intended "bolted on" behaviour and arguably safer (no accidental single-task web apps), but it's the key thing to know before merge.
- **No other behaviour change for existing manifests** beyond the headless-worker `QUEUE_CONNECTION` fix (was a bug). Bundled queue/scheduler, `tasks.queue: true`/`{…}`, etc. all resolve as before.
- `Manifest::queueHost()` / `schedulerHost()` are now nullable (null = runs nowhere); `deployGroup()` decoupled so it always resolves to a real tier.
- **Known limitation — [LPX-692](https://linear.app/codinglabsau/issue/LPX-692):** flipping an *already-provisioned* standalone queue/scheduler to `false` doesn't tear down the live ECS service (orphaned, exactly as removing the block does today). YOLO has no ECS-service-delete capability yet; it's split out. The common path (bundled → `false`) is fully clean.
- Quality stack green: **1228 tests pass**, Rector clean, Pint formatted, PHPStan (level 5) no errors. Docs updated (`manifest.md`, `scaling.md`, `images.md`, `commands.md`, `domains.md`).

🤖 Generated with [Claude Code](https://claude.ai/code)
