### PR TITLE
feat(fargate): CPU-priority ordering in combined containers — emitter > web/ssr > background

### DIFF
--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -98,7 +98,18 @@ tasks:
 - **The scheduler** runs [supercronic](https://github.com/aptible/supercronic), firing `php artisan schedule:run` every minute, bundled until you extract it. (YOLO uses cron, not `schedule:work`, so the scheduler survives `SIGTERM` cleanly — supercronic stops scheduling on stop and waits out the in-flight run.)
 - **`ssr: true`** adds Inertia's SSR renderer — see [Inertia SSR](#inertia-ssr) below.
 
-When the web server shares a container with the queue worker and/or scheduler, those background programs are launched under `nice -n 19` so the request path always wins CPU under contention — a heavy scheduled job or queue batch can't starve Octane and spike user-facing latency. `nice` only biases the kernel scheduler when CPU is saturated, so under the normal case the background work still runs at full speed; it reallocates CPU rather than capping it, so the burst still shows on the CloudWatch CPU metric, it just no longer hits web latency. This applies only to the combined container — a web-only, queue-only, or scheduler-only service (the split-service topology below) runs its programs at normal priority, since there's no shared CPU to arbitrate.
+### CPU priority within the container
+
+Where these programs share one container they share one Fargate CPU quota, so YOLO orders them by `nice` priority to keep the kernel scheduler arbitrating contention in the app's favour:
+
+```
+saturation emitter (highest)  >  web ≈ ssr  >  queue, scheduler (lowest)
+```
+
+- **The queue worker and scheduler** are launched under `nice -n 19` when bundled with the web server, so a heavy scheduled job or queue batch can't starve Octane and spike user-facing latency.
+- **The burst saturation emitter** (the sidecar that reports worker saturation to drive [burst step-scaling](/guide/scaling), present when the web tier autoscales) is the *highest* priority. If it were starved by the very saturation it reports, burst scaling would never trip exactly when it's needed. An unprivileged process can only *raise* its `nice`, never lower it, so the emitter stays at `nice 0` and the request path (web + ssr) is niced a few points below it — invisible to request latency, since the emitter is runnable for only milliseconds per cycle. This needs no `CAP_SYS_NICE` or task-definition `ulimit`.
+
+`nice` only biases the scheduler when CPU is saturated, so under the normal case every program still runs at full speed; it reallocates CPU rather than capping it, so a burst still shows on the CloudWatch CPU metric, it just no longer hits web latency. A web-only, queue-only, or scheduler-only service (the split-service topology below) keeps the same ordering for whatever it co-locates — and a single-role container with nothing to arbitrate runs at normal priority.
 
 ::: tip Independent task groups
 Run web in isolation by extracting the **worker tier**: add a top-level `tasks.queue` block and the queue worker and scheduler move to their own service, leaving the web container running just the web server. Add `tasks.scheduler` too for a dedicated singleton cron. Where each role runs is derived from which blocks you've added; see [Where each role runs](/reference/manifest#where-each-role-runs) and [Scaling](/guide/scaling).

--- a/docs/guide/images.md
+++ b/docs/guide/images.md
@@ -98,6 +98,8 @@ tasks:
 - **The scheduler** runs [supercronic](https://github.com/aptible/supercronic), firing `php artisan schedule:run` every minute, bundled until you extract it. (YOLO uses cron, not `schedule:work`, so the scheduler survives `SIGTERM` cleanly — supercronic stops scheduling on stop and waits out the in-flight run.)
 - **`ssr: true`** adds Inertia's SSR renderer — see [Inertia SSR](#inertia-ssr) below.
 
+When the web server shares a container with the queue worker and/or scheduler, those background programs are launched under `nice -n 19` so the request path always wins CPU under contention — a heavy scheduled job or queue batch can't starve Octane and spike user-facing latency. `nice` only biases the kernel scheduler when CPU is saturated, so under the normal case the background work still runs at full speed; it reallocates CPU rather than capping it, so the burst still shows on the CloudWatch CPU metric, it just no longer hits web latency. This applies only to the combined container — a web-only, queue-only, or scheduler-only service (the split-service topology below) runs its programs at normal priority, since there's no shared CPU to arbitrate.
+
 ::: tip Independent task groups
 Run web in isolation by extracting the **worker tier**: add a top-level `tasks.queue` block and the queue worker and scheduler move to their own service, leaving the web container running just the web server. Add `tasks.scheduler` too for a dedicated singleton cron. Where each role runs is derived from which blocks you've added; see [Where each role runs](/reference/manifest#where-each-role-runs) and [Scaling](/guide/scaling).
 :::

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -28,9 +28,37 @@ use Codinglabs\Yolo\Resources\ApplicationAutoScaling\WebBurstPolicy;
  * entrypoint exec's directly, with no supervisord config. The web config stays at
  * the path the scaffolded Dockerfile copies (docker/supervisord.conf); the queue
  * config rides along under docker/ via the Dockerfile's `COPY . /app`.
+ *
+ * When a container co-locates the web server with background programs (queue
+ * worker and/or scheduler), those background programs launch at a positive nice
+ * so the request path always wins CPU under contention — see config().
  */
 class GenerateSupervisorConfigStep implements Step
 {
+    /**
+     * The nice the background programs (queue worker, scheduler) launch at when
+     * they share a container with the web server, so the kernel scheduler favours
+     * the request path under CPU contention. +19 is the lowest priority an
+     * unprivileged user can set — background work effectively yields to web when
+     * CPU is saturated, yet still runs at full speed when it isn't (nice only
+     * biases the scheduler under contention). This reallocates CPU, it doesn't cap
+     * it: a queue/scheduler burst still shows on the CloudWatch CPU metric, it just
+     * no longer hits web latency. On a min-1 combined app, sustained web saturation
+     * that starves the queue is itself a scale-out signal the queue-depth alarm
+     * already covers.
+     */
+    private const int BACKGROUND_NICE = 19;
+
+    /**
+     * The programs that yield CPU priority to the web server when bundled alongside
+     * it. ssr is excluded — it renders the request path, so it stays at nice 0 with
+     * web — and so is the saturation emitter, whose burst metrics must report
+     * promptly to drive scale-out.
+     *
+     * @var list<string>
+     */
+    private const array BACKGROUND_PROGRAMS = ['scheduler', 'queue'];
+
     public function __construct(
         protected string $environment,
         protected $filesystem = new Filesystem()
@@ -87,6 +115,11 @@ class GenerateSupervisorConfigStep implements Step
     {
         $blocks = [$this->header()];
 
+        // The web server's presence in this container is what makes it the request
+        // path — programGraces only emits a 'web' grace for the web group — so it is
+        // exactly the co-location trigger for nicing the background programs below.
+        $colocatesWebServer = isset($graces['web']);
+
         // One block per program present in this container, in a stable order. Stop
         // waits come from ShutdownTimings so a program's graceful-stop window matches
         // the container stopTimeout derived from the same source.
@@ -100,7 +133,7 @@ class GenerateSupervisorConfigStep implements Step
         //  - queue     queue:work, with a longer stop wait so an in-flight job can finish
         foreach (['web', 'ssr', 'scheduler', 'queue'] as $program) {
             if (isset($graces[$program])) {
-                $blocks[] = $this->program($program, ProcessCommands::{$program}(), stopwaitsecs: $graces[$program]);
+                $blocks[] = $this->program($program, $this->command($program, $colocatesWebServer), stopwaitsecs: $graces[$program]);
             }
         }
 
@@ -235,6 +268,25 @@ class GenerateSupervisorConfigStep implements Step
             '[rpcinterface:supervisor]',
             'supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface',
         ]);
+    }
+
+    /**
+     * The shell command for a program's `command=` line. Background programs (queue
+     * worker, scheduler) are launched under `nice` when they share the container
+     * with the web server, so Octane keeps CPU priority under contention; the web
+     * server, ssr and any standalone (split-service) container run their commands
+     * unchanged. The container runs as www-data, and a positive nice (lowering
+     * priority) needs no privilege, so no CAP_SYS_NICE is involved.
+     */
+    protected function command(string $program, bool $colocatesWebServer): string
+    {
+        $command = ProcessCommands::{$program}();
+
+        if ($colocatesWebServer && in_array($program, self::BACKGROUND_PROGRAMS, true)) {
+            return sprintf('nice -n %d %s', self::BACKGROUND_NICE, $command);
+        }
+
+        return $command;
     }
 
     protected function program(string $name, string $command, int $stopwaitsecs = 10): string

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -29,9 +29,27 @@ use Codinglabs\Yolo\Resources\ApplicationAutoScaling\WebBurstPolicy;
  * the path the scaffolded Dockerfile copies (docker/supervisord.conf); the queue
  * config rides along under docker/ via the Dockerfile's `COPY . /app`.
  *
- * When a container co-locates the web server with background programs (queue
- * worker and/or scheduler), those background programs launch at a positive nice
- * so the request path always wins CPU under contention — see config().
+ * The web group runs a three-tier CPU-priority order so the kernel scheduler
+ * arbitrates contention in the app's favour (nice only bites when CPU is
+ * saturated — a no-op with spare capacity, so steady-state throughput is
+ * unchanged):
+ *
+ *     saturation (nice 0, highest)  >  web ≈ ssr  >  queue, scheduler (lowest)
+ *
+ *  - The burst saturation emitter must always be schedulable to report worker
+ *    saturation to CloudWatch — if it's starved exactly when the box is pinned,
+ *    burst step-scaling never trips and only slow CPU target-tracking rescues. It
+ *    stays at nice 0 (highest) because an unprivileged process can only RAISE its
+ *    nice, never lower it, so the request path is niced down to it rather than the
+ *    emitter up. The emitter is runnable only for milliseconds per cycle, so this
+ *    is invisible to request latency.
+ *  - The request path (web + ssr) is niced just below the emitter, but only when
+ *    the emitter shares its container (web autoscaling); otherwise it stays at the
+ *    default priority.
+ *  - Background work (queue worker, scheduler) is niced well below the request
+ *    path when co-located with it, so a heavy job can't starve the web tier.
+ *
+ * See config() / niceLevel() for the rendering.
  */
 class GenerateSupervisorConfigStep implements Step
 {
@@ -40,24 +58,42 @@ class GenerateSupervisorConfigStep implements Step
      * they share a container with the web server, so the kernel scheduler favours
      * the request path under CPU contention. +19 is the lowest priority an
      * unprivileged user can set — background work effectively yields to web when
-     * CPU is saturated, yet still runs at full speed when it isn't (nice only
-     * biases the scheduler under contention). This reallocates CPU, it doesn't cap
-     * it: a queue/scheduler burst still shows on the CloudWatch CPU metric, it just
-     * no longer hits web latency. On a min-1 combined app, sustained web saturation
-     * that starves the queue is itself a scale-out signal the queue-depth alarm
-     * already covers.
+     * CPU is saturated, yet still runs at full speed when it isn't. This reallocates
+     * CPU, it doesn't cap it: a queue/scheduler burst still shows on the CloudWatch
+     * CPU metric, it just no longer hits web latency. On a min-1 combined app,
+     * sustained web saturation that starves the queue is itself a scale-out signal
+     * the queue-depth alarm already covers.
      */
     private const int BACKGROUND_NICE = 19;
 
     /**
-     * The programs that yield CPU priority to the web server when bundled alongside
-     * it. ssr is excluded — it renders the request path, so it stays at nice 0 with
-     * web — and so is the saturation emitter, whose burst metrics must report
-     * promptly to drive scale-out.
+     * The nice the request path (web server, ssr renderer) launches at when the
+     * burst saturation emitter shares its container, leaving the emitter alone at
+     * nice 0 as the highest-priority process in the group. A small, deliberately
+     * minimal nudge: enough that the emitter is always picked promptly when it wakes
+     * (so it can sample and publish even while web + ssr peg a small box), far above
+     * the +19 background tier, and invisible to request latency. +2 is the lighter
+     * alternative; either holds the ordering.
+     */
+    private const int REQUEST_PATH_NICE = 3;
+
+    /**
+     * The programs niced below the web server when bundled alongside it.
      *
      * @var list<string>
      */
     private const array BACKGROUND_PROGRAMS = ['scheduler', 'queue'];
+
+    /**
+     * The request-path programs niced just below the saturation emitter when it
+     * shares their container, so the emitter is never starved by the very saturation
+     * it reports. Both contend for the box's CPU — Octane's workers and the SSR
+     * Node process — and neither can be treated as background, so the emitter is
+     * lifted above them instead.
+     *
+     * @var list<string>
+     */
+    private const array REQUEST_PATH_PROGRAMS = ['web', 'ssr'];
 
     public function __construct(
         protected string $environment,
@@ -120,6 +156,11 @@ class GenerateSupervisorConfigStep implements Step
         // exactly the co-location trigger for nicing the background programs below.
         $colocatesWebServer = isset($graces['web']);
 
+        // The burst saturation emitter rides only the web container, and only when the
+        // web tier autoscales. The same flag both adds the emitter below and nices the
+        // request path under it (niceLevel), so the two can't drift apart.
+        $bundlesEmitter = $group === ServerGroup::WEB && Manifest::isAutoscaling();
+
         // One block per program present in this container, in a stable order. Stop
         // waits come from ShutdownTimings so a program's graceful-stop window matches
         // the container stopTimeout derived from the same source.
@@ -133,13 +174,15 @@ class GenerateSupervisorConfigStep implements Step
         //  - queue     queue:work, with a longer stop wait so an in-flight job can finish
         foreach (['web', 'ssr', 'scheduler', 'queue'] as $program) {
             if (isset($graces[$program])) {
-                $blocks[] = $this->program($program, $this->command($program, $colocatesWebServer), stopwaitsecs: $graces[$program]);
+                $blocks[] = $this->program($program, $this->command($program, $colocatesWebServer, $bundlesEmitter), stopwaitsecs: $graces[$program]);
             }
         }
 
-        // The burst saturation emitter (web container only) — a stateless loop
-        // that needs no drain window, so a 1s stop wait is plenty.
-        if ($group === ServerGroup::WEB && Manifest::isAutoscaling()) {
+        // The burst saturation emitter (web container only) — a stateless loop that
+        // needs no drain window, so a 1s stop wait is plenty. It alone stays at nice 0:
+        // every other program in the group is niced below it (niceLevel) so it can
+        // always be scheduled to sample and report, even while the box is pinned.
+        if ($bundlesEmitter) {
             $blocks[] = $this->program('saturation', ProcessCommands::saturationEmitter(), stopwaitsecs: 1);
         }
 
@@ -271,22 +314,40 @@ class GenerateSupervisorConfigStep implements Step
     }
 
     /**
-     * The shell command for a program's `command=` line. Background programs (queue
-     * worker, scheduler) are launched under `nice` when they share the container
-     * with the web server, so Octane keeps CPU priority under contention; the web
-     * server, ssr and any standalone (split-service) container run their commands
-     * unchanged. The container runs as www-data, and a positive nice (lowering
-     * priority) needs no privilege, so no CAP_SYS_NICE is involved.
+     * The shell command for a program's `command=` line, wrapped in `nice` to place
+     * it in the web group's priority order (see the class docblock). The container
+     * runs as www-data and every nice applied here is positive (lowering priority),
+     * which needs no privilege — so no CAP_SYS_NICE or task-def ulimit is involved.
      */
-    protected function command(string $program, bool $colocatesWebServer): string
+    protected function command(string $program, bool $colocatesWebServer, bool $bundlesEmitter): string
     {
         $command = ProcessCommands::{$program}();
+        $nice = $this->niceLevel($program, $colocatesWebServer, $bundlesEmitter);
 
+        return $nice === null
+            ? $command
+            : sprintf('nice -n %d %s', $nice, $command);
+    }
+
+    /**
+     * The nice a program launches at, or null for the default priority. Background
+     * work yields to the request path when bundled with the web server; the request
+     * path in turn yields to the saturation emitter when that shares the container,
+     * so the emitter (always nice 0) is the highest-priority process in the group.
+     * The two tiers are independent program sets, so a container with no emitter just
+     * keeps the request path at the default priority above the background tier.
+     */
+    protected function niceLevel(string $program, bool $colocatesWebServer, bool $bundlesEmitter): ?int
+    {
         if ($colocatesWebServer && in_array($program, self::BACKGROUND_PROGRAMS, true)) {
-            return sprintf('nice -n %d %s', self::BACKGROUND_NICE, $command);
+            return self::BACKGROUND_NICE;
         }
 
-        return $command;
+        if ($bundlesEmitter && in_array($program, self::REQUEST_PATH_PROGRAMS, true)) {
+            return self::REQUEST_PATH_NICE;
+        }
+
+        return null;
     }
 
     protected function program(string $name, string $command, int $stopwaitsecs = 10): string

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -73,9 +73,11 @@ function generatedSupervisorConfig(): string
 }
 
 it('runs octane on the manifest port by default', function (): void {
+    // Non-autoscaling so the web command is the bare octane:start (no emitter → no
+    // request-path nice, no --caddyfile); the autoscaling forms are covered below.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['port' => 9000]],
+        'tasks' => ['web' => ['port' => 9000, 'autoscaling' => false]],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -89,9 +91,11 @@ it('defaults the octane port to 8000', function (): void {
 });
 
 it('runs frankenphp classic mode on the manifest port when tasks.web.octane is false', function (): void {
+    // Non-autoscaling so the web command is the bare classic launcher (no emitter → no
+    // request-path nice); the niced autoscaling form is covered below.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['octane' => false, 'port' => 9000]],
+        'tasks' => ['web' => ['octane' => false, 'port' => 9000, 'autoscaling' => false]],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -131,36 +135,23 @@ it('nices the bundled queue and scheduler so the web request path wins CPU under
 
 it('nices the bundled background programs in classic mode too', function (): void {
     // The web program is the request path whether it's Octane or FrankenPHP classic
-    // mode — the co-located background work yields to it either way.
+    // mode — the co-located background work yields to it either way. Non-autoscaling
+    // keeps it a clean two-tier (web at full priority, background niced).
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['octane' => false]],
+        'tasks' => ['web' => ['octane' => false, 'autoscaling' => false]],
     ]);
 
     $config = generatedSupervisorConfig();
 
     expect($config)->toContain('command=frankenphp php-server');
     expect($config)->not->toContain('nice -n 19 frankenphp');
+    expect($config)->not->toContain('nice -n 3 frankenphp');
     expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
     expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
 });
 
-it('keeps the bundled ssr renderer at full priority — it serves the request path', function (): void {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['ssr' => true]],
-    ]);
-
-    $config = generatedSupervisorConfig();
-
-    // ssr renders requests, so it stays at nice 0 beside web; queue + scheduler still nice.
-    expect($config)->toContain('command=php artisan inertia:start-ssr');
-    expect($config)->not->toContain('nice -n 19 php artisan inertia:start-ssr');
-    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
-    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
-});
-
-it('keeps the saturation emitter at full priority so burst metrics report promptly', function (): void {
+it('keeps the saturation emitter at the highest priority so burst metrics report promptly', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => true]],
@@ -168,21 +159,93 @@ it('keeps the saturation emitter at full priority so burst metrics report prompt
 
     $config = generatedSupervisorConfig();
 
-    // The emitter must publish promptly to drive scale-out, so it is not niced — but
-    // the co-located queue + scheduler in the same container still are.
+    // The emitter must always be schedulable to publish saturation, so it alone stays
+    // at nice 0 — every other program in the group is niced below it.
     expect($config)->toContain('command=php /app/docker/yolo-saturation.php');
     expect($config)->not->toContain('nice -n 19 php /app/docker/yolo-saturation.php');
+    expect($config)->not->toContain('nice -n 3 php /app/docker/yolo-saturation.php');
+
+    // The request path is niced just under the emitter; the background tier well below it.
+    expect($config)->toContain('command=nice -n 3 php artisan octane:start');
     expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
     expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
 });
 
-it('nices nothing in a web-only container when the worker tier is extracted', function (): void {
+it('orders the whole web group emitter > web/ssr > queue/scheduler when burst is bundled', function (): void {
+    // Grouped topology: web + ssr + queue + scheduler + the burst emitter all share
+    // the one web container, so all three priority tiers appear at once.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
+        'tasks' => ['web' => ['ssr' => true, 'autoscaling' => true]],
     ]);
 
-    // Octane alone — no co-located background work to arbitrate, so nothing is niced.
+    $config = generatedSupervisorConfig();
+
+    // Tier 0 — the emitter, never niced.
+    expect($config)->toContain('command=php /app/docker/yolo-saturation.php');
+    // Tier 1 — the request path (web + ssr), niced just below the emitter.
+    expect($config)->toContain('command=nice -n 3 php artisan octane:start');
+    expect($config)->toContain('command=nice -n 3 php artisan inertia:start-ssr');
+    // Tier 2 — background work, well below the request path.
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+});
+
+it('lifts the emitter above web and ssr in a separated-web container, leaving the standalone queue untouched', function (): void {
+    // Separated-web topology: the worker tier is extracted, so the web container holds
+    // only web + ssr + the emitter — but the emitter must still outrank the request path
+    // (its CPU contenders here are Octane and SSR, neither of which can be deprioritised
+    // as background).
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true, 'autoscaling' => true], 'queue' => true],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    $web = file_get_contents(Paths::build('docker/supervisord.conf'));
+    expect($web)->toContain('command=php /app/docker/yolo-saturation.php');
+    expect($web)->toContain('command=nice -n 3 php artisan octane:start');
+    expect($web)->toContain('command=nice -n 3 php artisan inertia:start-ssr');
+    expect($web)->not->toContain('[program:queue]');
+    expect($web)->not->toContain('[program:scheduler]');
+
+    // The standalone queue+scheduler service never carries the emitter, so web
+    // autoscaling must not leak any nice into it.
+    $queue = file_get_contents(Paths::build('docker/supervisord.queue.conf'));
+    expect($queue)->toContain('command=php artisan queue:work --tries=3 --max-time=3600');
+    expect($queue)->toContain('command=supercronic /app/docker/crontab');
+    expect($queue)->not->toContain('nice');
+});
+
+it('keeps web and ssr at full priority when no burst emitter shares the container', function (): void {
+    // Non-autoscaling: no emitter, so there's nothing to lift the request path under —
+    // web + ssr stay at the default priority (and ssr is never treated as background),
+    // only the queue/scheduler tier is niced.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true, 'autoscaling' => false]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('command=php artisan octane:start --host=0.0.0.0 --port=8000');
+    expect($config)->toContain('command=php artisan inertia:start-ssr');
+    expect($config)->not->toContain('nice -n 3');
+    expect($config)->not->toContain('nice -n 19 php artisan inertia:start-ssr');
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+});
+
+it('nices nothing in a web-only container when the worker tier is extracted and burst is off', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => false], 'queue' => true, 'scheduler' => true],
+    ]);
+
+    // Octane alone — no co-located background work to arbitrate and no emitter to outrank,
+    // so nothing is niced. (Autoscaling bundles the emitter and lifts web above it — see
+    // the separated-web ordering test above.)
     expect(generatedSupervisorConfig())->not->toContain('nice');
 });
 
@@ -310,9 +373,11 @@ it('honours a standalone queue shutdown-grace-period override', function (): voi
 });
 
 it('runs the inertia ssr renderer when tasks.web.ssr is enabled', function (): void {
+    // Non-autoscaling so the ssr command is bare (no emitter → no request-path nice); the
+    // niced autoscaling form is covered by the web-group ordering tests above.
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['ssr' => true]],
+        'tasks' => ['web' => ['ssr' => true, 'autoscaling' => false]],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -393,8 +458,9 @@ it('runs octane against the metrics Caddyfile via --caddyfile when autoscaling',
         'tasks' => ['web' => ['autoscaling' => true]],
     ]);
 
+    // Autoscaling bundles the burst emitter, so the web command is niced just below it.
     expect(generatedSupervisorConfig())
-        ->toContain('command=php artisan octane:start --host=0.0.0.0 --port=8000 --caddyfile=/app/docker/Caddyfile');
+        ->toContain('command=nice -n 3 php artisan octane:start --host=0.0.0.0 --port=8000 --caddyfile=/app/docker/Caddyfile');
 });
 
 it('writes no Caddyfile and passes no --caddyfile when the web tier is not autoscaling', function (): void {
@@ -414,7 +480,9 @@ it('writes no Caddyfile in classic mode even when autoscaling', function (): voi
     $config = generatedSupervisorConfig();
 
     // Classic mode runs frankenphp php-server, not octane:start — no Caddyfile, no flag.
-    expect($config)->toContain('command=frankenphp php-server');
+    // Autoscaling still bundles the emitter, so the web command is niced below it like
+    // any request-path program.
+    expect($config)->toContain('command=nice -n 3 frankenphp php-server');
     expect($config)->not->toContain('--caddyfile');
     expect(is_file(Paths::build('docker/Caddyfile')))->toBeFalse();
 });

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -107,11 +107,100 @@ it('bundles octane, the scheduler and the queue worker into the web config for a
 
     expect($config)->toContain('[program:web]');
     expect($config)->toContain('[program:scheduler]');
-    // The scheduler runs as cron, not a schedule:work daemon.
-    expect($config)->toContain('command=supercronic /app/docker/crontab');
+    // The scheduler runs as cron, not a schedule:work daemon. Bundled alongside the
+    // web server, it's niced so the request path wins CPU under contention (see the
+    // co-location tests below for the full nice contract).
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
     expect($config)->not->toContain('schedule:work');
     expect($config)->toContain('[program:queue]');
-    expect($config)->toContain('command=php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+});
+
+it('nices the bundled queue and scheduler so the web request path wins CPU under contention', function (): void {
+    // Plain web app: web + queue + scheduler share one container, so the background
+    // programs launch under nice while the web server keeps full CPU priority.
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+
+    // The web server is never niced — it's the request path the nicing protects.
+    expect($config)->toContain('command=php artisan octane:start --host=0.0.0.0 --port=8000');
+    expect($config)->not->toContain('nice -n 19 php artisan octane:start');
+});
+
+it('nices the bundled background programs in classic mode too', function (): void {
+    // The web program is the request path whether it's Octane or FrankenPHP classic
+    // mode — the co-located background work yields to it either way.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['octane' => false]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('command=frankenphp php-server');
+    expect($config)->not->toContain('nice -n 19 frankenphp');
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+});
+
+it('keeps the bundled ssr renderer at full priority — it serves the request path', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['ssr' => true]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // ssr renders requests, so it stays at nice 0 beside web; queue + scheduler still nice.
+    expect($config)->toContain('command=php artisan inertia:start-ssr');
+    expect($config)->not->toContain('nice -n 19 php artisan inertia:start-ssr');
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+});
+
+it('keeps the saturation emitter at full priority so burst metrics report promptly', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // The emitter must publish promptly to drive scale-out, so it is not niced — but
+    // the co-located queue + scheduler in the same container still are.
+    expect($config)->toContain('command=php /app/docker/yolo-saturation.php');
+    expect($config)->not->toContain('nice -n 19 php /app/docker/yolo-saturation.php');
+    expect($config)->toContain('command=nice -n 19 php artisan queue:work --tries=3 --max-time=3600');
+    expect($config)->toContain('command=nice -n 19 supercronic /app/docker/crontab');
+});
+
+it('nices nothing in a web-only container when the worker tier is extracted', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
+    ]);
+
+    // Octane alone — no co-located background work to arbitrate, so nothing is niced.
+    expect(generatedSupervisorConfig())->not->toContain('nice');
+});
+
+it('nices nothing in a standalone queue+scheduler container — no request path to protect', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true, 'queue' => true],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    // The standalone queue co-hosts the scheduler but no web server, so both background
+    // programs run at normal priority — nicing two co-equal background programs would
+    // just restore parity.
+    $queue = file_get_contents(Paths::build('docker/supervisord.queue.conf'));
+    expect($queue)->toContain('command=php artisan queue:work --tries=3 --max-time=3600');
+    expect($queue)->toContain('command=supercronic /app/docker/crontab');
+    expect($queue)->not->toContain('nice');
 });
 
 it('runs octane alone in the web config when both queue and scheduler are extracted', function (): void {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

CPU-priority ordering for the processes that share a **combined-services container** (web + ssr + queue + scheduler + the burst saturation emitter, all under one supervisord). Uses `nice` so the kernel scheduler arbitrates CPU contention in the app's favour:

```
saturation emitter (nice 0, highest)  >  web ≈ ssr (nice 3)  >  queue, scheduler (nice 19, lowest)
```

**What problems are you solving?**

- **Background work pegs CPU and spikes web p99.** On a combined container, web + queue + scheduler share one Fargate CPU quota; a heavy scheduled job or queue batch can starve Octane. Fix (commit 1): the bundled `queue:work` + scheduler launch under `nice -n 19` when co-located with web.
- **Burst step-scaling goes dark under SSR — the saturation emitter is CPU-starved** (commit 2). Burst scaling is driven by an in-container sidecar (`php /app/docker/yolo-saturation.php`) that samples FrankenPHP `:2019/metrics` and `PutMetricData`s `WorkerSaturation`. A **live load test on codinglabs prod** (SSR on, 0.5 vCPU web) found the burst alarm **never fired** across 5+ min at ~100% saturation — zero datapoints — yet the emit path is healthy at idle, and the same image emitted fine with SSR off. Mechanism: the Node SSR renderer pins the box under load, so the sidecar can't get scheduled (and/or its `:2019` read times out) exactly when burst is needed. The reporter is starved by the saturation it reports. The layer-1 scheme can't fix this — the emitter's contenders are `web` + `ssr`, the work itself. So the emitter must be the *highest*-priority process. Since www-data can only *raise* nice, it stays at nice 0 and the request path is niced **down** to it (no `CAP_SYS_NICE`/ulimit), invisible to latency (the emitter runs ms per 5s cycle).

**Is there anything the reviewer needs to know to deploy this?**

- **Image-only change.** No infra, IAM, manifest, or task-def change — it only alters the generated `supervisord.conf` `command=` lines. Takes effect on the next image build/deploy of an affected app.
- **Scope is gated on the emitter sharing the container** (web group + web autoscaling — autoscaling is the default). Behaviour by topology:

  | Container | Priority |
  | --- | --- |
  | Combined, autoscaling | sat 0 > web/ssr 3 > queue/scheduler 19 |
  | Separated-web, autoscaling | sat 0 > web/ssr 3 |
  | Combined, `autoscaling: false` | web/ssr 0 > queue/scheduler 19 |
  | Standalone queue+scheduler / single-role | unchanged — nothing niced |

  `GenerateSupervisorConfigStep` is the only generator that renders the web-group process list, so covering it covers every topology; standalone queue/scheduler services are verified untouched.
- **`nice` is positive-only** (lowering priority) → needs no privilege. Verified against the real base image (`dunglas/frankenphp:1-php8.4-alpine`): `/bin/nice` ships via BusyBox 1.37.0 and `nice -n N` as `www-data` takes effect — no Dockerfile/`apk`/`ulimit`/capability change.
- **Values hardcoded as named constants**, no manifest knob. `REQUEST_PATH_NICE = 3` (request path) / `BACKGROUND_NICE = 19` (background). **+2 is the lighter alternative** for the request path if preferred — one-line change.
- **Verification:** full suite green (1245 passed), Rector / Pint / PHPStan(L5) clean. Docs updated (`docs/guide/images.md` — new "CPU priority within the container" section). Pre-existing port/mode/ssr tests pinned to `autoscaling: false` to match the file's "fixed baseline, autoscaling opts in" convention (the nice prefix would otherwise break their `command=` anchors).
- **Out of scope — flagged as follow-ups, not in this PR:** (1) health-check tolerance — a single pinned task stays unhealthy until capacity lands (~45–60s); the web health check should tolerate a saturated-but-serving task ~60s to avoid churn. (2) `:2019` read robustness — if a live under-load repro shows the read stalls past 2s even when scheduled, bump the read timeout / make the gauge fetch cheaper.

🤖 Generated with [Claude Code](https://claude.ai/code)
