### PR TITLE
fix(sync): grant the admin tier the ECR push chain for the Typesense image build

### DIFF
--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -51,8 +51,11 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * Per-service write *wildcards* (`ecs:Create*`, `ecs:Delete*`, …) mirror
  * ObserverPolicy's read-wildcard discipline: a new sync write within a service
  * YOLO already manages can't AccessDenied-abort a sync; only adding a brand-new
- * AWS service needs a line here. The document is pure (manifest-derived, no live
- * AWS calls) and drift-reconciled via SynchronisesPolicyDocument.
+ * AWS service needs a line here. The exception is verbs that don't fit a write
+ * wildcard — ECR's image-push chain (`GetAuthorizationToken` + the layer-upload
+ * APIs) is enumerated explicitly because sync now builds + pushes the env
+ * Typesense image. The document is pure (manifest-derived, no live AWS calls)
+ * and drift-reconciled via SynchronisesPolicyDocument.
  */
 class AdminPolicy implements Resource, SynchronisesConfiguration
 {
@@ -137,6 +140,16 @@ class AdminPolicy implements Resource, SynchronisesConfiguration
                         'ecs:Put*', 'ecs:Tag*', 'ecs:Untag*',
                         'ecr:Create*', 'ecr:Delete*', 'ecr:Put*',
                         'ecr:Set*', 'ecr:Tag*', 'ecr:Untag*',
+                        // Image push — sync builds + pushes the env Typesense image
+                        // (BuildTypesenseImageStep), so the admin tier needs the same
+                        // login + layer-upload chain the deployer uses. These verbs
+                        // don't fit the management wildcards above; GetAuthorizationToken
+                        // is account-level (unscopeable) and PutImage is already in Put*.
+                        'ecr:GetAuthorizationToken',
+                        'ecr:BatchCheckLayerAvailability',
+                        'ecr:InitiateLayerUpload',
+                        'ecr:UploadLayerPart',
+                        'ecr:CompleteLayerUpload',
                         'elasticloadbalancing:Create*', 'elasticloadbalancing:Modify*',
                         'elasticloadbalancing:Delete*', 'elasticloadbalancing:Set*',
                         'elasticloadbalancing:Register*', 'elasticloadbalancing:Deregister*',

--- a/tests/Unit/Resources/Iam/AdminPolicyTest.php
+++ b/tests/Unit/Resources/Iam/AdminPolicyTest.php
@@ -42,6 +42,20 @@ it('grants the write surface for the services YOLO provisions', function (): voi
     );
 });
 
+it('grants the ECR login + layer-upload chain sync needs to push the Typesense image', function (): void {
+    // BuildTypesenseImageStep runs under the admin tier (it's a sync:environment
+    // step), so admin must hold the same push chain the deployer uses — the
+    // management wildcards (Create*/Delete*/Put*/…) don't cover these verbs, and
+    // GetAuthorizationToken is the login call that errored when they were missing.
+    expect(adminActions())->toContain(
+        'ecr:GetAuthorizationToken',
+        'ecr:BatchCheckLayerAvailability',
+        'ecr:InitiateLayerUpload',
+        'ecr:UploadLayerPart',
+        'ecr:CompleteLayerUpload',
+    );
+});
+
 it('never grants a blanket wildcard or blanket IAM', function (): void {
     $actions = adminActions();
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- `yolo sync <env>` aborts in the apply pass the first time it builds the Typesense image — `AccessDeniedException` on `ecr:GetAuthorizationToken` for the admin-tier role.
- Root cause: [`BuildTypesenseImageStep`](src/Steps/Sync/Environment/BuildTypesenseImageStep.php) runs inside `sync:environment` under the **admin** role and does a `docker login` + `docker push`. Pushing an image is new to the sync flow — before Typesense, image build/push lived only in `build`/`deploy` under the **deployer** role. So `AdminPolicy` only ever granted ECR *management* verbs (`Create*/Delete*/Put*/Set*/Tag*/Untag*`), never the login + layer-upload chain a push needs.

**Fix**
- Add the five missing push verbs to `AdminPolicy`'s service-set statement, mirroring what `DeployerPolicy` already grants: `GetAuthorizationToken`, `BatchCheckLayerAvailability`, `InitiateLayerUpload`, `UploadLayerPart`, `CompleteLayerUpload`. (`PutImage` was already covered by `Put*`.)
- Add a test pinning the push set, and a docblock note that ECR's push chain is enumerated explicitly because the management wildcards don't cover it.

**Is there anything the reviewer needs to know to deploy this?**
- **No resource-scope widening.** Admin could already `PutImage` to any repo via `Put*`; this just completes the push chain on the same `*` statement. IAM stays fenced to `yolo-*` for everything escalation-relevant.
- **Self-healing recovery, no bootstrap sync.** After the consuming app bumps its vendored yolo (`composer update codinglabsau/yolo`) and re-runs `yolo sync <env>`: in the apply pass `SyncAdminPolicyStep` (env step ~4) reconciles the policy to the new doc *before* the Typesense service steps (~step 7) hit the build. Admin already holds `iam:CreatePolicyVersion`/`SetDefaultPolicyVersion` on `yolo-*` policies, so it rewrites its own policy mid-run and the later `docker login` succeeds in the same sync.
- Pure manifest-derived policy document (no live AWS calls), drift-reconciled via `SynchronisesPolicyDocument` — the next `sync --check` after deploy will be clean.
- Full quality stack green: 1288 tests pass, PHPStan clean, Rector clean, Pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)