### PR TITLE
LPX-695: destroy:app — never tear down the hosted zone, withdraw only its records

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -604,7 +604,7 @@ When a [`tasks.web.autoscaling`](/reference/manifest#tasks-web-autoscaling) bloc
 
 ## `yolo destroy:app`
 
-Permanently tear one application's resources down in the given environment — the reverse of [`sync:app`](#yolo-sync-app). It uses the same **plan → confirm → apply** flow: a plan pass lists every resource that **would delete**, the confirm gate guards the irreversible apply (declining is the preview), and `--check` is the non-interactive plan-only form for CI. The apply pass deletes in reverse dependency order — CloudFront → autoscaling → ECS services → cluster → listener rules → target group → task security group → app IAM → SQS → hosted zone → buckets → ECR — so a resource is never deleted while something still references it.
+Permanently tear one application's resources down in the given environment — the reverse of [`sync:app`](#yolo-sync-app). It uses the same **plan → confirm → apply** flow: a plan pass lists every resource that **would delete**, the confirm gate guards the irreversible apply (declining is the preview), and `--check` is the non-interactive plan-only form for CI. The apply pass deletes in reverse dependency order — CloudFront → autoscaling → ECS services → cluster → listener rules → target group → task security group → app IAM → SQS → Route 53 records → buckets → ECR — so a resource is never deleted while something still references it.
 
 ```bash
 yolo destroy:app <environment> [--check] [--force] [--no-progress]
@@ -617,6 +617,7 @@ Arguments and options as [`sync`](#sync-options). Scope: **app**. Admin-tier.
 - The **app data bucket** (the BYO [`bucket`](/reference/manifest#bucket)) holds user data and is never deleted — it isn't even YOLO-tagged. The regenerable asset and config buckets *are* emptied and removed.
 - **RDS is never touched** (YOLO owns the security group, not the database) — destroy:app *revokes this app's 3306 ingress rule* from the shared RDS security group, never the group itself.
 - The shared **`:443` listener** and the **Valkey cache** stay for the environment's other apps — destroy:app removes only this app's listener rule + SNI certificate, and revokes this app's cache ingress rule. (If the certificate is the listener's *default*, it can't be removed app-side and is left for environment teardown.)
+- The **Route 53 hosted zone is never deleted** — a zone is domain-level (the registrar's NS delegation, the domain's email/verification DNS, sibling environments all live in it), so destroy:app withdraws only the A/AAAA records it inserted for this app and leaves the zone (and everything else in it) standing. YOLO creates the zone on first sync, but never tears it down.
 - **Environment- and account-scoped** resources (VPC, subnets, ALB, OIDC provider, …) are out of scope — environment teardown is a separate, later command.
 
 **It refuses rather than partially tearing down.** To guarantee a teardown can never orphan resources (which [`yolo audit`](#yolo-audit) would then flag), destroy:app refuses — with a clear message — app shapes whose teardown isn't fully modelled yet: **multi-tenant** apps, **headless** apps (no domain), apps with **no web task**, and apps still **consuming an env service** (Typesense / IVS / MediaConvert). For the last, remove the service from `yolo.yml` and deploy first, then tear the app down.

--- a/src/Resources/Route53/HostedZone.php
+++ b/src/Resources/Route53/HostedZone.php
@@ -9,7 +9,6 @@ use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\Route53;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
-use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Commands\SyncAppCommand;
 use Codinglabs\Yolo\Concerns\SyncsRecordSets;
@@ -31,7 +30,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * environments' deploy in-sync gate). The shared ownership surfaces as a sync
  * plan warning instead ({@see SyncAppCommand}).
  */
-class HostedZone implements Deletable, Resource
+class HostedZone implements Resource
 {
     use ResolvesCanonicalHost;
     use ResolvesTags;
@@ -75,61 +74,62 @@ class HostedZone implements Deletable, Resource
     }
 
     /**
-     * The environment named by the zone's `yolo:environment` tag, or null when
-     * the zone carries no such tag. Unlike {@see ownerEnvironment()} (a fail-soft
-     * signal for a sync plan warning that swallows read errors), this lets a read
-     * error PROPAGATE — the teardown gate must distinguish "unowned" from "couldn't
-     * read" and fail closed on the latter, never delete on an inconclusive read.
-     */
-    public function ownerTag(): ?string
-    {
-        return Aws::flattenTags($this->liveTags(Str::afterLast($this->arn(), '/')))['yolo:environment'] ?? null;
-    }
-
-    /**
-     * Tear down the Deletable contract — delegates to {@see teardown()}. The
-     * ownership gate (only a zone this env owns) lives in TeardownHostedZoneStep,
-     * which fails closed on an inconclusive ownership read.
-     */
-    public function delete(): void
-    {
-        $this->teardown();
-    }
-
-    /**
-     * Remove only the records YOLO manages for this app (the canonical host + its
-     * apex/www sibling A records), preserving every operator-added record — MX,
-     * SPF/DKIM/DMARC TXT, verification CNAMEs. The zone itself is deleted only
-     * when nothing but the apex NS + SOA remain afterwards (it was a pure-YOLO
-     * zone); a zone still holding other records is left standing, because a real
-     * domain outlives any single app and deleting it would take that DNS with it.
+     * Remove only the records YOLO inserted for this app — the canonical host and,
+     * when it's one half of the apex/www pair, its sibling (the A/AAAA alias
+     * records {@see SyncsRecordSets} writes). Every other
+     * record is left untouched: email (MX/SPF/DKIM), domain-verification, and any
+     * sibling environment's records.
      *
-     * @return bool whether the zone itself was deleted (false ⇒ kept, other records remain)
+     * The hosted zone itself is NEVER deleted. A zone is domain-level
+     * infrastructure — the registrar's NS delegation points at it and the domain's
+     * whole DNS lives in it — so it outlives any single app; `destroy:app` only
+     * withdraws the records it added. (YOLO creates the zone on first sync as a
+     * convenience, but create ≠ own-to-destroy here, exactly like the BYO data
+     * bucket.)
+     *
+     * @return int the number of record sets removed (0 ⇒ nothing of ours remained)
      */
-    public function teardown(): bool
+    public function removeAppRecords(): int
     {
-        try {
-            $id = Str::afterLast($this->arn(), '/');
-        } catch (ResourceDoesNotExistException) {
-            return true;
+        $changes = collect(Aws::route53()->listResourceRecordSets(['HostedZoneId' => $this->zoneId()])['ResourceRecordSets'] ?? [])
+            ->filter($this->isManagedRecord(...))
+            ->map(fn (array $record): array => ['Action' => 'DELETE', 'ResourceRecordSet' => $record])
+            ->values()
+            ->all();
+
+        if ($changes === []) {
+            return 0;
         }
 
-        $this->deleteManagedRecords($id);
+        Aws::route53()->changeResourceRecordSets([
+            'HostedZoneId' => $this->zoneId(),
+            'ChangeBatch' => ['Changes' => $changes],
+        ]);
 
-        if (! $this->onlyDefaultRecordsRemain($id)) {
-            return false;
-        }
+        return count($changes);
+    }
 
-        Aws::route53()->deleteHostedZone(['Id' => $id]);
+    /**
+     * Whether the zone still holds any of this app's managed records — the
+     * plan-pass / re-run check so teardown reports WOULD_DELETE vs SKIPPED without
+     * writing.
+     */
+    public function appRecordsExist(): bool
+    {
+        return collect(Aws::route53()->listResourceRecordSets(['HostedZoneId' => $this->zoneId()])['ResourceRecordSets'] ?? [])
+            ->contains($this->isManagedRecord(...));
+    }
 
-        return true;
+    protected function zoneId(): string
+    {
+        return Str::afterLast($this->arn(), '/');
     }
 
     /**
      * The hostnames YOLO writes A-alias records for — the canonical host and,
      * when it's one half of the apex/www pair, its sibling. Mirrors
      * {@see SyncsRecordSets::generateChanges()} so
-     * teardown removes exactly what sync created and nothing else.
+     * teardown withdraws exactly what sync created and nothing else.
      *
      * @return array<int, string>
      */
@@ -143,44 +143,18 @@ class HostedZone implements Deletable, Resource
     }
 
     /**
-     * Delete only this app's A/AAAA alias records at the managed hosts. Anything
-     * else in the zone (email/verification DNS, other apps' records) is left
-     * untouched.
+     * An A/AAAA record at one of this app's managed hosts — i.e. one YOLO inserted.
+     *
+     * @param  array<string, mixed>  $record
      */
-    protected function deleteManagedRecords(string $id): void
+    protected function isManagedRecord(array $record): bool
     {
         $managed = collect($this->managedHosts())
             ->map(fn (string $host): string => rtrim($host, '.') . '.')
             ->all();
 
-        $changes = collect(Aws::route53()->listResourceRecordSets(['HostedZoneId' => $id])['ResourceRecordSets'] ?? [])
-            ->filter(fn (array $record): bool => in_array($record['Type'], ['A', 'AAAA'], true)
-                && in_array(rtrim((string) $record['Name'], '.') . '.', $managed, true))
-            ->map(fn (array $record): array => ['Action' => 'DELETE', 'ResourceRecordSet' => $record])
-            ->values()
-            ->all();
-
-        if ($changes === []) {
-            return;
-        }
-
-        Aws::route53()->changeResourceRecordSets([
-            'HostedZoneId' => $id,
-            'ChangeBatch' => ['Changes' => $changes],
-        ]);
-    }
-
-    /**
-     * Whether the only records left in the zone are the apex NS + SOA that
-     * Route 53 auto-manages (and removes with the zone) — i.e. it was a pure-YOLO
-     * zone and is now safe to delete outright.
-     */
-    protected function onlyDefaultRecordsRemain(string $id): bool
-    {
-        $apex = rtrim($this->apex, '.') . '.';
-
-        return collect(Aws::route53()->listResourceRecordSets(['HostedZoneId' => $id])['ResourceRecordSets'] ?? [])
-            ->every(fn (array $record): bool => in_array($record['Type'], ['NS', 'SOA'], true) && rtrim((string) $record['Name'], '.') . '.' === $apex);
+        return in_array($record['Type'], ['A', 'AAAA'], true)
+            && in_array(rtrim((string) $record['Name'], '.') . '.', $managed, true);
     }
 
     public function synchroniseTags(bool $apply): array

--- a/src/Steps/Destroy/App/TeardownHostedZoneStep.php
+++ b/src/Steps/Destroy/App/TeardownHostedZoneStep.php
@@ -6,73 +6,39 @@ namespace Codinglabs\Yolo\Steps\Destroy\App;
 
 use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Concerns\RecordsChanges;
-use Codinglabs\Yolo\Concerns\RecordsWarnings;
 use Codinglabs\Yolo\Resources\Route53\HostedZone;
 
 /**
- * Tears down this app's Route 53 records — and the hosted zone too, but only when
- * it's safe. Hosted zones are shared across environments and a real domain often
- * carries operator-added records (email MX/SPF/DKIM, verification CNAMEs), so this
- * step is deliberately conservative:
- *
- *  - It FAILS CLOSED on ownership. The zone is touched only when its
- *    `yolo:environment` tag positively names this environment. A zone owned by a
- *    sibling env, a zone YOLO doesn't own (untagged), or an inconclusive read
- *    (Route 53 error) all skip with a warning — never an irreversible delete of a
- *    shared or foreign zone on a guess.
- *  - It removes only YOLO-managed records and deletes the zone only if it's then
- *    empty of everything but the apex NS/SOA (see {@see HostedZone::teardown()}),
- *    so a domain that also serves email keeps its zone (and a warning says so).
+ * Withdraws this app's DNS records — and ONLY its records. The hosted zone
+ * itself is never deleted: it's domain-level infrastructure (the registrar's NS
+ * delegation points at it, and the domain's email / verification DNS and any
+ * sibling environment's records all live in it), so it outlives any single app.
+ * Tearing the app down removes the A/AAAA records YOLO inserted for it and leaves
+ * the zone — and everything else in it — standing. See {@see HostedZone::removeAppRecords()}.
  */
 class TeardownHostedZoneStep implements Step
 {
     use RecordsChanges;
-    use RecordsWarnings;
 
     public function __invoke(array $options): StepResult
     {
-        $apex = Manifest::apex();
-        $zone = new HostedZone($apex);
+        $zone = new HostedZone(Manifest::apex());
 
-        if (! $zone->exists()) {
+        if (! $zone->exists() || ! $zone->appRecordsExist()) {
             return StepResult::SKIPPED;
         }
 
-        try {
-            $owner = $zone->ownerTag();
-        } catch (\Throwable) {
-            $this->recordWarning(sprintf('Could not read hosted-zone ownership for %s — left it in place. Re-run once Route 53 is reachable.', $apex));
-
-            return StepResult::SKIPPED;
-        }
-
-        if ($owner !== Helpers::app('environment')) {
-            $this->recordWarning(sprintf(
-                'Hosted zone %s is %s — left in place; destroy:app only removes a zone this environment owns.',
-                $apex,
-                $owner === null ? 'not YOLO-owned' : sprintf('owned by the "%s" environment', $owner),
-            ));
-
-            return StepResult::SKIPPED;
-        }
-
-        $this->recordChange(Change::make('hosted zone records', 'provisioned', null));
+        $this->recordChange(Change::make(sprintf('%s app DNS records', Manifest::apex()), 'present', null));
 
         if (Arr::get($options, 'dry-run')) {
             return StepResult::WOULD_DELETE;
         }
 
-        if (! $zone->teardown()) {
-            $this->recordWarning(sprintf(
-                'Hosted zone %s kept — it still holds non-YOLO records (e.g. email or domain-verification DNS). Its records for this app were removed; delete the zone manually if you are decommissioning the domain.',
-                $apex,
-            ));
-        }
+        $zone->removeAppRecords();
 
         return StepResult::DELETED;
     }

--- a/tests/Arch/ResourceTeardownTest.php
+++ b/tests/Arch/ResourceTeardownTest.php
@@ -4,20 +4,26 @@ use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\S3\S3Bucket;
+use Codinglabs\Yolo\Resources\Route53\HostedZone;
 
 /**
  * `yolo destroy` tears an environment down by deleting the live AWS resources it
  * owns, so every App-scoped resource must be able to delete itself — otherwise a
  * teardown would orphan it (and `yolo audit` would then flag it as unexpected).
  *
- * The one deliberate exception is the bring-your-own app data bucket
- * ({@see S3Bucket}): it holds user data, is never YOLO-tagged, and must survive a
- * teardown — so it is asserted NON-deletable here on purpose. A new App-scoped
- * resource that forgets `delete()` fails this test until it implements
- * {@see Deletable} (or, for a future shared resource, is moved off App scope).
+ * Two deliberate exceptions, both asserted NON-deletable directly below so the
+ * exclusion can't rot:
+ *  - the bring-your-own app data bucket ({@see S3Bucket}) — holds user data, never
+ *    YOLO-tagged, must survive a teardown;
+ *  - the {@see HostedZone} — a hosted zone is domain-level infrastructure (the
+ *    registrar's NS delegation, the domain's email/verification DNS, sibling
+ *    environments) that outlives any single app, so `destroy:app` withdraws only
+ *    the records it inserted and never deletes the zone.
  *
- * Env- and Account-scoped resources are intentionally NOT yet required to be
- * deletable — environment teardown is a later phase of LPX-695.
+ * A new App-scoped resource that forgets `delete()` fails this test until it
+ * implements {@see Deletable} (or, for a future shared resource, is moved off App
+ * scope). Env- and Account-scoped resources are intentionally NOT yet required to
+ * be deletable — environment teardown is a later phase of LPX-695.
  */
 it('every app-scoped resource is deletable, except the BYO data bucket', function (): void {
     $instantiate = function (ReflectionClass $reflection): object {
@@ -86,10 +92,10 @@ it('every app-scoped resource is deletable, except the BYO data bucket', functio
 
         $examined++;
 
-        // The BYO app data bucket is the deliberate exception — that it must NOT
-        // be Deletable is asserted directly in its own test below, never via this
-        // discovery loop (which could stop classifying it as App-scoped).
-        if ($class === S3Bucket::class) {
+        // The deliberate exceptions — that they must NOT be Deletable is asserted
+        // directly in their own tests below, never via this discovery loop (which
+        // could stop classifying one as App-scoped and pass vacuously).
+        if (in_array($class, [S3Bucket::class, HostedZone::class], true)) {
             continue;
         }
 
@@ -112,4 +118,13 @@ it('every app-scoped resource is deletable, except the BYO data bucket', functio
  */
 it('never makes the BYO app data bucket deletable', function (): void {
     expect(class_implements(S3Bucket::class))->not->toContain(Deletable::class);
+});
+
+/**
+ * Same hard counterpart for the hosted zone: a zone is domain-level (registrar NS
+ * delegation, email/verification DNS, sibling environments), so it must never be
+ * Deletable — `destroy:app` withdraws only the records it inserted, never the zone.
+ */
+it('never makes the hosted zone deletable', function (): void {
+    expect(class_implements(HostedZone::class))->not->toContain(Deletable::class);
 });

--- a/tests/Unit/Resources/TeardownTest.php
+++ b/tests/Unit/Resources/TeardownTest.php
@@ -298,37 +298,30 @@ it('finds and deletes the ssl certificate', function (): void {
         ->toBe('arn:aws:acm:ap-southeast-2:111111111111:certificate/abc-123');
 });
 
-it('removes only its managed A records, then deletes the zone when it is pure-YOLO', function (): void {
+it('withdraws only its own A records and never deletes the hosted zone', function (): void {
     $captured = [];
     bindTeardownRoutedClient('route53', Route53Client::class, [
         'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z123', 'Name' => 'example.com.']]]),
-        // First list = pre-delete; second = post-delete (only NS/SOA left → pure-YOLO → deletable).
-        'ListResourceRecordSets' => [
-            new Result(['ResourceRecordSets' => [
-                ['Name' => 'example.com.', 'Type' => 'NS', 'TTL' => 172800, 'ResourceRecords' => [['Value' => 'ns-1']]],
-                ['Name' => 'example.com.', 'Type' => 'SOA', 'TTL' => 900, 'ResourceRecords' => [['Value' => 'soa']]],
-                ['Name' => 'example.com.', 'Type' => 'A', 'TTL' => 60, 'ResourceRecords' => [['Value' => '1.1.1.1']]],
-                ['Name' => 'www.example.com.', 'Type' => 'A', 'TTL' => 60, 'ResourceRecords' => [['Value' => '1.1.1.1']]],
-            ]]),
-            new Result(['ResourceRecordSets' => [
-                ['Name' => 'example.com.', 'Type' => 'NS', 'TTL' => 172800, 'ResourceRecords' => [['Value' => 'ns-1']]],
-                ['Name' => 'example.com.', 'Type' => 'SOA', 'TTL' => 900, 'ResourceRecords' => [['Value' => 'soa']]],
-            ]]),
-        ],
+        'ListResourceRecordSets' => new Result(['ResourceRecordSets' => [
+            ['Name' => 'example.com.', 'Type' => 'NS', 'TTL' => 172800, 'ResourceRecords' => [['Value' => 'ns-1']]],
+            ['Name' => 'example.com.', 'Type' => 'SOA', 'TTL' => 900, 'ResourceRecords' => [['Value' => 'soa']]],
+            ['Name' => 'example.com.', 'Type' => 'A', 'TTL' => 60, 'ResourceRecords' => [['Value' => '1.1.1.1']]],
+            ['Name' => 'www.example.com.', 'Type' => 'A', 'TTL' => 60, 'ResourceRecords' => [['Value' => '1.1.1.1']]],
+        ]]),
     ], $captured);
 
-    (new HostedZone('example.com'))->delete();
+    expect((new HostedZone('example.com'))->removeAppRecords())->toBe(2);
 
     $names = array_column($captured, 'name');
-    expect($names)->toContain('ChangeResourceRecordSets')->toContain('DeleteHostedZone');
+    // The zone is NEVER deleted — only the app's records are withdrawn.
+    expect($names)->toContain('ChangeResourceRecordSets')->not->toContain('DeleteHostedZone');
 
-    // Both managed A records (apex + www) are removed; NS/SOA are never touched.
     $deleted = collect(collect($captured)->firstWhere('name', 'ChangeResourceRecordSets')['args']['ChangeBatch']['Changes'])
         ->pluck('ResourceRecordSet.Name')->all();
     expect($deleted)->toEqualCanonicalizing(['example.com.', 'www.example.com.']);
 });
 
-it('preserves non-YOLO records and keeps the zone standing', function (): void {
+it('leaves operator-added records (email / verification) untouched', function (): void {
     $captured = [];
     bindTeardownRoutedClient('route53', Route53Client::class, [
         'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z123', 'Name' => 'example.com.']]]),
@@ -340,15 +333,15 @@ it('preserves non-YOLO records and keeps the zone standing', function (): void {
         ]]),
     ], $captured);
 
-    (new HostedZone('example.com'))->delete();
+    expect((new HostedZone('example.com'))->removeAppRecords())->toBe(1);
 
     $names = array_column($captured, 'name');
-    // The app's A record is removed, but the zone is NOT deleted — the MX record survives.
-    expect($names)->toContain('ChangeResourceRecordSets')->not->toContain('DeleteHostedZone');
+    expect($names)->not->toContain('DeleteHostedZone');
 
+    // Only the A record is withdrawn — the MX (and NS/SOA) are never touched.
     $deleted = collect(collect($captured)->firstWhere('name', 'ChangeResourceRecordSets')['args']['ChangeBatch']['Changes'])
         ->pluck('ResourceRecordSet.Type')->all();
-    expect($deleted)->toBe(['A']); // never the MX/NS/SOA
+    expect($deleted)->toBe(['A']);
 });
 
 it('detaches and deletes every app IAM role', function (string $class): void {

--- a/tests/Unit/Steps/Destroy/DestroyAppStepsTest.php
+++ b/tests/Unit/Steps/Destroy/DestroyAppStepsTest.php
@@ -190,55 +190,40 @@ function bindDestroyRoutedClient(string $binding, string $clientClass, array $by
     ]));
 }
 
-// --- TeardownHostedZoneStep: fail-closed ownership gate (BLOCKER fix) ---
+// --- TeardownHostedZoneStep: withdraw records, NEVER delete the zone ---
 
-it('tears down the hosted zone only when this environment positively owns it', function (): void {
+it('withdraws the app records and never deletes the hosted zone', function (): void {
     $captured = [];
     bindDestroyRoutedClient('route53', Route53Client::class, [
         'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z1', 'Name' => 'example.com.']]]),
-        'ListTagsForResource' => new Result(['ResourceTagSet' => ['Tags' => [['Key' => 'yolo:environment', 'Value' => 'testing']]]]),
         'ListResourceRecordSets' => new Result(['ResourceRecordSets' => [
             ['Name' => 'example.com.', 'Type' => 'NS', 'ResourceRecords' => [['Value' => 'ns']]],
             ['Name' => 'example.com.', 'Type' => 'SOA', 'ResourceRecords' => [['Value' => 'soa']]],
+            ['Name' => 'example.com.', 'Type' => 'A', 'TTL' => 60, 'ResourceRecords' => [['Value' => '1.1.1.1']]],
         ]]),
     ], $captured);
 
-    expect((new TeardownHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::DELETED)
-        ->and(array_column($captured, 'name'))->toContain('DeleteHostedZone');
+    expect((new TeardownHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::DELETED);
+
+    $names = array_column($captured, 'name');
+    expect($names)->toContain('ChangeResourceRecordSets')->not->toContain('DeleteHostedZone');
 });
 
-it('refuses to touch a hosted zone a sibling environment owns', function (): void {
+it('skips the hosted-zone teardown when none of the app records remain', function (): void {
     $captured = [];
     bindDestroyRoutedClient('route53', Route53Client::class, [
         'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z1', 'Name' => 'example.com.']]]),
-        'ListTagsForResource' => new Result(['ResourceTagSet' => ['Tags' => [['Key' => 'yolo:environment', 'Value' => 'production']]]]),
+        // Only NS/SOA + an unrelated MX — nothing of this app's, so nothing to do.
+        'ListResourceRecordSets' => new Result(['ResourceRecordSets' => [
+            ['Name' => 'example.com.', 'Type' => 'NS', 'ResourceRecords' => [['Value' => 'ns']]],
+            ['Name' => 'example.com.', 'Type' => 'SOA', 'ResourceRecords' => [['Value' => 'soa']]],
+            ['Name' => 'example.com.', 'Type' => 'MX', 'TTL' => 3600, 'ResourceRecords' => [['Value' => '10 mail']]],
+        ]]),
     ], $captured);
 
     expect((new TeardownHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED)
-        ->and(array_column($captured, 'name'))->not->toContain('DeleteHostedZone')
-        ->not->toContain('ChangeResourceRecordSets');
-});
-
-it('refuses to touch a hosted zone YOLO does not own (untagged)', function (): void {
-    $captured = [];
-    bindDestroyRoutedClient('route53', Route53Client::class, [
-        'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z1', 'Name' => 'example.com.']]]),
-        'ListTagsForResource' => new Result(['ResourceTagSet' => ['Tags' => []]]),
-    ], $captured);
-
-    expect((new TeardownHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED)
-        ->and(array_column($captured, 'name'))->not->toContain('DeleteHostedZone');
-});
-
-it('fails closed and skips when the ownership read errors', function (): void {
-    $captured = [];
-    bindDestroyRoutedClient('route53', Route53Client::class, [
-        'ListHostedZones' => new Result(['HostedZones' => [['Id' => '/hostedzone/Z1', 'Name' => 'example.com.']]]),
-        'ListTagsForResource' => new RuntimeException('Route 53 throttled'),
-    ], $captured);
-
-    expect((new TeardownHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED)
-        ->and(array_column($captured, 'name'))->not->toContain('DeleteHostedZone');
+        ->and(array_column($captured, 'name'))->not->toContain('ChangeResourceRecordSets')
+        ->not->toContain('DeleteHostedZone');
 });
 
 // --- TeardownSslCertificateStep: detach + InUse-skip (WARNING fix / coverage) ---


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Follow-up to the merged [#158](https://github.com/codinglabsau/yolo/pull/158). ([LPX-695](https://linear.app/codinglabsau/issue/LPX-695))

**What problems are you solving?**
- `destroy:app` could delete the whole Route 53 **hosted zone** (when it was reduced to NS/SOA). That's the wrong call: a hosted zone is **domain-level** infrastructure — the registrar's NS delegation points at it, and the domain's email/verification DNS and any sibling environment's records all live in it — so it outlives any single app. App teardown should withdraw only the records YOLO inserted and leave the zone standing.
- Worth noting: YOLO *does* create the zone on first sync (`SyncHostedZoneStep`), but create ≠ own-to-destroy here — same stance as the BYO data bucket.

**Is there anything the reviewer needs to know to deploy this?**
- **No deploy/runtime change.** Only `destroy:app`'s Route 53 teardown behaviour changes (and `destroy:app` is admin-tier, human-gated, not in any automated path).
- `HostedZone` **no longer implements `Deletable`**. New `removeAppRecords()` deletes only this app's A/AAAA records (canonical host + apex/www sibling); the **zone is never deleted**. `TeardownHostedZoneStep` withdraws those records — no ownership gate (it only ever touches this app's own record names, so the shared-zone hazard is gone).
- Arch invariant updated: `HostedZone` joins `S3Bucket` as a deliberate non-`Deletable` App-scoped resource, asserted directly so the exclusion can't rot.
- **Supersedes the two Route 53 review blockers from #158** (fail-open ownership read; wiping all DNS records incl. email) — both disappear when nothing deletes the zone.
- Green: full suite **1351**; Pint, Rector, PHPStan, Coverage all pass in CI.

🤖 Generated with [Claude Code](https://claude.ai/code)