### PR TITLE
feat(manifest): require an explicit autoscaling decision on web and queue

### DIFF
--- a/docs/guide/domains.md
+++ b/docs/guide/domains.md
@@ -60,7 +60,8 @@ environments:
   production:
     # no domain / apex / tenants → headless
     tasks:
-      web: true
+      web:
+        autoscaling: true
 ```
 
 It still declares `tasks.web`. That's the container the app runs — the queue worker and scheduler ride inside it by default ([where each role runs](/reference/manifest#where-each-role-runs)) — so "headless" isn't about dropping the web tier, it's about not exposing it. With no domain to route, YOLO skips the hosted zone, certificate, ALB attachment, and DNS; the container still deploys and still processes queued and scheduled work, it just has no public URL.

--- a/docs/guide/multi-tenancy.md
+++ b/docs/guide/multi-tenancy.md
@@ -18,8 +18,10 @@ environments:
         domain: globex-with-yolo.com
     tasks:
       web:
-        queue: true
-        scheduler: true
+        autoscaling: true
+      queue:
+        autoscaling: true
+      scheduler: true
 ```
 
 The tenant id (`acme`, `globex`) identifies that tenant's resources throughout YOLO. Each tenant follows the same domain rules as a solo app — set `apex` separately if the tenant is served from a subdomain (see [Domains](/guide/domains)).

--- a/docs/guide/scaling.md
+++ b/docs/guide/scaling.md
@@ -19,7 +19,7 @@ Autoscaling **bounds** (`min`/`max`) live in the manifest and are reconciled by 
 
 ## Autoscaling
 
-`yolo init` scaffolds new apps with web autoscaling **on** (`tasks.web.autoscaling: true`, bounds 1–5) — so a fresh app scales out of the box. To set your own bounds, expand the shorthand into a block:
+`autoscaling` is **required** on web and queue — there's no implicit default, and neither accepts the bare `tasks.web: true` / `tasks.queue: true` shorthand (only the scheduler does). `yolo init` scaffolds new apps with `tasks.web.autoscaling: true` (bounds 1–5), so a fresh app scales out of the box. To set your own bounds, expand the shorthand into a block:
 
 ```yaml
 tasks:
@@ -35,10 +35,10 @@ The scaffolded shorthand takes the defaults (`min: 1`, `max: 5`):
 ```yaml
 tasks:
   web:
-    autoscaling: true       # shorthand for the defaults — on by default; `false` = a fixed single task
+    autoscaling: true       # shorthand for the defaults; `false` = a fixed single task
 ```
 
-Autoscaling is **on by default** for any enabled web tier — an omitted `autoscaling` key behaves like `true`. On the next `yolo sync` / `yolo sync:app`, YOLO registers an [Application Auto Scaling](https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html) **scalable target** on the ECS service (bounded by `min`/`max`) and attaches **target-tracking policies** to it. Set `autoscaling: false` to keep the service a fixed single task instead.
+An enabled web tier **must declare `autoscaling`** — omitting it (or using the bare `tasks.web: true` shorthand) hard-fails the manifest check, so a tier's scaling posture is always a deliberate decision rather than an inherited default. With `true` (or a block), the next `yolo sync` / `yolo sync:app` registers an [Application Auto Scaling](https://docs.aws.amazon.com/autoscaling/application/userguide/what-is-application-auto-scaling.html) **scalable target** on the ECS service (bounded by `min`/`max`) and attaches **target-tracking policies** to it. Set `autoscaling: false` to keep the service a fixed single task instead.
 
 ### Two metrics, composed
 
@@ -49,7 +49,7 @@ YOLO runs two target-tracking policies at once. Application Auto Scaling takes t
 | **Request concurrency** | in-flight requests per task (derived) | The default, leading signal — concurrency climbs the instant traffic does, ahead of CPU. Scales the web tier under normal HTTP load. No tuning: its target comes from the task's memory. |
 | **CPU** | `ECSServiceAverageCPUUtilization` | The safety net. Catches load that pegs the CPU without raising request concurrency — a few heavy, low-rate requests. Target defaults to 65%. |
 
-Both are on the moment the web tier is enabled (autoscaling is on by default) — there's nothing to seed from a load test first. Scaling on the requests a task is actively serving rather than trailing CPU means faster responses need fewer tasks for the same traffic, and a spike is caught as it arrives.
+Both are on the moment the web tier declares `autoscaling: true` (or a block) — there's nothing to seed from a load test first. Scaling on the requests a task is actively serving rather than trailing CPU means faster responses need fewer tasks for the same traffic, and a spike is caught as it arrives.
 
 ### How the concurrency target is derived
 
@@ -85,7 +85,7 @@ The burst alarm and step policy aren't taggable, so (like the target-tracking po
 
 ### Turning autoscaling off
 
-Autoscaling is declarative — sync reconciles live state down to what the manifest asks for, so removing the `autoscaling` block deregisters the scalable target on the next `yolo sync`, which cascades the delete to **every** policy and alarm on it.
+Autoscaling is declarative — sync reconciles live state down to what the manifest asks for. Since the key is required you turn it off by setting **`autoscaling: false`** (not by removing it); that deregisters the scalable target on the next `yolo sync`, which cascades the delete to **every** policy and alarm on it.
 
 Deregistering doesn't drop tasks — the service reverts to a **fixed** task count frozen at its current live count. Bring it down with [`yolo scale`](#manual-scaling) if you no longer need the extra capacity.
 
@@ -105,7 +105,7 @@ yolo scale production --queue --min=0 --max=20     # queue bounds (min 0 = scale
 
 Under autoscaling you set the **bounds** (`--min`/`--max`), never a desired count — the policies own desired count and would override it. Crucially, `scale` **writes the bounds back to the manifest** (surgically — your comments and formatting survive), so the manifest stays the single source of truth and the next `yolo sync` reconciles to the same values rather than clobbering your change.
 
-For a fixed service (`autoscaling: false` — web or queue) a positional `count` sets the ECS desired count directly. An autoscaling service (the default for web and queue) only takes `--min`/`--max`. The scheduler is a singleton and can't be scaled (`--scheduler` errors out).
+For a fixed service (`autoscaling: false` — web or queue) a positional `count` sets the ECS desired count directly. An autoscaling service (`autoscaling: true` or a block) only takes `--min`/`--max`. The scheduler is a singleton and can't be scaled (`--scheduler` errors out).
 
 ### Reducing capacity is guarded
 
@@ -123,7 +123,8 @@ Add a top-level `tasks.queue` block to give the queue worker its own ECS service
 
 ```yaml
 tasks:
-  web: true
+  web:
+    autoscaling: true
   queue:
     autoscaling:
       min: 0          # scale to zero when idle (opt-in; the default floor is 1)
@@ -132,7 +133,7 @@ tasks:
     spot: true        # optional: ~70% cheaper interruptible capacity
 ```
 
-Like web, the queue **autoscales by default** (`min: 1`, `max: 5`) — set `autoscaling: false` for a fixed single task. It scales on **backlog per task** — `ApproximateNumberOfMessagesVisible / RunningTaskCount`, computed with CloudWatch metric math (no Lambda) and held at `backlog-per-task` messages per running task. As the backlog grows it scales out toward `max`; as it drains it scales back in toward `min`.
+Like web, the queue **must declare `autoscaling`** — `true` takes the defaults (`min: 1`, `max: 5`), `false` pins a fixed single task. It scales on **backlog per task** — `ApproximateNumberOfMessagesVisible / RunningTaskCount`, computed with CloudWatch metric math (no Lambda) and held at `backlog-per-task` messages per running task. As the backlog grows it scales out toward `max`; as it drains it scales back in toward `min`.
 
 With `autoscaling.min: 0` the queue **scales to zero**: no tasks and no compute cost when idle. Target tracking can't lift it off zero (dividing by zero running tasks is undefined), so YOLO also attaches a step-scaling alarm that sets the service to exactly one task the instant a message becomes visible; target tracking owns it from one upward. The cost is a **~30–60s cold start** (image pull + boot) on the first message after idle.
 
@@ -176,5 +177,5 @@ tasks:
 YOLO pins it at exactly one task (never a scalable target) and deploys it **stop-then-start** (`minimumHealthyPercent: 0` / `maximumPercent: 100`) so a rollout stops the old cron before starting the new one — a deploy never briefly runs two schedulers (a missed cron minute is harmless; a double-run isn't). This removes the `onOneServer()` *requirement* entirely — it's genuinely a singleton now — though leaving `onOneServer()` on is harmless. The web tier then scales without any scheduler concern.
 
 ::: tip
-When the scheduler is bundled into a host that runs more than one task — an autoscaling web task, or a standalone queue (both autoscale by default) — `yolo sync` lists an advisory under the plan's **Warnings** section pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
+When the scheduler is bundled into a host that runs more than one task — an autoscaling web task, or a standalone queue (both must declare autoscaling) — `yolo sync` lists an advisory under the plan's **Warnings** section pointing at these two strategies. It's a nudge, not a gate — YOLO can't see inside your kernel to know whether you've used `onOneServer()`.
 :::

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -60,7 +60,7 @@ yolo init
 
 Interactive. Prompts for the app name, AWS account ID, region, and (unless multi-tenant) a domain and optional S3 bucket. It then:
 
-- Writes `yolo.yml` from the stub — with web [autoscaling](/guide/scaling) on by default (`tasks.web.autoscaling: true`, bounds 1–5).
+- Writes `yolo.yml` from the stub — with web [autoscaling](/guide/scaling) declared (`tasks.web.autoscaling: true`, bounds 1–5; it's a required key).
 - Writes a default `Dockerfile` and `.dockerignore` (asks before overwriting existing ones).
 - Creates a starter `.env.production`.
 - Appends `.yolo`, `.env.staging`, `.env.production`, and the env-shared working copies (`.env.environment.*`, `yolo-environment-*.yml`) to `.gitignore`.

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -80,7 +80,7 @@ environments:
         #   unhealthy-threshold: 5        # default: 5 — cushion for a slow-but-alive task
         #   grace-period: 60              # default: 60 (ECS health-check grace period)
         #
-        # autoscaling: false             # on by default (min 1, max 5); `false` = fixed single task
+        autoscaling: true              # REQUIRED for web — true (min 1, max 5) | false (fixed single task) | a block
         # autoscaling:                    # …or tune it (web min must be ≥ 1)
         #   min: 1                        # default: 1
         #   max: 5                        # default: 5
@@ -90,14 +90,15 @@ environments:
         #   # request concurrency is the default signal (derived from task memory); burst
         #   # (~10s spike detection) is unconditional for octane — neither has a knob
 
-      # Extract the queue into its own ECS service (scale independently of web).
-      # `true` extracts with defaults; `false` switches the worker off entirely.
-      # Autoscales by default (min 1, max 5); set autoscaling.min: 0 to scale to zero
-      # when idle — except when it also hosts the scheduler (no `scheduler` block below),
-      # where min 0 is rejected so cron isn't killed when it idles.
+      # Extract the queue into its own ECS service (scale independently of web). Like
+      # web, a standalone queue must be a config map that declares `autoscaling` — there's
+      # no bare `queue: true` shorthand. `false` switches the worker off entirely. Set
+      # autoscaling.min: 0 to scale to zero when idle — except when it also hosts the
+      # scheduler (no `scheduler` block below), where min 0 is rejected so cron isn't
+      # killed when it idles.
       # queue:
-      #   autoscaling:                    # on by default; `false` = fixed single task
-      #     min: 0                        # default: 1 — 0 = scale to zero when idle
+      #   autoscaling:                    # required — true | false | a { min, max } block
+      #     min: 0                        # 0 = scale to zero when idle (floor defaults to 1)
       #     max: 5                        # default: 5
       #     backlog-per-task: 100         # default: 100 — target messages per running task
       #   cpu: '256'                      # default: '256'
@@ -367,7 +368,7 @@ The budget block is **two-tier**: the same `budget` shape can also be declared i
 
 ## `tasks.web.*`
 
-Declaring `tasks.web` (as `true` or a config object) makes the app a Fargate web service; it **autoscales by default** (see [`tasks.web.autoscaling`](#tasks-web-autoscaling)). `tasks.web: false` — or omitting `tasks` entirely — is a build-only / headless app with no web container.
+Declaring `tasks.web` as a config object makes the app a Fargate web service; it **must declare** [`autoscaling`](#tasks-web-autoscaling) — there's no implicit default, and the bare `tasks.web: true` shorthand isn't accepted (a scalar tier has nowhere to state its scaling behaviour). `tasks.web: false` — or omitting `tasks` entirely — is a build-only / headless app with no web container.
 
 ### Where each role runs
 
@@ -375,7 +376,9 @@ Every app runs three roles — **web**, the **queue worker**, and the **schedule
 
 To run web in isolation, **extract the worker tier**: add a top-level [`tasks.queue`](#tasks-queue) block and the queue worker *and* the scheduler move out to their own service, leaving the web container running just the web server. Add [`tasks.scheduler`](#tasks-scheduler) as well to give cron its own pinned-singleton task. Placement is derived from which blocks are present — there are no `tasks.web.queue` / `tasks.web.scheduler` flags.
 
-Each block is **`true | false | {config}`** (the same boolean-or-object form as [`tasks.web.ssr`](#tasks-web)): `true` extracts the role with default sizing, a config object extracts it with overrides, and `false` switches it off so the role runs **nowhere** — neither bundled nor extracted. An empty block (`queue:`) or empty object (`{}`) is rejected — write `true` for defaults so the intent is never ambiguous.
+Each block is **`true | false | {config}`** (the same boolean-or-object form as [`tasks.web.ssr`](#tasks-web)): `true` extracts the role with default sizing, a config object extracts it with overrides, and `false` switches it off so the role runs **nowhere** — neither bundled nor extracted. An empty block (`queue:`) or empty object (`{}`) is rejected — state the intent explicitly. The **`queue`** block is the one exception to bare `true`: like web, a standalone queue must be a config object that declares [`autoscaling`](#tasks-queue) (web and queue both need a definitive scaling decision). Only **`scheduler`** — a pinned singleton that never scales — keeps the bare `true` shorthand.
+
+In the placement table below, `queue: true` is shorthand for "queue extracted" — the real manifest writes `queue: { autoscaling: … }`; only `scheduler: true` is literal.
 
 | Manifest | web container | worker container | scheduler container |
 | --- | --- | --- | --- |
@@ -420,11 +423,11 @@ The other defaults are tuned to avoid false-positive failures on a Laravel/Octan
 
 ### `tasks.web.autoscaling.*`
 
-[Application Auto Scaling](/guide/scaling) is **on by default** for the web service (`min: 1`, `max: 5`) — `autoscaling` is `true | false | {config}`, the same boolean-or-object form as the group itself. An omitted key or `autoscaling: true` takes the defaults; **`autoscaling: false`** pins a fixed single task (no scalable target); a `{min, max, …}` object sets bespoke bounds. An empty object (`{}`) is rejected — write `true` or `false`. Web **`min` must be ≥ 1** (it serves traffic and can't idle to zero). With autoscaling on, YOLO scales on **request concurrency** — the default, leading signal, with its target derived from the task's memory so there's nothing to tune — and composes a **CPU** policy alongside as a safety net. The only knobs are the bounds and cooldowns.
+[Application Auto Scaling](/guide/scaling) is **required** for the web service — `autoscaling` is `true | false | {config}` and the key can't be omitted (nor can web use the bare `tasks.web: true` shorthand). **`autoscaling: true`** takes the defaults (`min: 1`, `max: 5`); **`autoscaling: false`** pins a fixed single task (no scalable target); a `{min, max, …}` object sets bespoke bounds. An empty object (`{}`) is rejected — write `true` or `false`. Web **`min` must be ≥ 1** (it serves traffic and can't idle to zero). With autoscaling on, YOLO scales on **request concurrency** — the default, leading signal, with its target derived from the task's memory so there's nothing to tune — and composes a **CPU** policy alongside as a safety net. The only knobs are the bounds and cooldowns.
 
 | Key | Default | Description |
 |---|---|---|
-| `autoscaling` | *(on)* | `false` for a fixed single task; `true` / object to tune. On by default. |
+| `autoscaling` | *(required)* | `true` for scaling on defaults, `false` for a fixed single task, or an object to tune. No implicit default — must be declared. |
 | `autoscaling.min` | `1` | Minimum number of tasks (must be ≥ 1). |
 | `autoscaling.max` | `5` | Maximum number of tasks. |
 | `autoscaling.cpu-utilization` | `65` | Target average CPU % — the safety-net policy composed alongside concurrency. |
@@ -445,22 +448,22 @@ tasks:
 ```
 
 ::: warning Bundled scheduler
-A plain web app bundles the scheduler in the web container, so scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). The `sync` plan lists an advisory under its **Warnings** section whenever the scheduler is bundled into an autoscaling host (the web task, or a standalone queue — both autoscale by default). See [Scaling → the scheduler](/guide/scaling#the-scheduler).
+A plain web app bundles the scheduler in the web container, so scaling to N tasks runs cron N times — every scheduled task would fire on each replica. Every scheduled task **must** use Laravel's `->onOneServer()`, or extract the scheduler into its own service ([`tasks.scheduler`](#tasks-scheduler)). The `sync` plan lists an advisory under its **Warnings** section whenever the scheduler is bundled into an autoscaling host (the web task, or a standalone queue — both must declare autoscaling). See [Scaling → the scheduler](/guide/scaling#the-scheduler).
 :::
 
 ---
 
 ## `tasks.queue.*`
 
-`tasks.queue` is **`true | false | {config}`**. `true` (or a config object) extracts the queue worker into its **own** ECS service, so it scales independently of web; `false` switches the worker off entirely (it runs nowhere, and YOLO enforces `QUEUE_CONNECTION=sync` — see [Where each role runs](#where-each-role-runs)); omitting the block leaves the worker bundled in the web container. An empty block (`queue:`) or empty object (`{}`) is rejected — write `true` for a scale-to-zero worker on default sizing.
+`tasks.queue` is a **config object** that extracts the queue worker into its **own** ECS service (so it scales independently of web), or **`false`** to switch the worker off entirely (it runs nowhere, and YOLO enforces `QUEUE_CONNECTION=sync` — see [Where each role runs](#where-each-role-runs)); omitting the block leaves the worker bundled in the web container. Like web, a standalone queue **must declare `autoscaling`** — there's no bare `queue: true` shorthand, and an empty block (`queue:`) or empty object (`{}`) is rejected.
 
-A standalone queue **autoscales by default** (`min: 1`, `max: 5`) — the same `autoscaling: true | false | {min, max, backlog-per-task}` knob as web, on unless you set `autoscaling: false` (a fixed single task — no scalable target, no backlog policy). Set **`autoscaling.min: 0`** to opt into **scale to zero**: zero tasks — and zero compute cost — when the queue is empty, at the cost of a ~30–60s Fargate cold start on the first message after idle (so it suits bursty, latency-tolerant work). The queue `min` may be `0` (unlike web); but when the queue also hosts the scheduler (a `tasks.queue` block with no [`tasks.scheduler`](#tasks-scheduler)) it can't scale to zero — cron would stop — so an explicit `tasks.queue.autoscaling.min: 0` is rejected there.
+`autoscaling` is the same `true | false | {min, max, backlog-per-task}` knob as web: `true` takes the defaults (`min: 1`, `max: 5`), `false` pins a fixed single task (no scalable target, no backlog policy). Set **`autoscaling.min: 0`** to opt into **scale to zero**: zero tasks — and zero compute cost — when the queue is empty, at the cost of a ~30–60s Fargate cold start on the first message after idle (so it suits bursty, latency-tolerant work). The queue `min` may be `0` (unlike web); but when the queue also hosts the scheduler (a `tasks.queue` block with no [`tasks.scheduler`](#tasks-scheduler)) it can't scale to zero — cron would stop — so an explicit `tasks.queue.autoscaling.min: 0` is rejected there.
 
 Scaling is **backlog-per-task** target tracking (`ApproximateNumberOfMessagesVisible / RunningTaskCount`, CloudWatch metric math — no Lambda). A scale-to-zero queue (`autoscaling.min: 0`) also gets a step-scaling alarm that lifts it 0→1 the instant a message arrives (target tracking can't divide by zero running tasks).
 
 | Key | Default | Description |
 |---|---|---|
-| `tasks.queue.autoscaling` | *(on)* | `false` for a fixed single task; `true` / object to tune. On by default. |
+| `tasks.queue.autoscaling` | *(required)* | `true` for scaling on defaults, `false` for a fixed single task, or an object to tune. No implicit default — must be declared. |
 | `tasks.queue.autoscaling.min` | `1` | Minimum tasks. `0` = scale to zero when idle. |
 | `tasks.queue.autoscaling.max` | `5` | Maximum tasks. |
 | `tasks.queue.autoscaling.backlog-per-task` | `100` | Target visible messages per running task — the scale-out trigger. |

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -128,7 +128,41 @@ abstract class Command extends SymfonyCommand
             && $this->ensureCacheStoreValid()
             && $this->ensureSessionDriverValid()
             && $this->ensureServicesValid()
+            && $this->ensureAutoscalingDeclared()
             && $this->ensureSchedulerHostNotScaleToZero();
+    }
+
+    /**
+     * Web and queue must each make a definitive autoscaling decision — there is no
+     * implicit default. The value is `true` (cost-effective scaling from one task),
+     * `false` (a pinned single task), or a `{ min, max }` block for bespoke bounds.
+     * The bare `tasks.web: true` / `tasks.queue: true` shorthand is therefore not
+     * accepted for these two groups: a scalar tier has nowhere to declare scaling
+     * behaviour. Only the scheduler — a pinned singleton that never scales — keeps
+     * its bare-`true` shorthand. A disabled (`false`) or absent group is exempt.
+     */
+    protected function ensureAutoscalingDeclared(): bool
+    {
+        $enabled = [
+            ServerGroup::WEB->value => Manifest::hasWeb(),
+            ServerGroup::QUEUE->value => Manifest::hasStandaloneQueue(),
+        ];
+
+        foreach ($enabled as $group => $isEnabled) {
+            if ($isEnabled && ! Manifest::has("tasks.$group.autoscaling")) {
+                error(sprintf(
+                    'yolo.yml `tasks.%s` must declare `autoscaling` (true | false | { min, max }) — '
+                    . "web and queue need an explicit scaling decision, so the bare `tasks.%s: true` shorthand isn't accepted.\n"
+                    . 'See the manifest reference: https://codinglabsau.github.io/yolo/reference/manifest',
+                    $group,
+                    $group,
+                ));
+
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -39,9 +39,10 @@ environments:
         port: 8000
         enable-execute-command: true   # ECS Exec shell access (gate with MFA on your IAM)
 
-        # Request-based autoscaling, on by default — web scales out on request concurrency
-        # (with CPU as a safety net and a ~10s burst path), between 1 and 5 tasks. Expand to a
-        # block for your own bounds (autoscaling: { min: 2, max: 8 }); set false to pin one task.
+        # Request-based autoscaling — REQUIRED for web and queue (there is no implicit default,
+        # and the bare `web: true` shorthand isn't accepted for these two). `true` scales out on
+        # request concurrency (CPU safety net + a ~10s burst path) between 1 and 5 tasks; `false`
+        # pins one task; a block sets your own bounds (autoscaling: { min: 2, max: 8 }).
         autoscaling: true
 
         # shutdown-grace-period: seconds the web process gets to finish work on SIGTERM before it's
@@ -50,14 +51,15 @@ environments:
         # shutdown-grace-period: 10
 
       # Extract a workload into its own ECS service so it scales independently of
-      # web — just uncomment its block (presence is the opt-in). A standalone queue
-      # scales to zero by default; the scheduler is a pinned singleton (exactly one
-      # task), which drops the onOneServer() need. With only a queue extracted, the
-      # scheduler rides that queue (so its floor is pinned at min 1).
+      # web — just uncomment its block (presence is the opt-in). The scheduler is a
+      # pinned singleton (exactly one task), which drops the onOneServer() need. With
+      # only a queue extracted, the scheduler rides that queue (so its floor is pinned
+      # at min 1). Like web, a standalone queue must declare `autoscaling`.
       # queue:
-      #   min: 0                 # 0 = scale to zero when idle (default)
-      #   max: 10
-      #   backlog-per-task: 100  # target messages per running task
+      #   autoscaling:           # required — true | false | a { min, max } block
+      #     min: 0               # 0 opts into scale-to-zero when idle (floor defaults to 1)
+      #     max: 10
+      #     backlog-per-task: 100  # target messages per running task
       #   spot: true             # ~70% cheaper interruptible capacity
       #   shutdown-grace-period: 70   # let an in-flight job finish on SIGTERM
       # scheduler:

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -252,10 +252,74 @@ it('bails on an unrecognised key inside a task group', function (): void {
     expect(test()->promptOutput->fetch())->toContain('tasks.web.nonsense');
 });
 
+it('bails when a web config map omits autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['cpu' => '512']],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    $output = test()->promptOutput->fetch();
+    expect($output)->toContain('tasks.web');
+    expect($output)->toContain('autoscaling');
+});
+
+it('bails on the bare `tasks.web: true` shorthand — web needs an explicit autoscaling decision', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+    expect(test()->promptOutput->fetch())->toContain('tasks.web');
+});
+
+it('bails when a standalone queue omits autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['spot' => true]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    $output = test()->promptOutput->fetch();
+    expect($output)->toContain('tasks.queue');
+    expect($output)->toContain('autoscaling');
+});
+
+it('bails on the bare `tasks.queue: true` shorthand', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => true],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+    expect(test()->promptOutput->fetch())->toContain('tasks.queue');
+});
+
+it('accepts a headless app — a disabled web tier needs no autoscaling', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => false],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});
+
+it('keeps the bare `tasks.scheduler: true` shorthand — the scheduler never scales', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => true], 'scheduler' => true],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});
+
 it('bails when the scheduler rides a queue explicitly set to scale to zero', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]]],
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 0]]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeFalse();
@@ -268,7 +332,7 @@ it('bails when the scheduler rides a queue explicitly set to scale to zero', fun
 it('accepts a scheduler-hosting queue with a standing floor of one', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 1]]],
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 1]]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();
@@ -277,7 +341,7 @@ it('accepts a scheduler-hosting queue with a standing floor of one', function ()
 it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'queue' => true],
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => true]],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();
@@ -286,7 +350,7 @@ it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)',
 it('accepts a scale-to-zero queue when the scheduler is its own service', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'queue' => ['autoscaling' => ['min' => 0]], 'scheduler' => true],
+        'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 0]], 'scheduler' => true],
     ]);
 
     expect(invokeManifestIntegrity())->toBeTrue();

--- a/tests/Unit/Commands/InitCommandTest.php
+++ b/tests/Unit/Commands/InitCommandTest.php
@@ -4,6 +4,7 @@ use Codinglabs\Yolo\Paths;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Commands\InitCommand;
+use Codinglabs\Yolo\Commands\SyncCommand;
 
 function dockerignorePatterns(): array
 {
@@ -35,6 +36,22 @@ it('scaffolds web autoscaling on by default', function (): void {
     Helpers::app()->instance('environment', 'production');
 
     expect(Manifest::isAutoscaling())->toBeTrue();
+})->after(fn (): bool => @unlink(Paths::manifest()));
+
+it('scaffolds a manifest that satisfies the autoscaling-required integrity gate', function (): void {
+    // The stub declares an explicit `autoscaling`, so the scaffold a fresh app gets
+    // must pass `ensureManifestIntegrity` rather than tripping the new requirement.
+    file_put_contents(Paths::manifest(), str_replace(
+        ['{NAME}', '{AWS_ACCOUNT_ID}', '{AWS_REGION}'],
+        ['my-app', '111111111111', 'ap-southeast-2'],
+        file_get_contents(Paths::stubs('yolo.yml.stub'))
+    ));
+    Helpers::app()->instance('environment', 'production');
+
+    $command = new SyncCommand();
+    $gate = new ReflectionMethod($command, 'ensureManifestIntegrity');
+
+    expect($gate->invoke($command))->toBeTrue();
 })->after(fn (): bool => @unlink(Paths::manifest()));
 
 it('scaffolds a .dockerignore when none exists', function (): void {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

Autoscaling was *on by default*: an omitted `tasks.{web,queue}.autoscaling` key silently resolved to on (min 1, max 5). A tier's scaling posture is a real cost/resilience decision with no safe universal default, so it shouldn't be inherited silently — a forgotten key reads identically to a deliberate choice.

This makes the key **required** for web and queue:

- An enabled web or queue tier must declare `autoscaling` — `true` (cost-effective scaling from one task), `false` (a pinned single task), or a `{ min, max }` block. Omitting it hard-fails the manifest integrity check.
- The bare `tasks.web: true` / `tasks.queue: true` shorthand is **dropped** for these two groups — a scalar tier has nowhere to state its scaling behaviour, so scaling has to be explicit. Only the scheduler (a pinned singleton that never scales) keeps its bare-`true` shorthand. A disabled (`false`) or absent group is exempt.
- **Latent stub bug fixed:** the commented queue block in `yolo.yml.stub` placed `min`/`max`/`backlog-per-task` directly under `queue:` instead of under `autoscaling:` — uncommenting it as-is would have hard-failed on unknown keys. Also corrected stale "queue scales to zero by default" prose (the floor actually defaults to 1).

**Is there anything the reviewer needs to know to deploy this?**

- **Breaking for existing manifests.** Any web/queue tier that omits `autoscaling`, or uses the bare `tasks.{web,queue}: true` shorthand, now fails the integrity gate until updated. The error names the tier and points at the manifest reference. Adding `autoscaling: true` reproduces the previous default behaviour exactly (min 1, max 5).
- **Enforced at the `ensureManifestIntegrity` gate** (alongside region/account-id), not in the value resolvers — same two-layer pattern as every other required key. The resolvers stay tolerant value-readers, so no behaviour change to live scaling for a correctly-declared manifest.
- No AWS-facing or sync-step changes; this is manifest validation + scaffold + docs only.
- Docs updated across the manifest/scaling/commands references and the multi-tenancy/domains guides (every "on by default" claim and now-invalid bare-`true` YAML example). The VitePress build was **not** run locally (no `node_modules` in the worktree) — all touched links reuse pre-existing anchors, but CI's docs build is the real check.
- Tests: full suite green (1380 passed). New gate coverage for both groups (map-without-autoscaling, bare-`true` rejection, headless `web: false` exemption, `scheduler: true` retained) plus a test proving the shipped `init` stub passes the gate.

🤖 Generated with [Claude Code](https://claude.ai/code)