### PR TITLE
feat(destroy): service-aware destroy:app + strip the environment from yolo.yml

### DIFF
--- a/src/Commands/DestroyAppCommand.php
+++ b/src/Commands/DestroyAppCommand.php
@@ -4,6 +4,8 @@ namespace Codinglabs\Yolo\Commands;
 
 use Codinglabs\Yolo\Steps;
 use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Service;
+use Codinglabs\Yolo\Services\ServiceDefinition;
 
 use function Laravel\Prompts\error;
 
@@ -51,19 +53,45 @@ class DestroyAppCommand extends SyncSteppedCommand
      * Each refusal is a deliberate safety stop: a partial teardown would leave
      * orphaned resources behind (which `yolo audit` then flags), so an
      * unsupported shape is refused rather than half-deleted.
+     *
+     * Services no longer refuse outright — destroy:app reverses each service's
+     * per-app resources (see {@see appServiceTeardownSteps()}). The only service
+     * stop left is the honest one: a service with per-app resources whose teardown
+     * isn't modelled yet would orphan them, so it's named and refused.
      */
     protected function unsupportedReason(): ?string
     {
         return match (true) {
-            Manifest::isMultitenanted() => 'destroy:app does not yet support multi-tenant apps — their per-tenant queues and SNI certificates would be left behind. Tracked in LPX-695.',
-            Manifest::isHeadless() => 'destroy:app does not yet support headless apps (no domain / ALB). Tracked in LPX-695.',
-            ! Manifest::hasWeb() => 'destroy:app only supports apps with a web task today. Tracked in LPX-695.',
-            Manifest::services() !== [] => sprintf(
-                'destroy:app does not yet tear down env-service resources (%s) — the app\'s per-service IAM and keys would be orphaned. Remove the service(s) from yolo.yml and deploy first, or wait for service-aware teardown. Tracked in LPX-695.',
-                implode(', ', Manifest::services()),
+            Manifest::isMultitenanted() => 'destroy:app does not yet support multi-tenant apps — their per-tenant queues and SNI certificates would be left behind.',
+            Manifest::isHeadless() => 'destroy:app does not yet support headless apps (no domain / ALB).',
+            ! Manifest::hasWeb() => 'destroy:app only supports apps with a web task today.',
+            ($unmodelled = static::servicesWithoutTeardown()) !== [] => sprintf(
+                'destroy:app cannot yet tear down the per-app resources for: %s. Remove the service(s) from yolo.yml and deploy first.',
+                implode(', ', $unmodelled),
             ),
             default => null,
         };
+    }
+
+    /**
+     * The services this app uses that create per-app resources (appSteps) but
+     * model no teardown for them — tearing the app down would orphan those, so
+     * they're refused. Empty for every service today; a new service with appSteps
+     * and no teardownAppSteps trips it until its reverse steps are written.
+     *
+     * @return array<int, string>
+     */
+    protected static function servicesWithoutTeardown(): array
+    {
+        return array_values(array_map(
+            fn (ServiceDefinition $definition): string => $definition->service()->value,
+            array_filter(
+                Service::definitions(),
+                fn (ServiceDefinition $definition): bool => Manifest::usesService($definition->service())
+                    && $definition->appSteps() !== []
+                    && $definition->teardownAppSteps() === [],
+            ),
+        ));
     }
 
     #[\Override]
@@ -114,6 +142,10 @@ class DestroyAppCommand extends SyncSteppedCommand
                 Steps\Destroy\App\TeardownRedirectRuleStep::class,
                 Steps\Destroy\App\TeardownTargetGroupStep::class,
                 Steps\Destroy\App\TeardownTaskLogGroupStep::class,
+                // Per-app service resources (e.g. the Typesense node-SG ingress this
+                // app added) before the task SG / task role they hang off — each
+                // service's reverse steps, self-gating on the app's own usage.
+                ...static::appServiceTeardownSteps(),
                 // Revoke shared-SG ingress before deleting the task SG those rules
                 // reference. The cache revoke self-skips when the app has no cache SG.
                 Steps\Destroy\App\RevokeCacheIngressStep::class,
@@ -132,10 +164,35 @@ class DestroyAppCommand extends SyncSteppedCommand
                 Steps\Destroy\App\TeardownDeployerPolicyStep::class,
                 Steps\Destroy\App\TeardownAppObserverPolicyStep::class,
                 Steps\Destroy\App\UnpublishAppManifestStep::class,
+                // This app's per-app env file in the (env-shared) env config bucket —
+                // its build env channel, which also held any minted Typesense keys.
+                Steps\Destroy\App\RemoveAppEnvFileStep::class,
                 Steps\Destroy\App\TeardownAssetBucketStep::class,
                 Steps\Destroy\App\TeardownS3ConfigBucketStep::class,
                 Steps\Destroy\App\TeardownEcrRepositoryStep::class,
+                // Final act: stop yolo.yml advertising an environment whose resources
+                // are now gone — surgical, format-preserving, warns if it can't.
+                Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class,
             ])),
         ];
+    }
+
+    /**
+     * Every used service's per-app teardown steps, composed from the definitions
+     * in enum order — the mirror of SyncAppCommand's app service composition. Each
+     * step self-gates, so composing them all is safe; a service the app never used
+     * tears nothing down.
+     *
+     * @return array<int, class-string>
+     */
+    protected static function appServiceTeardownSteps(): array
+    {
+        $steps = [];
+
+        foreach (Service::definitions() as $definition) {
+            $steps = [...$steps, ...$definition->teardownAppSteps()];
+        }
+
+        return $steps;
     }
 }

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -154,7 +154,7 @@ class SyncAppCommand extends SyncSteppedCommand
                 Steps\Sync\App\SyncAppObserverRoleStep::class,
                 Steps\Sync\App\AttachDeployerRolePoliciesStep::class,
                 Steps\Sync\App\AttachAppObserverRolePolicyStep::class,
-                // per-app grant groups (LPX-680): membership grants deploy / read
+                // per-app grant groups: membership grants deploy / read
                 // on THIS app only. The deployers group is gated on a GitHub repo
                 // like the deployer role it points at; the observers group is always
                 // provisioned so a read grant can name a single app.
@@ -181,7 +181,7 @@ class SyncAppCommand extends SyncSteppedCommand
                         // alarm on it (mirrors the standalone-service melt below).
                         // Reverse-dependency order on teardown: alarm before queue.
                         // (Multi-tenant queues stay unconditional — their per-tenant
-                        // teardown is the unbuilt destroy:app gap, LPX-695.)
+                        // teardown is the unbuilt destroy:app gap.)
                         ...Manifest::queueDisabled()
                             ? [
                                 Steps\Destroy\App\TeardownQueueAlarmStep::class,

--- a/src/Commands/SyncEnvironmentCommand.php
+++ b/src/Commands/SyncEnvironmentCommand.php
@@ -109,11 +109,11 @@ class SyncEnvironmentCommand extends SyncSteppedCommand
                 // pre-deploy `sync --check` gate can read the whole stack under the
                 // deploy role, scoped to exactly the services YOLO provisions.
                 Steps\Sync\Environment\SyncObserverPolicyStep::class,
-                // The read-only role an operator/agent assumes for safe inspection
-                // (LPX-635) — created, then the observer policy attached to it.
+                // The read-only role an operator/agent assumes for safe inspection —
+                // created, then the observer policy attached to it.
                 Steps\Sync\Environment\SyncObserverRoleStep::class,
                 Steps\Sync\Environment\AttachObserverRolePolicyStep::class,
-                // The Admin tier (LPX-680): the write surface (yolo-{env}-admin)
+                // The Admin tier: the write surface (yolo-{env}-admin)
                 // and the role an operator assumes to run `yolo sync` / `yolo scale`
                 // capped to YOLO's blast radius. The role carries the observer
                 // (read) + admin (write) policies. Self-activating — the first sync
@@ -121,7 +121,7 @@ class SyncEnvironmentCommand extends SyncSteppedCommand
                 Steps\Sync\Environment\SyncAdminPolicyStep::class,
                 Steps\Sync\Environment\SyncAdminRoleStep::class,
                 Steps\Sync\Environment\AttachAdminRolePolicyStep::class,
-                // Grant groups (LPX-680): membership is the access lever. The
+                // Grant groups: membership is the access lever. The
                 // env-wide observers + admins groups each allow sts:AssumeRole on
                 // their tier role; YOLO owns the group + policy, never membership.
                 Steps\Sync\Environment\SyncObserversGroupStep::class,

--- a/src/Concerns/SynchronisesResource.php
+++ b/src/Concerns/SynchronisesResource.php
@@ -19,7 +19,7 @@ use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
  * apply=false so nothing is written), and any missing key / drifted attribute
  * is recorded as a Change so the plan→apply orchestrator (`SyncSteppedCommand`)
  * can list exactly what would change, and so the apply pass survives the
- * "only-pending-steps" filter from PR #57 (a step with tag drift but no
+ * "only-pending-steps" filter (a step with tag drift but no
  * config drift was silently dropped before, so the plan-clean SYNCED meant
  * the apply never ran the tag write).
  */

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -418,6 +418,101 @@ class Manifest
     }
 
     /**
+     * Surgically remove an environment's entire block from yolo.yml — the
+     * `environments.{environment}` key and every line nested under it, the
+     * trailing blank separator included — preserving every other byte (comments,
+     * ordering, the sibling environments' quoting), unlike the put() re-dump.
+     * The reverse of declaring a deployment target: `destroy:app` calls it as its
+     * final act, once the environment's resources are gone, so yolo.yml stops
+     * advertising a target that no longer exists.
+     *
+     * Verifies the result parses and that exactly this environment — and nothing
+     * else — was dropped before committing, so an unanticipated layout never
+     * corrupts the file: on any doubt it writes nothing and returns false, and
+     * the caller falls back to telling the operator to edit by hand.
+     */
+    public static function removeEnvironment(string $environment): bool
+    {
+        $raw = (string) file_get_contents(Paths::manifest());
+
+        $rewritten = static::rewriteEnvironmentRemoval($raw, $environment);
+
+        // Safety net: only commit a result that parses and leaves exactly the
+        // sibling environments standing — never a manifest mangled by an odd layout.
+        try {
+            $before = array_keys((array) Arr::get(Yaml::parse($raw) ?? [], 'environments', []));
+            $after = array_keys((array) Arr::get(Yaml::parse($rewritten) ?? [], 'environments', []));
+        } catch (\Throwable) {
+            return false;
+        }
+
+        if ($after !== array_values(array_diff($before, [$environment]))) {
+            return false;
+        }
+
+        return file_put_contents(Paths::manifest(), $rewritten) !== false;
+    }
+
+    /**
+     * The pure line-surgery behind removeEnvironment — returns the rewritten YAML
+     * with the `environments.{environment}` block (header + nested children +
+     * trailing blank lines) excised, or the input unchanged when the environment
+     * is already absent. The block ends at the next line indented no deeper than
+     * the header (a sibling environment or a top-level key) or at end of file.
+     */
+    protected static function rewriteEnvironmentRemoval(string $raw, string $environment): string
+    {
+        $lines = explode("\n", $raw);
+        $path = ['environments', $environment];
+
+        $stack = [];
+
+        foreach ($lines as $index => $line) {
+            if (! preg_match('/^(\s*)([A-Za-z0-9_.-]+):(.*)$/', $line, $matches)) {
+                continue;
+            }
+
+            $indent = strlen($matches[1]);
+
+            while ($stack !== [] && end($stack)[0] >= $indent) {
+                array_pop($stack);
+            }
+
+            $stack[] = [$indent, $matches[2]];
+            $currentPath = array_map(fn (array $entry): string => $entry[1], $stack);
+
+            if ($currentPath !== $path) {
+                continue;
+            }
+
+            // The block runs from the header to the next structural line indented
+            // no deeper than it; trailing blank lines are swept with it so the
+            // separator goes too, leaving the surviving siblings cleanly spaced.
+            $end = $index + 1;
+
+            while ($end < count($lines)) {
+                if (trim($lines[$end]) === '') {
+                    $end++;
+
+                    continue;
+                }
+
+                if (preg_match('/^(\s*)\S/', $lines[$end], $next) && strlen($next[1]) <= $indent) {
+                    break;
+                }
+
+                $end++;
+            }
+
+            array_splice($lines, $index, $end - $index);
+
+            return implode("\n", $lines);
+        }
+
+        return $raw;
+    }
+
+    /**
      * Render a scalar as a YAML value — bare where safe, double-quoted when it
      * contains characters that would otherwise change the parse.
      */

--- a/src/Resources/CloudWatch/QueueAlarm.php
+++ b/src/Resources/CloudWatch/QueueAlarm.php
@@ -20,13 +20,9 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * steps share it.
  *
  * A full Resource (+ SynchronisesConfiguration) so it rides the same create-or-sync
- * path as every other resource. It used to be a bespoke reconciler whose step
- * short-circuited to WOULD_SYNC on dry-run and re-put the alarm on every apply
- * regardless of drift — invisible in the plan's "Pending changes" yet still
- * tripping the confirm gate forever (so `yolo sync` on a clean account never
- * reported "Already in sync"). Modelling it as a Resource makes its tag AND config
- * drift surface symmetrically through syncResource(): a clean alarm records no
- * change and is pruned before apply; a drifted one is listed current → desired.
+ * path as every other resource, with its tag AND config drift surfacing
+ * symmetrically through syncResource(): a clean alarm records no change and is
+ * pruned before apply; a drifted one is listed current → desired.
  *
  * putMetricAlarm has no create/exists split (it's a pure upsert), which exists()
  * = DescribeAlarms + create() = putMetricAlarm resolves cleanly. Tags need their

--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -303,7 +303,7 @@ class AdminPolicy implements Resource, SynchronisesConfiguration
                     'Action' => ['iam:DetachRolePolicy'],
                 ],
                 [
-                    // Grant groups (LPX-680): sync provisions and reconciles the
+                    // Grant groups: sync provisions and reconciles the
                     // YOLO grant groups + their inline assume-role policy, and an
                     // admin manages their membership via `yolo permissions`. Scoped
                     // to yolo-* groups — the tier can never touch a non-YOLO group.

--- a/src/Resources/Iam/AdminRole.php
+++ b/src/Resources/Iam/AdminRole.php
@@ -13,7 +13,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * YOLO-managed IAM role an operator assumes to **provision** an environment — the
- * Admin tier of LPX-680 Phase 0. `yolo sync` / `yolo scale` run capped to this
+ * Admin tier. `yolo sync` / `yolo scale` run capped to this
  * role so a local operator can never exceed YOLO's own blast radius, even when
  * their personal identity is account-admin. It carries the read surface
  * ({@see ObserverPolicy}) plus the write surface ({@see AdminPolicy}).

--- a/src/Resources/Iam/ObserverRole.php
+++ b/src/Resources/Iam/ObserverRole.php
@@ -13,8 +13,8 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * YOLO-managed IAM role an operator or an automated agent assumes for
- * **read-only** inspection of the environment — the `*-readonly` profile target
- * from LPX-635. It carries the env-shared {@see ObserverPolicy} policy (attached by
+ * **read-only** inspection of the environment — the `*-readonly` profile target.
+ * It carries the env-shared {@see ObserverPolicy} policy (attached by
  * AttachObserverRolePolicyStep), so a profile assuming it can `describe`/`list`/
  * `get` exactly the services YOLO touches and **nothing mutating** — safe by
  * construction, not by convention.

--- a/src/Resources/Iam/SynchronisesPolicyDocument.php
+++ b/src/Resources/Iam/SynchronisesPolicyDocument.php
@@ -41,7 +41,7 @@ trait SynchronisesPolicyDocument
         // Canonical compare, not a naive json_encode string match: IAM round-trips
         // the document with reordered keys/statements and collapses single-element
         // Action/Condition lists to scalars, which a string compare reads as drift —
-        // re-versioning on every sync and burning the 5-version cap (LPX-670). Shared
+        // re-versioning on every sync and burning the 5-version cap. Shared
         // with SynchronisesAssumeRolePolicy via CanonicalisesPolicyDocuments.
         if ($this->policyDocumentsMatch($live, $desired)) {
             return [];

--- a/src/Services/MediaConvert.php
+++ b/src/Services/MediaConvert.php
@@ -74,6 +74,19 @@ class MediaConvert extends ServiceDefinition
     }
 
     /**
+     * Tear down the per-app role MediaConvert assumes — the mirror of
+     * SyncMediaConvertRoleStep. Its delete() detaches the policies first, so the
+     * one step reverses both appSteps.
+     */
+    #[\Override]
+    public function teardownAppSteps(): array
+    {
+        return [
+            Steps\Destroy\App\TeardownMediaConvertRoleStep::class,
+        ];
+    }
+
+    /**
      * Consuming mediaconvert provisions a per-app role for MediaConvert to
      * assume; the app passes it on every CreateJob, so the computed ARN is
      * baked in at build.

--- a/src/Services/ServiceDefinition.php
+++ b/src/Services/ServiceDefinition.php
@@ -143,6 +143,20 @@ abstract class ServiceDefinition
     }
 
     /**
+     * The ordered destroy:app steps that tear this service's per-app resources
+     * down — the mirror of {@see appSteps()}, composed into destroy:app the same
+     * way appSteps composes into sync:app. Each step self-gates, so it skips for
+     * an app that never consumed the service. A service whose app side is task-role
+     * grants only (swept with the task role) needs none.
+     *
+     * @return array<int, class-string>
+     */
+    public function teardownAppSteps(): array
+    {
+        return [];
+    }
+
+    /**
      * Build-time env values injected (unconditionally — these are YOLO-owned
      * keys, not defaults) when the app consumes this service.
      *

--- a/src/Services/Typesense.php
+++ b/src/Services/Typesense.php
@@ -238,6 +238,20 @@ class Typesense extends ServiceDefinition
     }
 
     /**
+     * Revoke this app's 8108 ingress from the env-shared node SG — the mirror of
+     * SyncTypesenseAppIngressStep. The minted keys it also wrote ride the app's
+     * per-app env file (env/.env.{app}), which destroy:app removes wholesale, so
+     * they need no service-specific step here.
+     */
+    #[\Override]
+    public function teardownAppSteps(): array
+    {
+        return [
+            Steps\Destroy\App\RevokeTypesenseIngressStep::class,
+        ];
+    }
+
+    /**
      * Build-time env injection for a consuming app, both traffic paths:
      *
      * - Server-side indexing (private, in-VPC, off the ALB/WAF — bulk reimports

--- a/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
+++ b/src/Steps/Build/Fargate/CheckMetricsRuntimeStep.php
@@ -23,7 +23,7 @@ use Codinglabs\Yolo\Resources\Ecr\EcrRepository;
  * off FrankenPHP registers no gauges, the runtime reporter reads nothing and publishes
  * no datapoint, the burst alarm sits in INSUFFICIENT_DATA, and the deploy still goes green on the
  * target-tracking policies — burst is simply, invisibly, dark (exactly how it shipped
- * broken in #118). Probing the actual image (`docker run … grep`, matching
+ * broken). Probing the actual image (`docker run … grep`, matching
  * CheckSsrRuntimeStep / CheckSchedulerRuntimeStep) catches both a Caddyfile that never
  * got generated and a Dockerfile that doesn't copy the build context into the image.
  *

--- a/src/Steps/Destroy/App/RemoveAppEnvFileStep.php
+++ b/src/Steps/Destroy/App/RemoveAppEnvFileStep.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\App;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Aws\S3;
+use Codinglabs\Yolo\Change;
+use Illuminate\Support\Arr;
+use Aws\S3\Exception\S3Exception;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
+
+/**
+ * Deletes this app's per-app env file (env/.env.{app}) from the env config
+ * bucket — the build's per-app environment channel, which also carries any
+ * Typesense keys sync:app minted. One object per app, so removing it touches
+ * only this app and never the env-shared .env beside it; the env config bucket
+ * itself is env-shared and left standing.
+ */
+class RemoveAppEnvFileStep implements Step
+{
+    use RecordsChanges;
+
+    public function __invoke(array $options): StepResult
+    {
+        if (! $this->exists()) {
+            return StepResult::SKIPPED;
+        }
+
+        $this->recordChange(Change::make(Paths::s3EnvAppEnvKey(), 'provisioned', null));
+
+        if ((bool) Arr::get($options, 'dry-run')) {
+            return StepResult::WOULD_DELETE;
+        }
+
+        Aws::s3()->deleteObject([
+            'Bucket' => Paths::s3EnvConfigBucket(),
+            'Key' => Paths::s3EnvAppEnvKey(),
+        ]);
+
+        return StepResult::DELETED;
+    }
+
+    protected function exists(): bool
+    {
+        try {
+            Aws::s3()->headObject([
+                'Bucket' => Paths::s3EnvConfigBucket(),
+                'Key' => Paths::s3EnvAppEnvKey(),
+            ]);
+
+            return true;
+        } catch (S3Exception $e) {
+            if (S3::isNotFound($e)) {
+                return false;
+            }
+
+            throw $e;
+        }
+    }
+}

--- a/src/Steps/Destroy/App/RemoveEnvironmentFromManifestStep.php
+++ b/src/Steps/Destroy/App/RemoveEnvironmentFromManifestStep.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\App;
+
+use Codinglabs\Yolo\Change;
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
+use Codinglabs\Yolo\Concerns\RecordsWarnings;
+
+/**
+ * The final act of destroy:app: drop this environment's entire block from the
+ * local yolo.yml, so the manifest stops advertising a deployment target whose
+ * resources have just been torn down. A local-file change, not an AWS one — the
+ * reverse of declaring the environment to deploy to it. Surgical and
+ * format-preserving (see {@see Manifest::removeEnvironment()}); if the block's
+ * layout can't be edited safely it writes nothing and warns the operator to
+ * remove it by hand rather than risk corrupting the file.
+ */
+class RemoveEnvironmentFromManifestStep implements Step
+{
+    use RecordsChanges;
+    use RecordsWarnings;
+
+    public function __invoke(array $options): StepResult
+    {
+        $environment = Helpers::environment();
+
+        if (! Manifest::environmentExists($environment)) {
+            return StepResult::SKIPPED;
+        }
+
+        $this->recordChange(Change::make("environment {$environment} in yolo.yml", 'declared', null));
+
+        if ((bool) Arr::get($options, 'dry-run')) {
+            return StepResult::WOULD_DELETE;
+        }
+
+        if (! Manifest::removeEnvironment($environment)) {
+            $this->recordWarning(sprintf(
+                "Couldn't safely remove the %s environment from yolo.yml — delete the environments.%s block by hand.",
+                $environment,
+                $environment,
+            ));
+
+            return StepResult::SKIPPED;
+        }
+
+        return StepResult::DELETED;
+    }
+}

--- a/src/Steps/Destroy/App/RevokeTypesenseIngressStep.php
+++ b/src/Steps/Destroy/App/RevokeTypesenseIngressStep.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\App;
+
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Service;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Services\Typesense;
+use Codinglabs\Yolo\Contracts\ExecutesWebStep;
+use Codinglabs\Yolo\Concerns\RevokesTaskIngress;
+use Codinglabs\Yolo\Resources\Ec2\TypesenseSecurityGroup;
+use Codinglabs\Yolo\Steps\Sync\App\SyncTypesenseAppIngressStep;
+
+/**
+ * Revokes this app's "8108 from the task SG" ingress rule from the env-shared
+ * Typesense node security group — never the group itself, which the cluster and
+ * the environment's other consumers keep. The teardown mirror of
+ * {@see SyncTypesenseAppIngressStep}, and the
+ * same RDS/cache revoke pattern: it must run before the task SG is deleted (AWS
+ * refuses to delete a security group another group's rule still references).
+ * Self-skips for an app that never consumed Typesense, or once the cluster's SG
+ * is already gone.
+ */
+class RevokeTypesenseIngressStep implements ExecutesWebStep
+{
+    use RevokesTaskIngress;
+
+    public function __invoke(array $options): StepResult
+    {
+        if (! Manifest::usesService(Service::TYPESENSE)) {
+            return StepResult::SKIPPED;
+        }
+
+        $securityGroup = new TypesenseSecurityGroup();
+
+        if (! $securityGroup->exists()) {
+            return StepResult::SKIPPED;
+        }
+
+        $dryRun = (bool) Arr::get($options, 'dry-run');
+
+        if (! $this->revokeTaskIngressRule($securityGroup->arn(), Typesense::API_PORT, $dryRun)) {
+            return StepResult::SKIPPED;
+        }
+
+        return $dryRun ? StepResult::WOULD_DELETE : StepResult::DELETED;
+    }
+}

--- a/src/Steps/Destroy/App/TeardownMediaConvertRoleStep.php
+++ b/src/Steps/Destroy/App/TeardownMediaConvertRoleStep.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\App;
+
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+use Codinglabs\Yolo\Resources\Iam\MediaConvertRole;
+use Codinglabs\Yolo\Steps\Sync\App\SyncMediaConvertRoleStep;
+
+/**
+ * Tears down the per-app IAM role MediaConvert assumes — the mirror of
+ * {@see SyncMediaConvertRoleStep}. Its delete()
+ * detaches the attached policies first, so this one step reverses both of the
+ * service's appSteps. Self-skips via exists() for an app that never consumed
+ * MediaConvert.
+ */
+class TeardownMediaConvertRoleStep extends TeardownStep
+{
+    protected function resource(): MediaConvertRole
+    {
+        return new MediaConvertRole();
+    }
+}

--- a/src/Steps/Sync/App/SyncTaskDefinitionStep.php
+++ b/src/Steps/Sync/App/SyncTaskDefinitionStep.php
@@ -66,7 +66,7 @@ class SyncTaskDefinitionStep implements Step
 
         // The registered revision already renders the desired payload — nothing to
         // do, so the step is pruned before apply and a clean app reports "Already
-        // in sync" instead of registering a no-op revision every time (LPX-646).
+        // in sync" instead of registering a no-op revision every time.
         if ($live !== null && $this->matchesDesired(Arr::except($desired, ['tags']), $live)) {
             return StepResult::SYNCED;
         }

--- a/src/Steps/Sync/Environment/SyncDefaultRouteStep.php
+++ b/src/Steps/Sync/Environment/SyncDefaultRouteStep.php
@@ -19,7 +19,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * block lists them, so we diff against that and only call createRoute when the
  * default route is absent — instead of re-stamping it (idempotently) on every
  * sync, which recorded no Change and so kept tripping the confirm gate even on a
- * clean account (LPX-646).
+ * clean account.
  */
 class SyncDefaultRouteStep implements Step
 {

--- a/src/Steps/Sync/Environment/SyncLoadBalancerSecurityGroupStep.php
+++ b/src/Steps/Sync/Environment/SyncLoadBalancerSecurityGroupStep.php
@@ -45,7 +45,7 @@ class SyncLoadBalancerSecurityGroupStep implements Step
         // Surface tag drift (e.g. the yolo:scope marker) the way
         // SynchronisesResource does: compute it regardless of --dry-run so the
         // plan lists it and the apply pass isn't dropped by the
-        // only-pending-steps filter (#57); the write happens only when applying.
+        // only-pending-steps filter; the write happens only when applying.
         $drifted = false;
 
         foreach ($securityGroup->synchroniseTags(apply: ! $dryRun) as $key => $value) {

--- a/src/Steps/Sync/Environment/SyncObserverRoleStep.php
+++ b/src/Steps/Sync/Environment/SyncObserverRoleStep.php
@@ -8,7 +8,7 @@ use Codinglabs\Yolo\Resources\Iam\ObserverRole;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 
 /**
- * Provisions the env-shared read-only `yolo-{env}-observer-role` (LPX-635) an
+ * Provisions the env-shared read-only `yolo-{env}-observer-role` an
  * operator or agent assumes for safe inspection. Unconditional, like the observer
  * policy it carries — it stands up with the environment. The read-only policy is
  * attached by {@see AttachObserverRolePolicyStep}, which runs after this.

--- a/src/Steps/Sync/Environment/SyncPublicSubnetsAssociationToRouteTableStep.php
+++ b/src/Steps/Sync/Environment/SyncPublicSubnetsAssociationToRouteTableStep.php
@@ -19,7 +19,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * lookup for an association, but the route table's `Associations` block lists them,
  * so we diff against that and only associate the subnets that aren't already
  * attached — instead of re-associating all three on every sync, which recorded no
- * Change and so kept tripping the confirm gate even on a clean account (LPX-646).
+ * Change and so kept tripping the confirm gate even on a clean account.
  */
 class SyncPublicSubnetsAssociationToRouteTableStep implements Step
 {

--- a/tests/Arch/ResourceTeardownTest.php
+++ b/tests/Arch/ResourceTeardownTest.php
@@ -17,7 +17,7 @@ use Codinglabs\Yolo\Resources\S3\S3Bucket;
  * {@see Deletable} (or, for a future shared resource, is moved off App scope).
  *
  * Env- and Account-scoped resources are intentionally NOT yet required to be
- * deletable — environment teardown is a later phase of LPX-695.
+ * deletable — environment teardown is a later phase.
  */
 it('every app-scoped resource is deletable, except the BYO data bucket', function (): void {
     $instantiate = function (ReflectionClass $reflection): object {

--- a/tests/Arch/SyncStepReconcilerTest.php
+++ b/tests/Arch/SyncStepReconcilerTest.php
@@ -10,7 +10,7 @@ use Codinglabs\Yolo\Steps\Sync\App\Tenant\SyncSslCertificateStep as TenantSslCer
 /**
  * Every sync step that mutates AWS must be able to record drift into the plan: a
  * write that records no Change is invisible to the plan pass and pruned before
- * apply — the LPX-646 / #95 class of bug. The structural floor is that every
+ * apply — the invisible-write class of bug. The structural floor is that every
  * concrete `Steps\Sync` step exposes `changes()` (via RecordsChanges, directly or
  * through SynchronisesResource / inheritance).
  *
@@ -31,7 +31,7 @@ it('every sync step can record drift into the plan, or is an explicit exemption'
         SyncInternetGatewayAttachmentStep::class, // checks the attachment state before attaching
     ];
 
-    // Known debt — does NOT belong here long-term. Tracked in LPX-669: it returns
+    // Known debt — does NOT belong here long-term: it returns
     // WOULD_SYNC on every plan pass regardless of drift, so a multi-tenant sync
     // never reaches "Already in sync". Remove once it's made diff-first.
     $knownOverReporters = [

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -157,7 +157,7 @@ function bindRoutedS3Client(array $byCommand, array &$captured): void
 }
 
 /**
- * Assert a sync step honours the reconciler contract that the LPX-646 / #95 class
+ * Assert a sync step honours the reconciler contract that the invisible-write class
  * of bug violated: its plan-pass status and recorded changes must reflect ACTUAL
  * drift, and it must never write on the plan pass. This is the shared standard —
  * every sync step that mutates AWS should carry one of these:

--- a/tests/Unit/Commands/DestroyAppCommandTest.php
+++ b/tests/Unit/Commands/DestroyAppCommandTest.php
@@ -48,11 +48,30 @@ it('refuses a partial teardown rather than orphaning resources', function (array
     'multi-tenant' => [['domain' => 'example.com', 'tasks' => ['web' => true], 'tenants' => ['t1' => ['domain' => 't1.example.com']]], 'multi-tenant'],
     'headless' => [['tasks' => ['web' => true]], 'headless'],
     'no web task' => [['domain' => 'example.com'], 'web task'],
-    'env services' => [['domain' => 'example.com', 'tasks' => ['web' => true], 'services' => ['typesense']], 'env-service'],
 ]);
 
 it('allows a standard solo web app', function () use ($soloWeb): void {
     expect(destroyReason($soloWeb))->toBeNull();
+});
+
+it('allows a solo web app that consumes services — their per-app teardown is modelled', function (): void {
+    expect(destroyReason(['domain' => 'example.com', 'tasks' => ['web' => true], 'services' => ['typesense', 'rekognition']]))->toBeNull();
+});
+
+it('composes a used service\'s per-app teardown, ahead of the task SG it references', function (): void {
+    $classes = destroyPlanClasses(['domain' => 'example.com', 'tasks' => ['web' => true], 'services' => ['typesense']]);
+    $at = fn (string $class): int|false => array_search($class, $classes, true);
+
+    expect($classes)->toContain(Steps\Destroy\App\RevokeTypesenseIngressStep::class);
+
+    // The Typesense ingress is revoked before the task SG its rule references is deleted.
+    expect($at(Steps\Destroy\App\RevokeTypesenseIngressStep::class))
+        ->toBeLessThan($at(Steps\Destroy\App\TeardownTaskSecurityGroupStep::class));
+});
+
+it('composes the MediaConvert role teardown when the app uses mediaconvert', function (): void {
+    expect(destroyPlanClasses(['domain' => 'example.com', 'tasks' => ['web' => true], 'services' => ['mediaconvert']]))
+        ->toContain(Steps\Destroy\App\TeardownMediaConvertRoleStep::class);
 });
 
 it('tears resources down in reverse dependency order', function () use ($soloWeb): void {
@@ -73,8 +92,11 @@ it('tears resources down in reverse dependency order', function () use ($soloWeb
     expect($at(Steps\Destroy\App\DeregisterWebAutoscalingStep::class))
         ->toBeLessThan($at(Steps\Destroy\App\TeardownWebServiceStep::class));
 
-    // ECR (holding the images) is the very last thing to go.
-    expect($at(Steps\Destroy\App\TeardownEcrRepositoryStep::class))->toBe(count($classes) - 1);
+    // Stripping the environment from yolo.yml is the very last act; ECR (holding
+    // the images) is the last AWS resource to go, just before it.
+    expect($at(Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class))->toBe(count($classes) - 1);
+    expect($at(Steps\Destroy\App\TeardownEcrRepositoryStep::class))
+        ->toBeLessThan($at(Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class));
 });
 
 it('never includes a teardown for the BYO app data bucket', function () use ($soloWeb): void {

--- a/tests/Unit/Concerns/SynchronisesResourceTest.php
+++ b/tests/Unit/Concerns/SynchronisesResourceTest.php
@@ -95,7 +95,7 @@ it('reports SYNCED and records the changes a real sync applied to a config-drift
 it('records missing tags as Changes so tag drift survives the apply-pending filter', function (): void {
     // The bug the new shape fixes: previously, a resource missing yolo:scope=env
     // returned a clean SYNCED at plan time (synchroniseTags was a no-op void),
-    // so PR #57's "only-pending-steps" filter dropped it from apply, so the tag
+    // so the "only-pending-steps" filter dropped it from apply, so the tag
     // never got written. Now tag drift is recorded as a Change and surfaces as
     // WOULD_SYNC (dry-run) / SYNCED-with-changes (real).
     $resource = new FakeConfigResource(present: true, missingTags: ['yolo:scope' => 'env']);

--- a/tests/Unit/ManifestRemoveEnvironmentTest.php
+++ b/tests/Unit/ManifestRemoveEnvironmentTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Manifest;
+use Symfony\Component\Yaml\Yaml;
+
+function writeRemoveEnvManifest(string $yaml): void
+{
+    file_put_contents(BASE_PATH . '/yolo.yml', $yaml);
+}
+
+it('removes a middle environment block, preserving siblings, comments and blank lines', function (): void {
+    writeRemoveEnvManifest(<<<'YAML'
+    name: my-app
+
+    environments:
+      production:
+        domain: example.com  # the real one
+        services:
+          - typesense
+
+      typesense:
+        domain: typesense.example.com
+        tasks:
+          web: {}
+
+      staging:
+        domain: staging.example.com
+    YAML);
+
+    expect(Manifest::removeEnvironment('typesense'))->toBeTrue();
+
+    expect(file_get_contents(BASE_PATH . '/yolo.yml'))->toBe(<<<'YAML'
+    name: my-app
+
+    environments:
+      production:
+        domain: example.com  # the real one
+        services:
+          - typesense
+
+      staging:
+        domain: staging.example.com
+    YAML);
+});
+
+it('removes the last environment block', function (): void {
+    writeRemoveEnvManifest(<<<'YAML'
+    name: my-app
+
+    environments:
+      production:
+        domain: example.com
+
+      typesense:
+        domain: typesense.example.com
+        tasks:
+          web: {}
+    YAML);
+
+    expect(Manifest::removeEnvironment('typesense'))->toBeTrue();
+
+    $raw = file_get_contents(BASE_PATH . '/yolo.yml');
+
+    expect($raw)->toContain('production:')->not->toContain('typesense');
+    expect(array_keys(Yaml::parse($raw)['environments']))->toBe(['production']);
+});
+
+it('refuses (false) and leaves the file untouched when the layout is too ambiguous to edit safely', function (): void {
+    // An inline (flow) environments map can't be surgically block-edited — bail
+    // rather than risk corrupting it.
+    $yaml = <<<'YAML'
+    name: my-app
+    environments: { production: { domain: example.com }, typesense: { domain: ts.example.com } }
+    YAML;
+    writeRemoveEnvManifest($yaml);
+
+    expect(Manifest::removeEnvironment('typesense'))->toBeFalse();
+    expect(file_get_contents(BASE_PATH . '/yolo.yml'))->toBe($yaml);
+});
+
+it('is a safe no-op when the environment is already absent', function (): void {
+    writeRemoveEnvManifest(<<<'YAML'
+    name: my-app
+    environments:
+      production:
+        domain: example.com
+    YAML);
+
+    expect(Manifest::removeEnvironment('typesense'))->toBeTrue();
+    expect(array_keys(Yaml::parse(file_get_contents(BASE_PATH . '/yolo.yml'))['environments']))->toBe(['production']);
+});

--- a/tests/Unit/Steps/Destroy/DestroyAppServiceTeardownTest.php
+++ b/tests/Unit/Steps/Destroy/DestroyAppServiceTeardownTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Aws\Command as AwsCommand;
+use Aws\S3\Exception\S3Exception;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Ec2\EcsTaskSecurityGroup;
+use Codinglabs\Yolo\Resources\Ec2\TypesenseSecurityGroup;
+use Codinglabs\Yolo\Steps\Destroy\App\RemoveAppEnvFileStep;
+use Codinglabs\Yolo\Steps\Destroy\App\RevokeTypesenseIngressStep;
+
+function destroyServiceManifest(array $extra = []): void
+{
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
+        'tasks' => ['web' => true],
+        ...$extra,
+    ]);
+}
+
+it('revokes only this app\'s 8108 rule from the env Typesense security group', function (): void {
+    destroyServiceManifest(['services' => ['typesense']]);
+
+    $typesenseName = (new TypesenseSecurityGroup())->name();
+    $taskName = (new EcsTaskSecurityGroup())->name();
+
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => new Result(['SecurityGroups' => [
+            ['GroupName' => $typesenseName, 'GroupId' => 'sg-typesense'],
+            ['GroupName' => $taskName, 'GroupId' => 'sg-task'],
+        ]]),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => [
+            ['SecurityGroupRuleId' => 'sgr-8108', 'IsEgress' => false, 'IpProtocol' => 'tcp', 'FromPort' => 8108, 'ReferencedGroupInfo' => ['GroupId' => 'sg-task']],
+        ]]),
+    ], $captured);
+
+    expect((new RevokeTypesenseIngressStep())(['dry-run' => false]))->toBe(StepResult::DELETED)
+        ->and(array_column($captured, 'name'))->toContain('RevokeSecurityGroupIngress');
+});
+
+it('skips the Typesense ingress revoke for an app that does not use the service', function (): void {
+    destroyServiceManifest();
+
+    expect((new RevokeTypesenseIngressStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED);
+});
+
+it('deletes the per-app env file from the env config bucket', function (): void {
+    destroyServiceManifest();
+
+    $captured = [];
+    bindRoutedS3Client([
+        'HeadObject' => new Result([]),
+        'DeleteObject' => new Result([]),
+    ], $captured);
+
+    expect((new RemoveAppEnvFileStep())(['dry-run' => false]))->toBe(StepResult::DELETED)
+        ->and(array_column($captured, 'name'))->toContain('DeleteObject');
+});
+
+it('reports WOULD_DELETE for the per-app env file without writing on the plan pass', function (): void {
+    destroyServiceManifest();
+
+    $captured = [];
+    bindRoutedS3Client(['HeadObject' => new Result([])], $captured);
+
+    expect((new RemoveAppEnvFileStep())(['dry-run' => true]))->toBe(StepResult::WOULD_DELETE)
+        ->and(array_column($captured, 'name'))->not->toContain('DeleteObject');
+});
+
+it('skips the per-app env file when it is already absent', function (): void {
+    destroyServiceManifest();
+
+    $captured = [];
+    bindRoutedS3Client([
+        'HeadObject' => new S3Exception('Not found', new AwsCommand('HeadObject'), ['code' => 'NoSuchKey']),
+    ], $captured);
+
+    expect((new RemoveAppEnvFileStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED)
+        ->and(array_column($captured, 'name'))->not->toContain('DeleteObject');
+});

--- a/tests/Unit/Steps/Fargate/SyncTaskLogGroupStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncTaskLogGroupStepTest.php
@@ -82,7 +82,7 @@ it('strips the stream wildcard `:*` suffix before calling the CloudWatch Logs ta
 
 it('reads tags during a dry-run for plan-time drift but never writes', function (): void {
     // The plan pass needs to know whether tag sync would change anything (so
-    // the apply-pending filter from PR #57 doesn't drop a step with tag drift),
+    // the apply-pending filter doesn't drop a step with tag drift),
     // so ListTagsForResource is expected — but TagResource (the write) is not.
     $captured = [];
 

--- a/tests/Unit/Steps/Iam/DeployerStepsTest.php
+++ b/tests/Unit/Steps/Iam/DeployerStepsTest.php
@@ -283,7 +283,7 @@ it('does not re-version the deployer policy when IAM returns the same document r
     // IAM round-trips a managed policy with reordered top-level keys, reordered
     // statements, and single-element Action lists collapsed to bare scalars. The
     // old naive json_encode string compare read all of that as drift and created a
-    // fresh version on every sync (LPX-670); the canonical compare must see it as
+    // fresh version on every sync; the canonical compare must see it as
     // in-sync and write nothing.
     manifestWithDeployer();
 

--- a/tests/Unit/Steps/Network/SyncLoadBalancerSecurityGroupStepTest.php
+++ b/tests/Unit/Steps/Network/SyncLoadBalancerSecurityGroupStepTest.php
@@ -83,7 +83,7 @@ it('stamps the missing yolo:scope tag on an existing security group when applyin
 
 it('surfaces the missing yolo:scope tag as a plan-time change without writing during a dry-run', function (): void {
     // Tag drift alone must mark the step WOULD_SYNC so the apply pass isn't
-    // dropped by the only-pending-steps filter (#57) — the rules are clean here,
+    // dropped by the only-pending-steps filter — the rules are clean here,
     // so the WOULD_SYNC can only come from the tag.
     $captured = [];
 


### PR DESCRIPTION
## What

Completes the Phase-1 gap in `destroy:app` — it's now service-aware and finishes by cleaning the manifest.

### Service-aware teardown
`destroy:app` no longer refuses apps that consume services. Each service's per-app resources are reversed, composed the same way `sync:app` composes `appSteps`:

- **Typesense** — revoke this app's `8108` ingress from the env-shared node SG (the existing RDS/cache revoke pattern), *before* the task SG it references is deleted.
- **MediaConvert** — delete the per-app role (its `delete()` detaches policies first).
- **Rekognition / IVS** — task-role only; already swept with the task role.

The per-app env file (`env/.env.{app}`) — the build's env channel, which also carries minted Typesense keys — is removed from the (env-shared) env config bucket.

The guard now refuses only a service with per-app resources whose teardown isn't modelled yet (none today — future-proofing), instead of every service.

### Manifest cleanup
As its final act, `destroy:app` strips the whole environment block from the local `yolo.yml` via `Manifest::removeEnvironment` — surgical and format-preserving (comments / ordering / quoting), with a parse-verify safety net that writes nothing and warns rather than corrupt the file.

### Hygiene (first commit)
Drops stray Linear (`LPX-*`) and PR (`#NN`) cross-reference tombstones from comments and test docblocks, and trims one "it used to be a bespoke reconciler" history block in `QueueAlarm`.

## Test plan
- `pint --test`, `phpstan`, `rector --dry-run` ✅
- `pest --parallel` ✅ (1456 passed)
- New: `ManifestRemoveEnvironmentTest` (middle / last / ambiguous-bail / absent), `DestroyAppServiceTeardownTest` (revoke 8108, remove env file, plan-pass safety), updated `DestroyAppCommandTest` (guard now allows serviced apps; ingress revoked before the task SG; env-strip is the last step).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
