### PR TITLE
feat(destroy): destroy orchestrator + gated VPC/account reclaim + refusal summary (LPX-695 Phase 3)

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -26,8 +26,9 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`build <env>`](#yolo-build) | Build and push the container image |
 | [`deploy <env>`](#yolo-deploy) | Build, then roll out a zero-downtime deploy |
 | [`rollback <env>`](#yolo-rollback) | Re-deploy a previously-built version from ECR, without a build |
+| [`destroy <env>`](#yolo-destroy) | Permanently tear down an application and its environment, in reverse-dependency order (the reverse of `sync`) |
 | [`destroy:app <env>`](#yolo-destroy-app) | Permanently tear down one app's resources (the reverse of `sync:app`) |
-| [`destroy:environment <env>`](#yolo-destroy-environment) | Permanently tear down an environment's shared compute/edge resources (the reverse of `sync:environment`) |
+| [`destroy:environment <env>`](#yolo-destroy-environment) | Permanently tear down an entire environment — compute, edge and network (the reverse of `sync:environment`) |
 | [`status <env>`](#yolo-status) | Live status dashboard (or a one-shot `--snapshot` / `--json` frame) |
 | [`status:app <env>`](#yolo-status-app) | App-tier status (the same as `status`, under the scope namespace) |
 | [`status:environment <env>`](#yolo-status-environment) | Roll up every app's status across an environment |
@@ -604,6 +605,30 @@ When a [`tasks.web.autoscaling`](/reference/manifest#tasks-web-autoscaling) bloc
 
 ---
 
+## `yolo destroy`
+
+Permanently tear an application **and its environment** down in one pass — the reverse of [`sync`](#sync), which builds account → environment → app. destroy runs **app → environment → account** in reverse-dependency order, behind a single **plan → confirm → apply** gate, so nothing is removed while something still references it. Everything that belongs to the environment goes — gated only on whether anything else still uses it.
+
+```bash
+yolo destroy <environment> [--check] [--force] [--no-progress]
+```
+
+Arguments and options as [`sync`](#sync-options). Scope: **app → environment → account**. Admin-tier.
+
+What it tears down, each scope self-gating:
+
+- **app** — this app's resources ([`destroy:app`](#yolo-destroy-app)).
+- **environment** — the compute/edge tier ([`destroy:environment`](#yolo-destroy-environment) Tier A) **and the network shell** (VPC, subnets, route table, internet gateway, RDS SG + subnet group) — *unless a database is attached to the VPC*, which keeps the shell standing (YOLO never deletes a database it doesn't own, and a live DB pins the whole network; the blocking instance is named in the summary).
+- **account** — the account-shared GitHub OIDC provider, reclaimed **only when no other environment remains** (no resource tagged `yolo:environment=<other>`). It fails safe: if that can't be determined, the provider is kept, never deleted on a guess.
+
+**Never deleted.** The database and the bring-your-own [app data bucket](/reference/manifest#bucket) are off-limits — not by configuration, but structurally: the data bucket isn't a deletable resource, and no destructive RDS call exists anywhere in YOLO (both enforced by tests). The confirmation names them so you can see they're safe.
+
+**Guarded.** The app must be a shape `destroy:app` supports, and no *other* app may still claim the environment — this app is torn down in the same run, so it's excused, but any sibling must be destroyed first. The yolo.yml environment block is stripped as the very last step, after everything that still needs the manifest's account/region to resolve.
+
+**The confirmation.** A destroy is irreversible, so the gate is loud: a red banner, a **PROTECTED** callout naming the database + app data bucket, and a prompt to **type the environment name** (no fat-fingerable y/N). `--force` / non-interactive skips it, as with sync. Anything deliberately kept — the network shell while a database is attached, the OIDC provider while other environments exist — is listed back at the end of the run with the reason, so it's never a silent omission.
+
+---
+
 ## `yolo destroy:app`
 
 Permanently tear one application's resources down in the given environment — the reverse of [`sync:app`](#yolo-sync-app). It uses the same **plan → confirm → apply** flow: a plan pass lists every resource that **would delete**, the confirm gate guards the irreversible apply (declining is the preview), and `--check` is the non-interactive plan-only form for CI. The apply pass deletes in reverse dependency order — CloudFront → autoscaling → ECS services → cluster → listener rules → target group → task security group → app IAM → SQS → hosted-zone records → buckets → ECR — so a resource is never deleted while something still references it.
@@ -625,11 +650,13 @@ Arguments and options as [`sync`](#sync-options). Scope: **app**. Admin-tier.
 
 **It refuses rather than partially tearing down.** To guarantee a teardown can never orphan resources (which [`yolo audit`](#yolo-audit) would then flag), destroy:app refuses — with a clear message — app shapes whose teardown isn't fully modelled yet: **multi-tenant** apps, **headless** apps (no domain), and apps with **no web task**. (Consuming an env service is no longer a refusal — destroy:app reverses each service's per-app resources; only a service that adds per-app resources with no teardown modelled would refuse, which none do today.)
 
+**The confirmation.** Like the other destroy commands, the gate is a red banner with a **PROTECTED** callout (the database + app data bucket) and a prompt to **type the environment name** before the irreversible apply. `--force` / non-interactive skips it.
+
 ---
 
 ## `yolo destroy:environment`
 
-Permanently tear an environment's shared **compute/edge** resources down — the reverse of [`sync:environment`](#yolo-sync-environment), behind the same **plan → confirm → apply** flow (`--check` is the CI plan-only form). The apply pass deletes in reverse dependency order: the env-backed **service stacks** (Typesense / IVS) first, then the **WAF** off the load balancer, the `:443`/`:80` **listeners** + the **load balancer** + its security group, the shared **Valkey cache** (replication group + its subnet/parameter groups + security group), the **SNS alarm topic**, the shared **ECS execution role** and the **observer/admin** IAM tiers, and finally the **env buckets**.
+Permanently tear an **entire environment** down — the reverse of [`sync:environment`](#yolo-sync-environment), behind the same **plan → confirm → apply** flow (`--check` is the CI plan-only form). The apply pass deletes in reverse dependency order: the env-backed **service stacks** (Typesense / IVS) first, then the **WAF** off the load balancer, the `:443`/`:80` **listeners** + the **load balancer** + its security group, the shared **Valkey cache** (replication group + its subnet/parameter groups + security group), the **SNS alarm topic**, the shared **ECS execution role** and the **observer/admin** IAM tiers, the **env buckets**, and finally the **network shell** (RDS subnet group + SG, the public subnets, the route table, the internet gateway, and the VPC last).
 
 ```bash
 yolo destroy:environment <environment> [--check] [--force] [--no-progress]
@@ -637,15 +664,16 @@ yolo destroy:environment <environment> [--check] [--force] [--no-progress]
 
 Arguments and options as [`sync`](#sync-options). Scope: **environment**. Admin-tier.
 
-**It tears down Tier A (compute/edge) and deliberately leaves Tier B (the network shell + database):**
+**It tears the whole environment down — compute/edge (Tier A) and the network shell (Tier B):**
 
-- **The VPC, subnets, route tables, internet gateway, and the RDS security group + subnet group stay standing.** A surviving RDS instance lives in the VPC's private subnets using that security group and subnet group, and AWS pins all of it (you can't delete an in-use security group, an in-use subnet, or a VPC with a live ENI) — so keeping the database keeps the whole network shell. "Decommission the compute tier, keep the data" is the likely case; full VPC reclamation is a separate, gated step.
+- **The network shell is reclaimed automatically** (VPC, subnets, route table, internet gateway, RDS security group + subnet group), after Tier A — *unless a database is attached to the VPC*. A surviving RDS instance lives in the VPC's private subnets using that security group and subnet group, and AWS pins all of it (you can't delete an in-use security group, an in-use subnet, or a VPC with a live ENI), so a live database keeps the whole shell standing; it's named in the refusal summary. Snapshot and drop the database out-of-band, then re-run to reclaim the network.
 - **RDS is never touched** — YOLO owns the security group, never the database.
+- **The env buckets go with the environment.** The env config bucket (the env manifest + env-shared `.env`) and the env logs bucket (ALB access logs) are regeneratable infrastructure config, emptied and deleted as part of the teardown. The bring-your-own app data bucket is never touched (it isn't even a deletable resource).
 - The env-backed **service stacks** come down even though the env manifest still declares them: the command forces [the service lifecycle](/guide/services#the-service-lifecycle) to *teardown* for the duration of the run, reusing the same per-service teardown the manifest-removal path uses.
 
 **Guarded — it refuses while any app still claims the environment.** If any app has a published claim file or running tasks, destroy:environment names them and stops: tear each down with [`destroy:app`](#yolo-destroy-app) first, so the shared resources never go out from under a live app.
 
-**The env buckets go with the environment.** The env config bucket (the env manifest + env-shared `.env`) and the env logs bucket (ALB access logs) are regeneratable infrastructure config, emptied and deleted as part of the teardown. The BYO app data bucket and the database are never touched.
+**The confirmation.** Same loud gate as [`destroy`](#yolo-destroy): a red banner, a **PROTECTED** callout naming the database + app data bucket, and a prompt to **type the environment name** before the irreversible apply. `--force` / non-interactive skips it.
 
 ---
 

--- a/resources/boost/skills/yolo/SKILL.md
+++ b/resources/boost/skills/yolo/SKILL.md
@@ -19,7 +19,7 @@ allowed-tools:
 **Read freely. Never mutate AWS without explicit human approval.**
 
 - **Safe to run unprompted** (read-only, no AWS writes): the whole `status:*` read family (`status`, `status:environment`, `status:logs`, `status:events`, `status:alarms`, `status:budget`), `audit --json`, `services --json`, `sync <env> --check`. All take `--json`.
-- **Mutations — never run these yourself.** `sync` (apply), `deploy`, `rollback`, `scale`, `env:push`, `environment:*:push`, `services --add/--remove/--set`, `permissions` (RBAC grant-group edits), and the **teardown commands** (`destroy:app`, `destroy:environment` — irreversible; see [Teardown](#teardown)). Prepare them, explain them, and hand them to the human to run — or land the change as a **PR** (edit `yolo.yml`, open the PR) and let a human merge and deploy.
+- **Mutations — never run these yourself.** `sync` (apply), `deploy`, `rollback`, `scale`, `env:push`, `environment:*:push`, `services --add/--remove/--set`, `permissions` (RBAC grant-group edits), and the **teardown commands** (`destroy`, `destroy:app`, `destroy:environment` — irreversible; see [Teardown](#teardown)). Prepare them, explain them, and hand them to the human to run — or land the change as a **PR** (edit `yolo.yml`, open the PR) and let a human merge and deploy.
 - Even with approval, honour YOLO's own confirm gates — don't reach for `--force`/`-f` unless the human explicitly asked for an unattended apply.
 
 This mirrors the operator's standing rule: infrastructure commands never run against a real account without explicit confirmation.
@@ -129,13 +129,15 @@ Cost: `{currency, spend, budget: {amount, strategy}}` — month-to-date spend (U
 
 The reverse of `sync` — same scope-first model, same plan → confirm → apply runner, run in **reverse** dependency order. The most destructive thing YOLO does and **irreversible**: never run a teardown yourself. Prepare it, explain exactly what it removes and what it keeps, and hand it to a human.
 
+- **`destroy <env>`** — the full orchestrator: tears an app **and its environment** down in one pass (app → environment → account), the reverse of `sync`. Each scope self-gates: the network shell is reclaimed unless a database is attached, and the account-shared OIDC provider only when no other environment remains. Refuses while any *other* app still claims the env (this one is torn down in the same run).
 - **`destroy:app <env>`** — tears the manifest's app down (Fargate, storage, app IAM, CDN, DNS) and reverses the per-app slice of any service it consumes — revokes its 3306/cache/Typesense ingress rules, deletes its per-app MediaConvert role, removes its per-app env file (`env/.env.{app}`, which also held minted Typesense keys). The env-shared resources (`:443` listener, cache, search cluster, WAF) stay for other apps. Refuses the shapes whose teardown isn't modelled yet — **multi-tenant**, **headless** (no domain), **no web task**.
-- **`destroy:environment <env>`** — the mirror of `sync:environment`. Tears down **Tier A** (env-backed services, WAF, ALB + `:80`/`:443` listeners, Valkey cache, SNS, shared exec role, observer/admin IAM, env buckets) and deliberately leaves **Tier B** (the network shell + database) standing — a surviving RDS pins the VPC, so the default is "decommission the compute, keep the data". Refuses while any app still claims the env — `destroy:app` each first.
+- **`destroy:environment <env>`** — the mirror of `sync:environment`. Tears down **Tier A** (env-backed services, WAF, ALB + `:80`/`:443` listeners, Valkey cache, SNS, shared exec role, observer/admin IAM, env buckets) **then Tier B** (the network shell: VPC, subnets, route table, IGW, RDS SG + subnet group). The network is reclaimed automatically — *unless a database is attached to the VPC*, which keeps the whole shell standing (a live RDS pins it) and is named in the summary. Refuses while any app still claims the env — `destroy:app` each first.
 
 **What it never touches, and the gates:**
 
 - **RDS / the database is never deleted** — YOLO owns the security group, not the instance. It can't be: there is no destructive RDS call anywhere in YOLO (CI-enforced).
 - The **BYO app data bucket stays** (holds user data) — it isn't even a deletable resource. The regeneratable env config/logs buckets are deleted as part of the teardown.
+- **Shared infrastructure is reclaimed only when safe** — the network shell stays while a database is attached to the VPC; the account-shared GitHub OIDC provider is kept unless no other environment remains (and kept on *any* uncertainty — never deleted on a guess). Each is named in the end-of-run summary when kept.
 - **The confirm gate is loud** — a red banner, a PROTECTED callout naming the database + app data bucket, and a type-the-environment-name prompt (no y/N). `--force` skips it for CI.
 
 **Previewing is safe.** `--check` runs the plan pass read-only (prints the full teardown plan, writes nothing) — the way to show a human exactly what a teardown would remove before they run the apply. Only reach for it when teardown is the actual question, not during a routine sweep.

--- a/src/Aws/Rds.php
+++ b/src/Aws/Rds.php
@@ -17,4 +17,32 @@ class Rds
 
         throw new ResourceDoesNotExistException("Could not find RDS subnet group $name");
     }
+
+    /**
+     * The identifiers of every live DB instance whose subnet group sits in the
+     * given VPC. A network-shell teardown refuses while this isn't empty — the
+     * database lives in the VPC's private subnets and pins the whole network, and
+     * YOLO never deletes a database it doesn't own.
+     *
+     * @return array<int, string>
+     */
+    public static function instancesInVpc(string $vpcId): array
+    {
+        $identifiers = [];
+        $marker = null;
+
+        do {
+            $page = Aws::rds()->describeDBInstances(array_filter(['Marker' => $marker]));
+
+            foreach ($page['DBInstances'] ?? [] as $instance) {
+                if (($instance['DBSubnetGroup']['VpcId'] ?? null) === $vpcId) {
+                    $identifiers[] = $instance['DBInstanceIdentifier'];
+                }
+            }
+
+            $marker = $page['Marker'] ?? null;
+        } while ($marker !== null);
+
+        return $identifiers;
+    }
 }

--- a/src/Commands/DestroyAppCommand.php
+++ b/src/Commands/DestroyAppCommand.php
@@ -61,8 +61,11 @@ class DestroyAppCommand extends SyncSteppedCommand
      * per-app resources (see {@see appServiceTeardownSteps()}). The only service
      * stop left is the honest one: a service with per-app resources whose teardown
      * isn't modelled yet would orphan them, so it's named and refused.
+     *
+     * Public so the {@see DestroyCommand} orchestrator can apply the same guard to
+     * the app it tears down before it touches the environment.
      */
-    protected function unsupportedReason(): ?string
+    public function unsupportedReason(): ?string
     {
         return match (true) {
             Manifest::isMultitenanted() => 'destroy:app does not yet support multi-tenant apps — their per-tenant queues and SNI certificates would be left behind.',

--- a/src/Commands/DestroyCommand.php
+++ b/src/Commands/DestroyCommand.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Codinglabs\Yolo\Commands;
+
+use Codinglabs\Yolo\Steps;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Destroying;
+use Codinglabs\Yolo\Services\Lifecycle;
+use Codinglabs\Yolo\Concerns\ReclaimsNetwork;
+use Codinglabs\Yolo\Concerns\ConfirmsDestruction;
+
+use function Laravel\Prompts\error;
+
+/**
+ * Tears an application and its environment down in one pass — the reverse of
+ * `sync`, which builds account → environment → app; destroy runs app → environment
+ * (→ account), so nothing is removed while something still references it. One
+ * plan → confirm → apply across the scopes, behind a single confirm gate.
+ *
+ * Everything that belongs to the environment goes, gated only on "is anything else
+ * still using it":
+ *  - the app's resources, then the environment's compute/edge (Tier A);
+ *  - the network shell (Tier B) — unless a database is attached to the VPC, which
+ *    keeps it standing (YOLO never deletes a database it doesn't own);
+ *  - the account-shared GitHub OIDC provider — but only when no other environment
+ *    remains (and it fails safe: if that can't be determined, it's kept and named).
+ *
+ * Guarded: the app must be a shape `destroy:app` supports, and no OTHER app may
+ * still claim the environment (this one is being torn down in the same run). The
+ * env-backed services come down via the {@see Destroying} flag, as in
+ * `destroy:environment`. Stripping the environment from yolo.yml runs dead last,
+ * after the teardown that still needs the manifest's account/region to resolve.
+ */
+class DestroyCommand extends SyncSteppedCommand
+{
+    use ConfirmsDestruction;
+    use ReclaimsNetwork;
+
+    protected function configure(): void
+    {
+        $this->addSyncOptions()
+            ->setName('destroy')
+            ->setDescription('Permanently tear down an application and its environment (app → environment → account), in reverse-dependency order');
+    }
+
+    #[\Override]
+    public function handle(): int
+    {
+        if (($reason = (new DestroyAppCommand())->unsupportedReason()) !== null) {
+            error($reason);
+
+            return self::FAILURE;
+        }
+
+        // This app is torn down in the same run, so it's allowed to still claim the
+        // environment — but any OTHER live app must be destroyed first.
+        $others = array_values(array_diff(Lifecycle::claimingApps(), [Manifest::name()]));
+
+        if ($others !== []) {
+            error(sprintf(
+                'destroy refuses while other apps still claim %s: %s. Tear each down with `yolo destroy:app %s` first.',
+                $this->argument('environment'),
+                implode(', ', $others),
+                $this->argument('environment'),
+            ));
+
+            return self::FAILURE;
+        }
+
+        return Destroying::during(fn (): int => parent::handle());
+    }
+
+    #[\Override]
+    protected function planHeading(): string
+    {
+        return 'Will destroy';
+    }
+
+    #[\Override]
+    protected function confirmQuestion(string $environment): string
+    {
+        return sprintf('Permanently delete this application and the entire %s environment? This cannot be undone.', $environment);
+    }
+
+    #[\Override]
+    protected function completionVerb(): string
+    {
+        return 'Destroyed';
+    }
+
+    /**
+     * App → environment → account → manifest, the reverse of sync's account → env →
+     * app. runScopes processes the scopes in this order, so the app is gone before
+     * the environment, the environment before the account-shared provider, and the
+     * yolo.yml environment block is stripped dead last — after every step that still
+     * needs the manifest's account/region to resolve. Each scope is self-gating: the
+     * network steps drop out when a database is attached, and the account provider
+     * step keeps itself when another environment still exists.
+     *
+     * @return array<string, array<int, class-string>>
+     */
+    public function scopes(): array
+    {
+        return [
+            // Every destroy:app step except its yolo.yml strip, which is deferred to
+            // the 'manifest' scope below so the environment teardown can still read
+            // the account/region out of the manifest.
+            'app' => array_values(array_filter(
+                (new DestroyAppCommand())->scopes()['app'],
+                fn (string $step): bool => $step !== Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class,
+            )),
+            'environment' => [
+                ...DestroyEnvironmentCommand::tierASteps(),
+                ...$this->networkSteps(),
+            ],
+            // The account-shared OIDC provider, reclaimed only when this is the last
+            // environment — the step self-gates on the live yolo:environment tags and
+            // keeps itself (named in the summary) otherwise.
+            'account' => [Steps\Destroy\Account\TeardownGithubOidcProviderStep::class],
+            'manifest' => [Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class],
+        ];
+    }
+
+    /**
+     * The refusal summary: the network-shell line when a database keeps it standing.
+     * The account-provider "kept — other environments exist" line is recorded by its
+     * own step and surfaces in the same summary.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function warnings(): array
+    {
+        return $this->networkWarnings();
+    }
+
+    /**
+     * The databases YOLO will never delete, named in the confirmation banner — the
+     * live RDS instances attached to this environment's VPC.
+     *
+     * @return array<int, string>
+     */
+    protected function protectedDatabases(): array
+    {
+        return $this->liveDatabases();
+    }
+}

--- a/src/Commands/DestroyEnvironmentCommand.php
+++ b/src/Commands/DestroyEnvironmentCommand.php
@@ -6,44 +6,46 @@ use Codinglabs\Yolo\Steps;
 use Codinglabs\Yolo\Destroying;
 use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Services\Lifecycle;
+use Codinglabs\Yolo\Concerns\ReclaimsNetwork;
 use Codinglabs\Yolo\Concerns\ConfirmsDestruction;
 
 use function Laravel\Prompts\error;
 
 /**
- * Tears down an environment's shared "Tier A" resources — the compute/edge layer:
- * the env-backed service stacks (Typesense/IVS), the WAF, the load balancer +
- * listeners + its security group, the shared Valkey cache, the SNS alarm topic,
- * the shared exec role + the observer/admin IAM tiers, and the env buckets. The
- * reverse of
- * `sync:environment`, behind the same plan → confirm → apply runner.
+ * Tears an environment all the way down — the reverse of `sync:environment`, behind
+ * the same plan → confirm → apply runner. First the shared "Tier A" compute/edge
+ * layer (the env-backed service stacks, the WAF, the load balancer + listeners + its
+ * security group, the shared Valkey cache, the SNS alarm topic, the shared exec role
+ * + observer/admin IAM tiers, the env buckets), then "Tier B" — the network shell
+ * (VPC, subnets, route table, internet gateway, RDS security group + subnet group).
  *
- * Tier B — the network shell (VPC, subnets, route tables, the RDS security group +
- * subnet group) — is deliberately LEFT STANDING: a surviving RDS instance lives in
- * it, and YOLO never touches a database it doesn't own. "Decommission the compute
- * tier, keep the data" is the likely 90% case; full VPC reclamation is a separate,
- * gated step.
+ * The network is reclaimed automatically once nothing else needs it. The one thing
+ * that holds it back is a database: a surviving RDS instance lives in the VPC's
+ * private subnets and pins the whole network, and YOLO NEVER deletes a database it
+ * doesn't own — so a live DB leaves the network shell standing and is named in the
+ * summary (snapshot + drop the DB out-of-band to fully reclaim). RDS is never touched.
  *
- * Guarded: refuses while any app still claims the environment (a published claim
- * file or running tasks) — tear those down with `destroy:app` first, so the shared
- * resources never go out from under a live app. The env-backed services come down
- * via their existing sync Teardown branches, forced on by the {@see Destroying}
- * flag for the duration of the run.
+ * Guarded: refuses while any app still claims the environment (a published claim file
+ * or running tasks) — tear those down with `destroy:app` first, so the shared
+ * resources never go out from under a live app. The env-backed services come down via
+ * their existing sync Teardown branches, forced on by the {@see Destroying} flag for
+ * the duration of the run.
  *
- * The env config + logs buckets (the env manifest + shared .env, the ALB access
- * logs) are regeneratable infrastructure config, so they go with the environment.
- * The bring-your-own app data bucket and the database are never touched — the
- * database isn't YOLO's, and the data bucket isn't even Deletable.
+ * The env config + logs buckets (the env manifest + shared .env, the ALB access logs)
+ * are regeneratable infrastructure config, so they go with the environment. The
+ * bring-your-own app data bucket and the database are never touched — the database
+ * isn't YOLO's, and the data bucket isn't even Deletable.
  */
 class DestroyEnvironmentCommand extends SyncSteppedCommand
 {
     use ConfirmsDestruction;
+    use ReclaimsNetwork;
 
     protected function configure(): void
     {
         $this->addSyncOptions()
             ->setName('destroy:environment')
-            ->setDescription('Permanently tear down an environment\'s shared compute/edge resources (leaves the network shell + database)');
+            ->setDescription('Permanently tear down an entire environment — compute, edge and network (the database is never touched)');
     }
 
     #[\Override]
@@ -74,7 +76,7 @@ class DestroyEnvironmentCommand extends SyncSteppedCommand
     #[\Override]
     protected function confirmQuestion(string $environment): string
     {
-        return sprintf('Permanently delete the shared compute/edge resources for %s? This cannot be undone.', $environment);
+        return sprintf('Permanently delete every resource in the %s environment? This cannot be undone.', $environment);
     }
 
     #[\Override]
@@ -84,11 +86,8 @@ class DestroyEnvironmentCommand extends SyncSteppedCommand
     }
 
     /**
-     * Tier A teardown in reverse-dependency order: the env-backed service stacks
-     * first (their listener rules + target groups hang off the shared ALB), then
-     * the WAF + listeners + load balancer + its security group, the SNS topic, the
-     * shared exec role and the observer/admin IAM tiers, and finally the env
-     * buckets. Tier B (the VPC and everything the database pins) is never listed.
+     * Tier A (compute/edge), then Tier B (the network shell) — reclaimed unless a
+     * database is attached to the VPC (see {@see ReclaimsNetwork::networkSteps()}).
      *
      * @return array<string, array<int, class-string>>
      */
@@ -96,45 +95,104 @@ class DestroyEnvironmentCommand extends SyncSteppedCommand
     {
         return [
             'environment' => [
-                // Env-backed service stacks (Typesense/IVS): the Destroying flag
-                // forces each service's lifecycle to Teardown, so these reuse the
-                // sync steps' Teardown branches, ordered for teardown by the service.
-                ...static::environmentServiceTeardownSteps(),
-                // WAF off the ALB before either goes (a web ACL can't be deleted
-                // while associated), then the listeners + load balancer, then the
-                // now-unreferenced web ACL + its IP sets.
-                Steps\Destroy\Environment\DisassociateWafStep::class,
-                Steps\Destroy\Environment\TeardownHttpsListenerStep::class,
-                Steps\Destroy\Environment\TeardownHttpListenerStep::class,
-                Steps\Destroy\Environment\TeardownLoadBalancerStep::class,
-                Steps\Destroy\Environment\TeardownWebAclStep::class,
-                Steps\Destroy\Environment\TeardownAllowIpSetStep::class,
-                Steps\Destroy\Environment\TeardownBlockIpSetStep::class,
-                // The LB security group, once the load balancer that used it is gone.
-                Steps\Destroy\Environment\TeardownLoadBalancerSecurityGroupStep::class,
-                // The shared Valkey cache (env-owned, bootstrapped by sync:app): the
-                // replication group first — its delete waits for completion — then the
-                // subnet/parameter groups + security group it pinned.
-                Steps\Destroy\Environment\TeardownCacheClusterStep::class,
-                Steps\Destroy\Environment\TeardownCacheSecurityGroupStep::class,
-                Steps\Destroy\Environment\TeardownCacheSubnetGroupStep::class,
-                Steps\Destroy\Environment\TeardownCacheParameterGroupStep::class,
-                Steps\Destroy\Environment\TeardownSnsAlarmTopicStep::class,
-                // Shared identity: the exec role, then grant groups → tier roles →
-                // tier policies (each delete() self-detaches; reverse of create order
-                // keeps it tidy).
-                Steps\Destroy\Environment\TeardownEcsExecutionRoleStep::class,
-                Steps\Destroy\Environment\TeardownAdminsGroupStep::class,
-                Steps\Destroy\Environment\TeardownObserversGroupStep::class,
-                Steps\Destroy\Environment\TeardownAdminRoleStep::class,
-                Steps\Destroy\Environment\TeardownObserverRoleStep::class,
-                Steps\Destroy\Environment\TeardownAdminPolicyStep::class,
-                Steps\Destroy\Environment\TeardownObserverPolicyStep::class,
-                // Storage last: the env logs bucket, then the env config bucket,
-                // whose deletion is the final act of the env teardown.
-                Steps\Destroy\Environment\TeardownEnvLogsBucketStep::class,
-                Steps\Destroy\Environment\TeardownEnvConfigBucketStep::class,
+                ...static::tierASteps(),
+                ...$this->networkSteps(),
             ],
+        ];
+    }
+
+    /**
+     * The refusal summary: the network shell line when a database keeps it standing.
+     *
+     * @return array<int, string>
+     */
+    #[\Override]
+    public function warnings(): array
+    {
+        return $this->networkWarnings();
+    }
+
+    /**
+     * The databases YOLO will never delete, named in the confirmation banner — the
+     * live RDS instances attached to this environment's VPC.
+     *
+     * @return array<int, string>
+     */
+    protected function protectedDatabases(): array
+    {
+        return $this->liveDatabases();
+    }
+
+    /**
+     * Tier A (compute/edge) teardown in reverse-dependency order: the env-backed
+     * service stacks first (their listener rules + target groups hang off the
+     * shared ALB), then the WAF + listeners + load balancer + its security group,
+     * the Valkey cache, the SNS topic, the shared exec role and the observer/admin
+     * IAM tiers, and finally the env buckets. Shared with the destroy orchestrator.
+     *
+     * @return array<int, class-string>
+     */
+    public static function tierASteps(): array
+    {
+        return [
+            // Env-backed service stacks (Typesense/IVS): the Destroying flag forces
+            // each service's lifecycle to Teardown, so these reuse the sync steps'
+            // Teardown branches, ordered for teardown by the service.
+            ...static::environmentServiceTeardownSteps(),
+            // WAF off the ALB before either goes (a web ACL can't be deleted while
+            // associated), then the listeners + load balancer, then the
+            // now-unreferenced web ACL + its IP sets.
+            Steps\Destroy\Environment\DisassociateWafStep::class,
+            Steps\Destroy\Environment\TeardownHttpsListenerStep::class,
+            Steps\Destroy\Environment\TeardownHttpListenerStep::class,
+            Steps\Destroy\Environment\TeardownLoadBalancerStep::class,
+            Steps\Destroy\Environment\TeardownWebAclStep::class,
+            Steps\Destroy\Environment\TeardownAllowIpSetStep::class,
+            Steps\Destroy\Environment\TeardownBlockIpSetStep::class,
+            // The LB security group, once the load balancer that used it is gone.
+            Steps\Destroy\Environment\TeardownLoadBalancerSecurityGroupStep::class,
+            // The shared Valkey cache: the replication group first — its delete
+            // waits for completion — then the subnet/parameter groups + SG it pinned.
+            Steps\Destroy\Environment\TeardownCacheClusterStep::class,
+            Steps\Destroy\Environment\TeardownCacheSecurityGroupStep::class,
+            Steps\Destroy\Environment\TeardownCacheSubnetGroupStep::class,
+            Steps\Destroy\Environment\TeardownCacheParameterGroupStep::class,
+            Steps\Destroy\Environment\TeardownSnsAlarmTopicStep::class,
+            // Shared identity: the exec role, then grant groups → tier roles → tier
+            // policies (each delete() self-detaches; reverse of create order is tidy).
+            Steps\Destroy\Environment\TeardownEcsExecutionRoleStep::class,
+            Steps\Destroy\Environment\TeardownAdminsGroupStep::class,
+            Steps\Destroy\Environment\TeardownObserversGroupStep::class,
+            Steps\Destroy\Environment\TeardownAdminRoleStep::class,
+            Steps\Destroy\Environment\TeardownObserverRoleStep::class,
+            Steps\Destroy\Environment\TeardownAdminPolicyStep::class,
+            Steps\Destroy\Environment\TeardownObserverPolicyStep::class,
+            // Storage last: the env logs bucket, then the env config bucket, whose
+            // deletion is the final act of the env (Tier A) teardown.
+            Steps\Destroy\Environment\TeardownEnvLogsBucketStep::class,
+            Steps\Destroy\Environment\TeardownEnvConfigBucketStep::class,
+        ];
+    }
+
+    /**
+     * Tier B (the network shell) teardown in reverse-dependency order, only ever
+     * reached once no database is attached to the VPC: the RDS subnet group + SG
+     * first, then the public subnets, the route table, the internet gateway
+     * (detached then deleted) and, last, the VPC itself.
+     *
+     * @return array<int, class-string>
+     */
+    public static function tierBSteps(): array
+    {
+        return [
+            Steps\Destroy\Environment\TeardownRdsSubnetStep::class,
+            Steps\Destroy\Environment\TeardownRdsSecurityGroupStep::class,
+            Steps\Destroy\Environment\TeardownPublicSubnetAStep::class,
+            Steps\Destroy\Environment\TeardownPublicSubnetBStep::class,
+            Steps\Destroy\Environment\TeardownPublicSubnetCStep::class,
+            Steps\Destroy\Environment\TeardownRouteTableStep::class,
+            Steps\Destroy\Environment\TeardownInternetGatewayStep::class,
+            Steps\Destroy\Environment\TeardownVpcStep::class,
         ];
     }
 

--- a/src/Concerns/ReclaimsNetwork.php
+++ b/src/Concerns/ReclaimsNetwork.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Concerns;
+
+use Codinglabs\Yolo\Aws\Rds;
+use Codinglabs\Yolo\Resources\Ec2\Vpc;
+use Codinglabs\Yolo\Commands\DestroyEnvironmentCommand;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * Shared network-reclaim behaviour for the destroy commands. Destroying an
+ * environment tears its network shell (Tier B) down automatically — the one thing
+ * that holds it back is a database: a surviving RDS instance lives in the VPC's
+ * private subnets and pins the whole network, and YOLO never deletes a database it
+ * doesn't own. So a live DB leaves the network standing and is named in the refusal
+ * summary; otherwise the shell goes with the rest of the environment.
+ */
+trait ReclaimsNetwork
+{
+    /** @var array<int, string>|null memoised live DB identifiers in the env VPC */
+    private ?array $liveDatabasesInVpc = null;
+
+    /**
+     * The network shell is reclaimed whenever no database is attached to the VPC.
+     */
+    protected function reclaimsNetwork(): bool
+    {
+        return $this->liveDatabases() === [];
+    }
+
+    /**
+     * The Tier-B teardown steps, appended after Tier A — empty when a database
+     * blocks the reclaim.
+     *
+     * @return array<int, class-string>
+     */
+    protected function networkSteps(): array
+    {
+        return $this->reclaimsNetwork() ? DestroyEnvironmentCommand::tierBSteps() : [];
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    protected function liveDatabases(): array
+    {
+        if ($this->liveDatabasesInVpc !== null) {
+            return $this->liveDatabasesInVpc;
+        }
+
+        try {
+            return $this->liveDatabasesInVpc = Rds::instancesInVpc((new Vpc())->arn());
+        } catch (ResourceDoesNotExistException) {
+            // No VPC (already reclaimed, or never created) → nothing attached.
+            return $this->liveDatabasesInVpc = [];
+        }
+    }
+
+    /**
+     * The refusal summary line: present only when a database keeps the network
+     * shell standing, naming the blocking instance(s).
+     *
+     * @return array<int, string>
+     */
+    protected function networkWarnings(): array
+    {
+        if (($databases = $this->liveDatabases()) !== []) {
+            return [sprintf(
+                'Refusing to reclaim the network shell — the database(s) %s are still attached to this environment\'s VPC. YOLO never deletes a database it doesn\'t own; snapshot and drop them out-of-band, then re-run to reclaim the network.',
+                implode(', ', $databases),
+            )];
+        }
+
+        return [];
+    }
+}

--- a/src/Resources/Ec2/InternetGateway.php
+++ b/src/Resources/Ec2/InternetGateway.php
@@ -6,7 +6,9 @@ use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Ec2\Exception\Ec2Exception;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
@@ -15,7 +17,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * routing 0.0.0.0/0 through it are separate relationship actions
  * (SyncInternetGatewayAttachmentStep, SyncDefaultRouteStep).
  */
-class InternetGateway implements Resource
+class InternetGateway implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -57,5 +59,43 @@ class InternetGateway implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseEc2Tags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Detach the gateway from the VPC, then delete it — AWS refuses to delete an
+     * internet gateway that is still attached. The detach is the inverse of
+     * SyncInternetGatewayAttachmentStep's attach. A detach against an
+     * already-detached gateway (Gateway.NotAttached) is tolerated so we still
+     * proceed to delete; a concurrent removal (InvalidInternetGatewayID.NotFound)
+     * on either call is tolerated as already-gone.
+     */
+    public function delete(): void
+    {
+        $internetGatewayId = $this->arn();
+
+        try {
+            Aws::ec2()->detachInternetGateway([
+                'InternetGatewayId' => $internetGatewayId,
+                'VpcId' => (new Vpc())->arn(),
+            ]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidInternetGatewayID.NotFound') {
+                return;
+            }
+
+            if ($e->getAwsErrorCode() !== 'Gateway.NotAttached') {
+                throw $e;
+            }
+        }
+
+        try {
+            Aws::ec2()->deleteInternetGateway(['InternetGatewayId' => $internetGatewayId]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidInternetGatewayID.NotFound') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Resources/Ec2/PublicSubnet.php
+++ b/src/Resources/Ec2/PublicSubnet.php
@@ -7,8 +7,10 @@ use Illuminate\Support\Str;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Ec2\Exception\Ec2Exception;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Enums\PublicSubnets;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
@@ -19,7 +21,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * the internet without a NAT gateway. Point `public-subnets` at three existing
  * subnet names to adopt instead.
  */
-class PublicSubnet implements Resource
+class PublicSubnet implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -91,5 +93,25 @@ class PublicSubnet implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseEc2Tags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Delete this subnet by id. Assumes upstream teardown has already removed
+     * everything in it — no Fargate ENIs remain and the route-table association
+     * goes with the subnet — so a plain delete succeeds; AWS would otherwise
+     * refuse with DependencyViolation. A concurrent removal
+     * (InvalidSubnetID.NotFound) is tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::ec2()->deleteSubnet(['SubnetId' => $this->arn()]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidSubnetID.NotFound') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Resources/Ec2/RdsSecurityGroup.php
+++ b/src/Resources/Ec2/RdsSecurityGroup.php
@@ -6,8 +6,10 @@ use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Ec2\Exception\Ec2Exception;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Enums\SecurityGroup;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
@@ -17,7 +19,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * SyncRdsSecurityGroupStep. Point `rds.security-group` at an existing group
  * to adopt one (reported CUSTOM_MANAGED, never mutated).
  */
-class RdsSecurityGroup implements Resource
+class RdsSecurityGroup implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -62,5 +64,25 @@ class RdsSecurityGroup implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseEc2Tags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Delete the RDS security group. Assumes upstream teardown has already removed
+     * everything that references it — no database remains in the group and the
+     * 3306-from-task-SG ingress rule went with the task security group — so a plain
+     * delete succeeds; AWS would otherwise refuse with DependencyViolation. A
+     * concurrent removal (InvalidGroup.NotFound) is tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::ec2()->deleteSecurityGroup(['GroupId' => $this->arn()]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidGroup.NotFound') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Resources/Ec2/RouteTable.php
+++ b/src/Resources/Ec2/RouteTable.php
@@ -6,7 +6,9 @@ use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Ec2\Exception\Ec2Exception;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
@@ -14,7 +16,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * Shared public route table for the environment. The default 0.0.0.0/0 route
  * and the subnet associations are separate relationship actions.
  */
-class RouteTable implements Resource
+class RouteTable implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -57,5 +59,25 @@ class RouteTable implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseEc2Tags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Delete the route table by id. The subnet associations go when the subnets
+     * themselves are deleted (upstream teardown order) and the default 0.0.0.0/0
+     * route goes with the table, so a plain delete succeeds; AWS would otherwise
+     * refuse with DependencyViolation while a subnet is still associated. A
+     * concurrent removal (InvalidRouteTableID.NotFound) is tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::ec2()->deleteRouteTable(['RouteTableId' => $this->arn()]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidRouteTableID.NotFound') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Resources/Ec2/Vpc.php
+++ b/src/Resources/Ec2/Vpc.php
@@ -7,7 +7,9 @@ use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Ec2\Exception\Ec2Exception;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
@@ -24,7 +26,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * it lands in. Point `vpc` at an existing VPC name to adopt rather than create
  * one; SyncVpcStep reports that as CUSTOM_MANAGED.
  */
-class Vpc implements Resource, SynchronisesConfiguration
+class Vpc implements Deletable, Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
 
@@ -147,6 +149,26 @@ class Vpc implements Resource, SynchronisesConfiguration
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseEc2Tags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Delete the VPC by id. The network shell inside it — subnets, route table,
+     * internet gateway, security groups — has been torn down by the earlier
+     * destroy steps, so a plain delete succeeds; AWS would otherwise refuse with
+     * DependencyViolation. A concurrent removal (InvalidVpcID.NotFound) is
+     * tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::ec2()->deleteVpc(['VpcId' => $this->arn()]);
+        } catch (Ec2Exception $e) {
+            if ($e->getAwsErrorCode() === 'InvalidVpcID.NotFound') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 
     /**

--- a/src/Resources/Iam/GithubOidcProvider.php
+++ b/src/Resources/Iam/GithubOidcProvider.php
@@ -6,7 +6,9 @@ namespace Codinglabs\Yolo\Resources\Iam;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Iam\Exception\IamException;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Aws\Iam as IamClient;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -24,7 +26,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * GitHub Actions workflow exchange its OIDC token for short-lived AWS credentials
  * via sts:AssumeRoleWithWebIdentity — keyless.
  */
-class GithubOidcProvider implements Resource
+class GithubOidcProvider implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -84,5 +86,24 @@ class GithubOidcProvider implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseIamOidcProviderTags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Teardown: delete the OIDC provider. Account-scoped and shared across every
+     * environment, so this only ever runs once the last environment is gone (the
+     * destroy orchestrator gates it on no other environment remaining). A
+     * concurrent not-found is tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::iam()->deleteOpenIDConnectProvider([
+                'OpenIDConnectProviderArn' => $this->arn(),
+            ]);
+        } catch (IamException $e) {
+            if ($e->getAwsErrorCode() !== 'NoSuchEntity') {
+                throw $e;
+            }
+        }
     }
 }

--- a/src/Resources/Rds/RdsSubnet.php
+++ b/src/Resources/Rds/RdsSubnet.php
@@ -7,8 +7,10 @@ use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Aws\Rds;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
+use Aws\Rds\Exception\RdsException;
 use Codinglabs\Yolo\Resources\Ec2\Vpc;
 use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Enums\Rds as RdsEnum;
 use Codinglabs\Yolo\Resources\ResolvesTags;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -18,7 +20,7 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * launched into the YOLO network. Point `rds.subnet` at an existing group
  * name to adopt one instead.
  */
-class RdsSubnet implements Resource
+class RdsSubnet implements Deletable, Resource
 {
     use ResolvesTags;
 
@@ -61,5 +63,24 @@ class RdsSubnet implements Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseRdsTags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Delete the DB subnet group by name. Assumes upstream teardown has already
+     * removed any database that used it — AWS refuses to delete a subnet group
+     * still referenced by a DB instance. A concurrent removal
+     * (DBSubnetGroupNotFoundFault) is tolerated.
+     */
+    public function delete(): void
+    {
+        try {
+            Aws::rds()->deleteDBSubnetGroup(['DBSubnetGroupName' => $this->name()]);
+        } catch (RdsException $e) {
+            if ($e->getAwsErrorCode() === 'DBSubnetGroupNotFoundFault') {
+                return;
+            }
+
+            throw $e;
+        }
     }
 }

--- a/src/Steps/Destroy/Account/TeardownGithubOidcProviderStep.php
+++ b/src/Steps/Destroy/Account/TeardownGithubOidcProviderStep.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Account;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
+use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
+use Codinglabs\Yolo\Concerns\RecordsWarnings;
+use Codinglabs\Yolo\Aws\ResourceGroupsTaggingApi;
+use Codinglabs\Yolo\Resources\Iam\GithubOidcProvider;
+
+/**
+ * Reclaims the account-shared GitHub OIDC provider — but only when no other
+ * environment remains. The provider is account-scoped (one per account, federated
+ * by every environment's deployer roles), so it's deleted only as the very last
+ * act of tearing down the final environment. While any resource tagged
+ * yolo:environment=<other> still exists, it's deliberately kept and named in the
+ * teardown's refusal summary, never deleted.
+ *
+ * It fails safe: if the "are there other environments?" tag scan can't be
+ * completed, the provider is kept, never deleted on a guess — an account-shared
+ * resource is only reclaimed when its emptiness is positively confirmed.
+ */
+class TeardownGithubOidcProviderStep implements Step
+{
+    use RecordsChanges;
+    use RecordsWarnings;
+
+    public function __invoke(array $options): StepResult
+    {
+        $provider = new GithubOidcProvider();
+
+        if (! $provider->exists()) {
+            return StepResult::SKIPPED;
+        }
+
+        try {
+            $others = $this->otherEnvironments();
+        } catch (\Throwable $exception) {
+            // Fail safe: can't prove this is the last environment ⇒ keep the
+            // account-shared provider rather than risk pulling it from a live env.
+            $this->recordWarning(sprintf(
+                'Kept the account-shared GitHub OIDC provider — could not verify whether other environments exist (%s). It is reclaimed only once that is confirmed.',
+                $exception->getMessage(),
+            ));
+
+            return StepResult::SKIPPED;
+        }
+
+        if ($others !== []) {
+            $this->recordWarning(sprintf(
+                'Kept the account-shared GitHub OIDC provider — other environments still exist (%s). It is reclaimed only when the last environment is torn down.',
+                implode(', ', $others),
+            ));
+
+            return StepResult::SKIPPED;
+        }
+
+        $this->recordChange(Change::make($provider->name(), 'provisioned', null));
+
+        if ((bool) Arr::get($options, 'dry-run')) {
+            return StepResult::WOULD_DELETE;
+        }
+
+        $provider->delete();
+
+        return StepResult::DELETED;
+    }
+
+    /**
+     * Every environment other than this one that still has tagged resources,
+     * derived from the live yolo:environment tags across the account.
+     *
+     * @return array<int, string>
+     */
+    protected function otherEnvironments(): array
+    {
+        return collect(ResourceGroupsTaggingApi::getResources([['Key' => 'yolo:environment']]))
+            ->map(fn (array $resource): array => Aws::flattenTags($resource['Tags']))
+            ->map(fn (array $tags): ?string => $tags['yolo:environment'] ?? null)
+            ->filter()
+            ->reject(fn (string $environment): bool => $environment === Helpers::environment())
+            ->unique()
+            ->sort()
+            ->values()
+            ->all();
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownInternetGatewayStep.php
+++ b/src/Steps/Destroy/Environment/TeardownInternetGatewayStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+use Codinglabs\Yolo\Resources\Ec2\InternetGateway;
+
+/**
+ * Tears down the internet gateway, detaching it from the VPC first (AWS refuses
+ * to delete a gateway still attached). Runs after the subnets and route table.
+ */
+class TeardownInternetGatewayStep extends TeardownStep
+{
+    protected function resource(): InternetGateway
+    {
+        return new InternetGateway();
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownPublicSubnetAStep.php
+++ b/src/Steps/Destroy/Environment/TeardownPublicSubnetAStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the first public subnet (AZ index 0), after everything in it — the
+ * ALB and Fargate ENIs — is gone.
+ */
+class TeardownPublicSubnetAStep extends TeardownStep
+{
+    protected function resource(): PublicSubnet
+    {
+        return new PublicSubnet(0);
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownPublicSubnetBStep.php
+++ b/src/Steps/Destroy/Environment/TeardownPublicSubnetBStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the second public subnet (AZ index 1), after everything in it — the
+ * ALB and Fargate ENIs — is gone.
+ */
+class TeardownPublicSubnetBStep extends TeardownStep
+{
+    protected function resource(): PublicSubnet
+    {
+        return new PublicSubnet(1);
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownPublicSubnetCStep.php
+++ b/src/Steps/Destroy/Environment/TeardownPublicSubnetCStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the third public subnet (AZ index 2), after everything in it — the
+ * ALB and Fargate ENIs — is gone.
+ */
+class TeardownPublicSubnetCStep extends TeardownStep
+{
+    protected function resource(): PublicSubnet
+    {
+        return new PublicSubnet(2);
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownRdsSecurityGroupStep.php
+++ b/src/Steps/Destroy/Environment/TeardownRdsSecurityGroupStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+use Codinglabs\Yolo\Resources\Ec2\RdsSecurityGroup;
+
+/**
+ * Tears down the RDS security group, after any database that used it is gone
+ * (AWS refuses to delete a security group still in use).
+ */
+class TeardownRdsSecurityGroupStep extends TeardownStep
+{
+    protected function resource(): RdsSecurityGroup
+    {
+        return new RdsSecurityGroup();
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownRdsSubnetStep.php
+++ b/src/Steps/Destroy/Environment/TeardownRdsSubnetStep.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Rds\RdsSubnet;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the RDS DB subnet group, after any database that used it is gone.
+ */
+class TeardownRdsSubnetStep extends TeardownStep
+{
+    protected function resource(): RdsSubnet
+    {
+        return new RdsSubnet();
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownRouteTableStep.php
+++ b/src/Steps/Destroy/Environment/TeardownRouteTableStep.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Ec2\RouteTable;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the public route table, after the subnets it associated are gone.
+ */
+class TeardownRouteTableStep extends TeardownStep
+{
+    protected function resource(): RouteTable
+    {
+        return new RouteTable();
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownVpcStep.php
+++ b/src/Steps/Destroy/Environment/TeardownVpcStep.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Resources\Ec2\Vpc;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+
+/**
+ * Tears down the VPC, the last of the network shell — after its subnets, route
+ * table, internet gateway and security groups are gone.
+ */
+class TeardownVpcStep extends TeardownStep
+{
+    protected function resource(): Vpc
+    {
+        return new Vpc();
+    }
+}

--- a/src/Yolo.php
+++ b/src/Yolo.php
@@ -33,7 +33,8 @@ class Yolo
         // Rollback
         Commands\RollbackCommand::class,
 
-        // Destroy (teardown — the reverse of sync:app / sync:environment)
+        // Destroy (teardown — the reverse of sync; app → environment → account)
+        Commands\DestroyCommand::class,
         Commands\DestroyAppCommand::class,
         Commands\DestroyEnvironmentCommand::class,
 

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,6 +8,7 @@ use Aws\Ec2\Ec2Client;
 use Aws\Ecr\EcrClient;
 use Aws\Ecs\EcsClient;
 use Aws\Iam\IamClient;
+use Aws\Rds\RdsClient;
 use Aws\Sqs\SqsClient;
 use Aws\CommandInterface;
 use Aws\WAFV2\WAFV2Client;
@@ -454,6 +455,47 @@ function bindMockElastiCacheClient(array $byCommand, array &$captured): void
     };
 
     Helpers::app()->instance('elastiCache', new ElastiCacheClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
+ * Bind a mock RDS client with command-routed responses, capturing every call.
+ * Mirrors bindMockElastiCacheClient.
+ *
+ * @param  array<string, Result|array<int, Result>>  $byCommand
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
+ */
+function bindMockRdsClient(array $byCommand, array &$captured): void
+{
+    $mock = new class($byCommand, $captured) extends MockHandler
+    {
+        /** @var array<string, int> */
+        private array $cursors = [];
+
+        public function __construct(protected array $byCommand, protected array &$captured) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $name = $cmd->getName();
+            $this->captured[] = ['name' => $name, 'args' => $cmd->toArray()];
+
+            $entry = $this->byCommand[$name] ?? new Result();
+
+            if (is_array($entry)) {
+                $index = min($this->cursors[$name] ?? 0, count($entry) - 1);
+                $this->cursors[$name] = $index + 1;
+                $entry = $entry[$index];
+            }
+
+            return Create::promiseFor($entry);
+        }
+    };
+
+    Helpers::app()->instance('rds', new RdsClient([
         'region' => 'ap-southeast-2',
         'version' => 'latest',
         'credentials' => false,

--- a/tests/Unit/Aws/RdsTest.php
+++ b/tests/Unit/Aws/RdsTest.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Aws\Rds;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+});
+
+it('returns only the databases whose subnet group sits in the given VPC', function (): void {
+    $rds = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'in-vpc', 'DBSubnetGroup' => ['VpcId' => 'vpc-1']],
+            ['DBInstanceIdentifier' => 'other-vpc', 'DBSubnetGroup' => ['VpcId' => 'vpc-2']],
+            ['DBInstanceIdentifier' => 'classic-no-subnet-group'],
+        ]]),
+    ], $rds);
+
+    // Only the instance in vpc-1 — a database in another VPC (or none) doesn't pin it.
+    expect(Rds::instancesInVpc('vpc-1'))->toBe(['in-vpc']);
+});

--- a/tests/Unit/Commands/DestroyCommandTest.php
+++ b/tests/Unit/Commands/DestroyCommandTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Steps;
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Resources\Ec2\Vpc;
+use Codinglabs\Yolo\Services\Lifecycle;
+use Codinglabs\Yolo\Commands\DestroyCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+beforeEach(function (): void {
+    Helpers::app()->instance('runningInAws', false);
+    writeManifest([
+        'account-id' => '111111111111',
+        'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
+        'tasks' => ['web' => true],
+    ]);
+    Lifecycle::reset();
+});
+
+/**
+ * @return array<int, class-string>
+ */
+function orchestratorPlanClasses(): array
+{
+    // A VPC with no attached database — the default path, where the network shell
+    // is reclaimed as part of the environment teardown.
+    $ec2 = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1', 'Tags' => [['Key' => 'Name', 'Value' => (new Vpc())->name()]]]]]),
+    ], $ec2);
+    $rds = [];
+    bindMockRdsClient(['DescribeDBInstances' => new Result(['DBInstances' => []])], $rds);
+
+    $command = new DestroyCommand();
+    $input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->input = $input;
+    $command->output = new BufferedOutput();
+
+    [$plan] = (new ReflectionMethod($command, 'collateSteps'))->invoke($command, $command->scopes(), 'testing');
+
+    return $plan->pluck('step')->map(fn (object $step): string => $step::class)->values()->all();
+}
+
+it('orchestrates app → environment → account, stripping the manifest dead last', function (): void {
+    $classes = orchestratorPlanClasses();
+    $at = fn (string $class): int|false => array_search($class, $classes, true);
+
+    // The app teardown precedes the environment teardown.
+    expect($at(Steps\Destroy\App\TeardownWebServiceStep::class))
+        ->toBeLessThan($at(Steps\Destroy\Environment\TeardownLoadBalancerStep::class));
+    // The network shell (env, Tier B) comes before the account-shared provider.
+    expect($at(Steps\Destroy\Environment\TeardownVpcStep::class))
+        ->toBeLessThan($at(Steps\Destroy\Account\TeardownGithubOidcProviderStep::class));
+    // The account provider precedes the manifest strip.
+    expect($at(Steps\Destroy\Account\TeardownGithubOidcProviderStep::class))
+        ->toBeLessThan($at(Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class));
+    // Stripping yolo.yml is the very last step — after everything that still needs
+    // the manifest's account/region to resolve.
+    expect($at(Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class))->toBe(count($classes) - 1);
+    // It appears exactly once — deferred out of the app scope, never duplicated.
+    expect(array_keys($classes, Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class, true))->toHaveCount(1);
+});
+
+it('always composes the account provider teardown, which self-gates on no other environment', function (): void {
+    $classes = orchestratorPlanClasses();
+    $at = fn (string $class): int|false => array_search($class, $classes, true);
+
+    // No flag — the account-shared provider step is always planned; it decides at
+    // run time whether to delete or keep itself (named in the summary).
+    expect($classes)->toContain(Steps\Destroy\Account\TeardownGithubOidcProviderStep::class);
+    expect($at(Steps\Destroy\Account\TeardownGithubOidcProviderStep::class))
+        ->toBeGreaterThan($at(Steps\Destroy\Environment\TeardownEnvConfigBucketStep::class))
+        ->toBeLessThan($at(Steps\Destroy\App\RemoveEnvironmentFromManifestStep::class));
+});
+
+it('reframes the runner wording as an irreversible destroy', function (): void {
+    $command = new DestroyCommand();
+
+    expect((new ReflectionMethod($command, 'planHeading'))->invoke($command))->toBe('Will destroy')
+        ->and((new ReflectionMethod($command, 'confirmQuestion'))->invoke($command, 'production'))->toContain('Permanently delete')
+        ->and((new ReflectionMethod($command, 'completionVerb'))->invoke($command))->toBe('Destroyed');
+});
+
+it('refuses while another app still claims the environment', function (): void {
+    // Two published claims — this app (my-app) and another. The orchestrator destroys
+    // my-app in the same run, so it's excused; other-app is not, so it refuses.
+    $s3 = [];
+    bindRoutedS3Client([
+        'ListObjectsV2' => new Result(['Contents' => [['Key' => 'apps/my-app.yml'], ['Key' => 'apps/other-app.yml']], 'IsTruncated' => false]),
+        'GetObject' => [
+            new Result(['Body' => "name: my-app\nservices: {}\n"]),
+            new Result(['Body' => "name: other-app\nservices: {}\n"]),
+        ],
+    ], $s3);
+    $ecs = [];
+    bindRoutedEcsClient(['ListClusters' => new Result(['clusterArns' => []])], $ecs);
+    Lifecycle::reset();
+
+    $command = new DestroyCommand();
+    $input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->input = $input;
+    $command->output = new BufferedOutput();
+
+    expect($command->handle())->toBe(Command::FAILURE)
+        ->and(array_column($s3, 'name'))->not->toContain('DeleteBucket');
+});

--- a/tests/Unit/Commands/DestroyEnvironmentCommandTest.php
+++ b/tests/Unit/Commands/DestroyEnvironmentCommandTest.php
@@ -7,6 +7,7 @@ use Codinglabs\Yolo\Steps;
 use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Destroying;
 use Codinglabs\Yolo\Enums\Service;
+use Codinglabs\Yolo\Resources\Ec2\Vpc;
 use Codinglabs\Yolo\Enums\ServiceState;
 use Codinglabs\Yolo\Services\Lifecycle;
 use Symfony\Component\Console\Command\Command;
@@ -27,10 +28,26 @@ beforeEach(function (): void {
 });
 
 /**
+ * Bind a VPC with no databases attached — the default destroy path, where the
+ * network shell (Tier B) is reclaimed.
+ */
+function bindEnvironmentWithoutDatabase(): void
+{
+    $ec2 = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1', 'Tags' => [['Key' => 'Name', 'Value' => (new Vpc())->name()]]]]]),
+    ], $ec2);
+    $rds = [];
+    bindMockRdsClient(['DescribeDBInstances' => new Result(['DBInstances' => []])], $rds);
+}
+
+/**
  * @return array<int, class-string>
  */
 function destroyEnvPlanClasses(): array
 {
+    bindEnvironmentWithoutDatabase();
+
     $command = new DestroyEnvironmentCommand();
     $input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
     $input->setInteractive(false);
@@ -41,6 +58,74 @@ function destroyEnvPlanClasses(): array
 
     return $plan->pluck('step')->map(fn (object $step): string => $step::class)->values()->all();
 }
+
+it('reclaims the network shell when no database is attached', function (): void {
+    $classes = destroyEnvPlanClasses();
+    $at = fn (string $class): int|false => array_search($class, $classes, true);
+
+    expect($classes)->toContain(Steps\Destroy\Environment\TeardownVpcStep::class)
+        ->toContain(Steps\Destroy\Environment\TeardownRdsSubnetStep::class);
+    // RDS subnet group + SG go before the subnets; the VPC is the very last step.
+    expect($at(Steps\Destroy\Environment\TeardownRdsSubnetStep::class))
+        ->toBeLessThan($at(Steps\Destroy\Environment\TeardownPublicSubnetAStep::class));
+    expect($at(Steps\Destroy\Environment\TeardownVpcStep::class))->toBe(count($classes) - 1);
+});
+
+it('refuses the network reclaim while a database is attached, naming it in the summary', function (): void {
+    $ec2 = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1', 'Tags' => [['Key' => 'Name', 'Value' => (new Vpc())->name()]]]]]),
+    ], $ec2);
+    $rds = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'codinglabs', 'DBSubnetGroup' => ['VpcId' => 'vpc-1']],
+        ]]),
+    ], $rds);
+
+    $command = new DestroyEnvironmentCommand();
+    $input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->input = $input;
+    $command->output = new BufferedOutput();
+
+    $classes = (new ReflectionMethod($command, 'collateSteps'))->invoke($command, $command->scopes(), 'testing')[0]
+        ->pluck('step')->map(fn (object $step): string => $step::class)->values()->all();
+
+    // The network shell is left standing — no Tier-B steps composed.
+    expect($classes)->not->toContain(Steps\Destroy\Environment\TeardownVpcStep::class);
+    // The refusal names the blocking database.
+    expect(implode(' ', $command->warnings()))
+        ->toContain('codinglabs')
+        ->toContain('Refusing to reclaim the network shell');
+});
+
+it('reclaims the network shell when the only database is in a different VPC', function (): void {
+    $ec2 = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1', 'Tags' => [['Key' => 'Name', 'Value' => (new Vpc())->name()]]]]]),
+    ], $ec2);
+    $rds = [];
+    bindMockRdsClient([
+        // A live database, but in a different VPC — it does NOT pin this env's
+        // network, so it must not block the reclaim.
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'someone-else', 'DBSubnetGroup' => ['VpcId' => 'vpc-other']],
+        ]]),
+    ], $rds);
+
+    $command = new DestroyEnvironmentCommand();
+    $input = new ArrayInput(['environment' => 'testing'], $command->getDefinition());
+    $input->setInteractive(false);
+    $command->input = $input;
+    $command->output = new BufferedOutput();
+
+    $classes = (new ReflectionMethod($command, 'collateSteps'))->invoke($command, $command->scopes(), 'testing')[0]
+        ->pluck('step')->map(fn (object $step): string => $step::class)->values()->all();
+
+    expect($classes)->toContain(Steps\Destroy\Environment\TeardownVpcStep::class)
+        ->and($command->warnings())->toBe([]);
+});
 
 it('forces env-backed services to teardown only for the duration of the run', function (): void {
     expect(Destroying::active())->toBeFalse();
@@ -53,7 +138,7 @@ it('forces env-backed services to teardown only for the duration of the run', fu
         ->and(Destroying::active())->toBeFalse();
 });
 
-it('tears the service stacks down before the shared edge, and the env config bucket last', function (): void {
+it('tears the service stacks down before the shared edge, and the env config bucket before the network', function (): void {
     $classes = destroyEnvPlanClasses();
     $at = fn (string $class): int|false => array_search($class, $classes, true);
 
@@ -76,8 +161,9 @@ it('tears the service stacks down before the shared edge, and the env config buc
     expect($at(Steps\Destroy\Environment\TeardownLoadBalancerStep::class))
         ->toBeLessThan($at(Steps\Destroy\Environment\TeardownLoadBalancerSecurityGroupStep::class));
 
-    // Deleting the env config bucket is the final act.
-    expect($at(Steps\Destroy\Environment\TeardownEnvConfigBucketStep::class))->toBe(count($classes) - 1);
+    // The env config bucket (Tier A's last) is deleted before the network shell goes.
+    expect($at(Steps\Destroy\Environment\TeardownEnvConfigBucketStep::class))
+        ->toBeLessThan($at(Steps\Destroy\Environment\TeardownVpcStep::class));
 });
 
 it('tears the Valkey cache cluster down before the groups and SG it pins', function (): void {
@@ -90,19 +176,6 @@ it('tears the Valkey cache cluster down before the groups and SG it pins', funct
         ->toBeLessThan($at(Steps\Destroy\Environment\TeardownCacheParameterGroupStep::class))
         ->and($at(Steps\Destroy\Environment\TeardownCacheClusterStep::class))
         ->toBeLessThan($at(Steps\Destroy\Environment\TeardownCacheSecurityGroupStep::class));
-});
-
-it('never touches the network shell (Tier B) or the database', function (): void {
-    // The cache subnet group is Tier A (YOLO-owned), so match the network-shell
-    // resources by their specific names rather than a loose "Subnet" substring.
-    foreach (destroyEnvPlanClasses() as $class) {
-        expect($class)->not->toContain('Vpc')
-            ->not->toContain('PublicSubnet')
-            ->not->toContain('RouteTable')
-            ->not->toContain('InternetGateway')
-            ->not->toContain('RdsSubnet')
-            ->not->toContain('RdsSecurityGroup');
-    }
 });
 
 it('reframes the runner wording as an irreversible destroy', function (): void {

--- a/tests/Unit/Resources/TeardownTest.php
+++ b/tests/Unit/Resources/TeardownTest.php
@@ -5,16 +5,20 @@ declare(strict_types=1);
 use Aws\Result;
 use Aws\MockHandler;
 use Aws\Acm\AcmClient;
+use Aws\Rds\RdsClient;
 use Aws\CommandInterface;
 use Codinglabs\Yolo\Helpers;
 use Aws\Route53\Route53Client;
 use GuzzleHttp\Promise\Create;
 use Aws\CloudFront\CloudFrontClient;
 use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Resources\Ec2\Vpc;
 use Codinglabs\Yolo\Resources\Sqs\Queue;
 use Codinglabs\Yolo\Resources\WafV2\WebAcl;
 use Aws\CloudWatchLogs\CloudWatchLogsClient;
 use Codinglabs\Yolo\Resources\Iam\AdminRole;
+use Codinglabs\Yolo\Resources\Rds\RdsSubnet;
+use Codinglabs\Yolo\Resources\Ec2\RouteTable;
 use Codinglabs\Yolo\Resources\Ecs\EcsCluster;
 use Codinglabs\Yolo\Resources\Ecs\EcsService;
 use Codinglabs\Yolo\Resources\S3\AssetBucket;
@@ -22,6 +26,7 @@ use Codinglabs\Yolo\Resources\Iam\AdminPolicy;
 use Codinglabs\Yolo\Resources\Iam\AdminsGroup;
 use Codinglabs\Yolo\Resources\Iam\EcsTaskRole;
 use Codinglabs\Yolo\Resources\S3\S3LogsBucket;
+use Codinglabs\Yolo\Resources\Ec2\PublicSubnet;
 use Codinglabs\Yolo\Resources\Iam\DeployerRole;
 use Codinglabs\Yolo\Resources\Iam\ObserverRole;
 use Codinglabs\Yolo\Resources\WafV2\AllowIpSet;
@@ -39,9 +44,11 @@ use Codinglabs\Yolo\Resources\Iam\ObserverPolicy;
 use Codinglabs\Yolo\Resources\Iam\ObserversGroup;
 use Codinglabs\Yolo\Resources\Route53\HostedZone;
 use Codinglabs\Yolo\Resources\S3\EnvConfigBucket;
+use Codinglabs\Yolo\Resources\Ec2\InternetGateway;
 use Codinglabs\Yolo\Resources\ElbV2\HttpsListener;
 use Codinglabs\Yolo\Resources\Iam\AppObserverRole;
 use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
+use Codinglabs\Yolo\Resources\Ec2\RdsSecurityGroup;
 use Codinglabs\Yolo\Resources\Iam\EcsExecutionRole;
 use Codinglabs\Yolo\Resources\CloudWatch\QueueAlarm;
 use Codinglabs\Yolo\Resources\Iam\AppObserverPolicy;
@@ -618,4 +625,88 @@ it('resolves the cache security group id then deletes it', function (): void {
     $group->delete();
 
     expect(collect($captured)->firstWhere('name', 'DeleteSecurityGroup')['args']['GroupId'])->toBe('sg-cache');
+});
+
+it('resolves the rds security group id then deletes it', function (): void {
+    $group = new RdsSecurityGroup();
+
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeSecurityGroups' => new Result(['SecurityGroups' => [['GroupName' => $group->name(), 'GroupId' => 'sg-rds']]]),
+    ], $captured);
+
+    $group->delete();
+
+    expect(collect($captured)->firstWhere('name', 'DeleteSecurityGroup')['args']['GroupId'])->toBe('sg-rds');
+});
+
+it('deletes the rds db subnet group by name', function (): void {
+    $subnet = new RdsSubnet();
+
+    $captured = [];
+    bindTeardownRoutedClient('rds', RdsClient::class, [], $captured);
+
+    $subnet->delete();
+
+    expect(collect($captured)->firstWhere('name', 'DeleteDBSubnetGroup')['args']['DBSubnetGroupName'])
+        ->toBe($subnet->name());
+});
+
+it('resolves each public subnet id then deletes it', function (int $index, string $subnetId): void {
+    $subnet = new PublicSubnet($index);
+
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeSubnets' => new Result(['Subnets' => [['SubnetId' => $subnetId]]]),
+    ], $captured);
+
+    $subnet->delete();
+
+    expect(collect($captured)->firstWhere('name', 'DeleteSubnet')['args']['SubnetId'])->toBe($subnetId);
+})->with([
+    [0, 'subnet-a'],
+    [1, 'subnet-b'],
+    [2, 'subnet-c'],
+]);
+
+it('detaches the internet gateway from the vpc before deleting it', function (): void {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeInternetGateways' => new Result(['InternetGateways' => [['InternetGatewayId' => 'igw-1', 'Attachments' => []]]]),
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1']]]),
+    ], $captured);
+
+    (new InternetGateway())->delete();
+
+    $names = array_column($captured, 'name');
+    expect($names)->toContain('DetachInternetGateway')->toContain('DeleteInternetGateway')
+        ->and(array_search('DetachInternetGateway', $names, true))->toBeLessThan(array_search('DeleteInternetGateway', $names, true));
+
+    $detach = collect($captured)->firstWhere('name', 'DetachInternetGateway');
+    expect($detach['args']['InternetGatewayId'])->toBe('igw-1')
+        ->and($detach['args']['VpcId'])->toBe('vpc-1');
+
+    expect(collect($captured)->firstWhere('name', 'DeleteInternetGateway')['args']['InternetGatewayId'])->toBe('igw-1');
+});
+
+it('resolves the route table id then deletes it', function (): void {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeRouteTables' => new Result(['RouteTables' => [['RouteTableId' => 'rtb-1']]]),
+    ], $captured);
+
+    (new RouteTable())->delete();
+
+    expect(collect($captured)->firstWhere('name', 'DeleteRouteTable')['args']['RouteTableId'])->toBe('rtb-1');
+});
+
+it('resolves the vpc id then deletes it', function (): void {
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-1']]]),
+    ], $captured);
+
+    (new Vpc())->delete();
+
+    expect(collect($captured)->firstWhere('name', 'DeleteVpc')['args']['VpcId'])->toBe('vpc-1');
 });

--- a/tests/Unit/Steps/Destroy/TeardownGithubOidcProviderStepTest.php
+++ b/tests/Unit/Steps/Destroy/TeardownGithubOidcProviderStepTest.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Helpers;
+use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Enums\StepResult;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Create as PromiseCreate;
+use Codinglabs\Yolo\Resources\Iam\GithubOidcProvider;
+use Aws\ResourceGroupsTaggingAPI\ResourceGroupsTaggingAPIClient;
+use Codinglabs\Yolo\Steps\Destroy\Account\TeardownGithubOidcProviderStep;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+});
+
+it('keeps the OIDC provider while another environment still has resources', function (): void {
+    $iam = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => [['Arn' => (new GithubOidcProvider())->arn()]]]),
+    ], $iam);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [
+        new Result(['ResourceTagMappingList' => [
+            ['ResourceARN' => 'arn:aws:ecs:ap-southeast-2:111111111111:cluster/x', 'Tags' => [['Key' => 'yolo:environment', 'Value' => 'production']]],
+        ]]),
+    ]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [new Result(['ResourceTagMappingList' => []])]);
+
+    $step = new TeardownGithubOidcProviderStep();
+
+    expect($step(['dry-run' => false]))->toBe(StepResult::SKIPPED)
+        ->and($step->recordedWarnings())->not->toBeEmpty()
+        ->and(array_column($iam, 'name'))->not->toContain('DeleteOpenIDConnectProvider');
+});
+
+it('reclaims the OIDC provider when no other environment remains', function (): void {
+    $iam = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => [['Arn' => (new GithubOidcProvider())->arn()]]]),
+        'DeleteOpenIDConnectProvider' => new Result([]),
+    ], $iam);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApi', [new Result(['ResourceTagMappingList' => []])]);
+    bindMockResourceGroupsTaggingApiClient('resourceGroupsTaggingApiGlobal', [new Result(['ResourceTagMappingList' => []])]);
+
+    $step = new TeardownGithubOidcProviderStep();
+
+    expect($step(['dry-run' => false]))->toBe(StepResult::DELETED)
+        ->and(array_column($iam, 'name'))->toContain('DeleteOpenIDConnectProvider');
+});
+
+it('keeps the OIDC provider when other environments cannot be verified', function (): void {
+    $iam = [];
+    bindRoutedIamClient([
+        'ListOpenIDConnectProviders' => new Result(['OpenIDConnectProviderList' => [['Arn' => (new GithubOidcProvider())->arn()]]]),
+        'DeleteOpenIDConnectProvider' => new Result([]),
+    ], $iam);
+
+    // The "are there other environments?" tag scan fails — fail safe: keep, never
+    // delete an account-shared resource on a guess.
+    Helpers::app()->instance('resourceGroupsTaggingApi', new ResourceGroupsTaggingAPIClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => fn ($command, $request): PromiseInterface => PromiseCreate::rejectionFor(
+            new AwsException('tagging API unavailable', $command),
+        ),
+    ]));
+
+    $step = new TeardownGithubOidcProviderStep();
+
+    expect($step(['dry-run' => false]))->toBe(StepResult::SKIPPED)
+        ->and($step->recordedWarnings())->not->toBeEmpty()
+        ->and(array_column($iam, 'name'))->not->toContain('DeleteOpenIDConnectProvider');
+});


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Phase 3 of `yolo destroy` (LPX-695), **stacked on [#166](https://github.com/codinglabsau/yolo/pull/166)** (Phase 2) — review/merge that first.

**What problems are you solving?**

- #166 added `destroy:environment` (Tier A). There's still no single command that tears an app *and* its environment down together, and no path to reclaim the network shell or the account-shared provider.
- `yolo destroy <env>` does it in one pass — the reverse of `sync` (account → env → app), run **app → environment → account** so nothing is removed while something references it. One plan → confirm → apply over the merged scopes, behind a single gate.

### Destroy means destroy — no reclaim flags
Per the design call: dropped `--reclaim-network` and `--reclaim-account`. Everything auto-deletes, each scope **self-gating on whether anything else still uses it**:

- **Network shell** (Tier B: VPC, subnets, route table, internet gateway, RDS SG + subnet group) — reclaimed automatically after Tier A, **unless a database is attached to the *environment's* VPC**, which keeps it standing and names the blocking instance in the summary. A live DB pins that VPC's network; a DB elsewhere in the account is ignored (the gate filters `DescribeDBInstances` by `DBSubnetGroup.VpcId` against this env's VPC).
- **Account-shared GitHub OIDC provider** — reclaimed **only when no other environment remains** (no resource tagged `yolo:environment=<other>`). It **fails safe**: if that tag scan can't be completed, the provider is *kept*, never deleted on a guess.

### Never deleted
RDS is never touched — a live DB in the env's VPC *refuses the network reclaim*, but the database itself is never a teardown target (no destructive RDS call exists in YOLO, CI-enforced in #166). The BYO app data bucket isn't even a deletable resource. The confirmation banner names them.

### Guards
The app must be a `destroy:app`-supported shape, and no *other* app may still claim the env (this one is excused — torn down in the same run). The `yolo.yml` environment block is stripped **dead last**, after everything that still needs the manifest's account/region to resolve.

**Is there anything the reviewer needs to know to deploy this?**

- **The DB gate is VPC-scoped.** Only a database in the environment's *own* VPC blocks the network reclaim — `Rds::instancesInVpc()` filters by `DBSubnetGroup.VpcId`, so a database living in another VPC (or EC2-Classic, no subnet group) never blocks it. Locked in by a direct `RdsTest` plus a command-level "different VPC → still reclaims" test.
- **Behaviour change vs the first cut of this PR:** network + account teardown used to be opt-in flags; they're now the default, gated automatically. The biggest thing to sanity-check is the account gate — it reaches *up* to an account-shared resource, so it only deletes on a *positive* "no other environment" proof, and keeps-on-uncertainty (RGT failure → kept + named).
- **The loud confirm is the safety net now that there are no flags:** red banner + PROTECTED callout (database + app data bucket) + type-the-environment-name. `--force` / non-interactive bypasses (CI), as with sync.
- Plan composition now calls `liveDatabases()` (describeDBInstances) every run to decide the network gate — a read, no writes until the gate is confirmed.

## Test plan
- `pint --test`, `phpstan`, `rector --dry-run` ✅
- `pest --parallel` ✅ (1512 passed)
- New/updated: `DestroyCommandTest` (app→env→account→manifest ordering, network composed when no DB, account step always planned + self-gating), `DestroyEnvironmentCommandTest` (network reclaimed by default; refused + named when a DB is in this VPC; **reclaimed when the DB is in a different VPC**), `RdsTest` (`instancesInVpc` filters by VPC), `TeardownGithubOidcProviderStepTest` (kept / reclaimed / **kept when RGT can't be verified**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

