### PR TITLE
feat(audit): turn audit into an environment health check (drift + RDS deletion protection)

### DIFF
--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -161,13 +161,23 @@ Writes that land in the fallback store during an outage are **not** synced back 
 
 ## Auditing what's deployed
 
-`yolo audit` is the read-only counterpart to `sync`. It's an **ownership/inventory** check — it queries every resource tagged `yolo:environment=<env>` and asks "is this accounted for?". It does **not** inspect a resource's configuration; comparing live attributes against the manifest is `sync`'s job (and `sync`'s "drift" — config superseded — is a different thing from anything here).
+`yolo audit` is the read-only **health check** for an environment. It rolls up three things and exits **non-zero if any of them turns up an error** — a green/red gate you can wire into CI or run by hand:
+
+1. **A tag inventory** — every resource tagged `yolo:environment=<env>`, classified `ok` or `unexpected` (the ownership check below).
+2. **A drift check** — the whole-stack `sync --check` plan, so "what's drifted from the manifest?" is part of the same answer (it reuses the deploy gate's machinery, read-only, no MFA).
+3. **An RDS deletion-protection probe** — reads the manifest [`database:`](/reference/manifest#database) target and verifies deletion protection is on (an **error** if it's off), reporting the instance/cluster basics alongside.
 
 ```bash
 yolo audit production
 ```
 
-There are two statuses, and a **Reason** column explains every `unexpected` row:
+**Errors fail the run** (exit 1): unexpected resources, drift, and a database with deletion protection off. **Warnings never do**: e.g. a database the tier couldn't read, where protection can't be confirmed either way. Findings print in one block at the end.
+
+> The drift check and RDS probe are **bare `audit` only**. The scoped verbs — `audit:environment`, `audit:app` — stay focused inventory tools (they still exit non-zero on an unexpected resource, but run no drift or RDS probe).
+
+### The tag inventory
+
+The inventory is the ownership half — it asks "is this resource accounted for?", **not** "does its config match the manifest?" (that attribute-level comparison is the drift check's job, via `sync`). There are two statuses, and a **Reason** column explains every `unexpected` row:
 
 | Status | Meaning |
 |---|---|

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -44,7 +44,7 @@ Every YOLO command, with its arguments and options. Run `vendor/bin/yolo` with n
 | [`sync:account <env>`](#yolo-sync-account) | Provision account-global resources |
 | [`sync:environment <env>`](#yolo-sync-environment) | Provision environment-shared resources |
 | [`sync:app <env>`](#yolo-sync-app) | Provision one app's resources |
-| [`audit <env>`](#yolo-audit) | Audit tagged resources and flag anything unexpected |
+| [`audit <env>`](#yolo-audit) | Health-check: tagged-resource inventory + drift check + RDS deletion-protection probe |
 | [`audit:environment <env>`](#yolo-audit-environment) | Audit environment-tier resources |
 | [`audit:app <env> <app>`](#yolo-audit-app) | Audit one app's resources |
 
@@ -682,7 +682,7 @@ Arguments and options as [`sync`](#sync-options). Scope: **environment**. Admin-
 
 ## `yolo audit`
 
-Audit YOLO-tagged resources for an environment (account → environment → app) and flag anything not accounted for. Read-only.
+Health-check an environment. Bare `audit` does three things: the **tag inventory** (every YOLO-tagged resource, account → environment → app, flagging anything not accounted for), a **whole-stack drift check** (the same `sync --check` plan the deploy gate runs), and an **RDS deletion-protection / topology probe**. Read-only — it never writes, and runs under the env observer tier.
 
 ```bash
 yolo audit <environment> [--unexpected] [--json]
@@ -694,10 +694,18 @@ yolo audit <environment> [--unexpected] [--json]
 
 | Option | Value | Description |
 |---|---|---|
-| `--unexpected` | flag | Only show unexpected resources — anything not accounted for by YOLO. |
-| `--json` | flag | Emit the audit as JSON (`{environment, liveApps, okCount, unexpectedCount, resources}`) and exit — machine-readable for the `/yolo` skill and scripts. Honours the same scope and `--unexpected` filtering as the table. |
+| `--unexpected` | flag | Only show unexpected resources — anything not accounted for by YOLO. (Filters the inventory table; the drift and RDS probes still run.) |
+| `--json` | flag | Emit the audit as JSON (`{environment, liveApps, okCount, unexpectedCount, resources, health, findings, healthy}`) and exit — machine-readable for the `/yolo` skill and scripts. The `health` block carries the RDS snapshot and drift verdict; `findings` lists the same errors/warnings the table prints. Honours the same scope and `--unexpected` filtering as the table. |
 
-Queries the Resource Groups Tagging API for everything tagged `yolo:environment=<env>` and classifies each resource as **`ok`** or **`unexpected`**, with a **Reason** explaining each unexpected row — `no ownership tag`, `service no longer provisioned`, or `app cluster gone` (see [Provisioning › Auditing](/guide/provisioning#auditing-what-s-deployed)). Audit is an ownership/inventory check; it does not inspect a resource's configuration (that's `sync`'s job). Results are grouped by scope, unexpected-first within a scope, with clickable AWS Console links where the terminal supports them.
+**The tag inventory** queries the Resource Groups Tagging API for everything tagged `yolo:environment=<env>` and classifies each resource as **`ok`** or **`unexpected`**, with a **Reason** explaining each unexpected row — `no ownership tag`, `service no longer provisioned`, or `app cluster gone` (see [Provisioning › Auditing](/guide/provisioning#auditing-what-s-deployed)). Results are grouped by scope, unexpected-first within a scope, with clickable AWS Console links where the terminal supports them.
+
+**The drift check** runs the whole-stack `sync --check` plan (account → environment → app) in-process, reusing the deploy gate's machinery verbatim. It plans only — never writes — and inherits the audit's read-only cap, so there's no escalation and no MFA prompt. A drifted environment surfaces the sync plan (so you see *which* resources drifted) and points you at `yolo sync <env>` to reconcile. The admin-owned env-service reconcilers a read tier can't inspect are skipped, exactly as in the deploy gate — `yolo sync` is their drift check.
+
+**The RDS probe** looks up the database the manifest [`database:`](/reference/manifest#database) key declares — instance or Aurora cluster, MySQL or Aurora — and reports its **deletion protection**, engine/version, size and (for Aurora) the writer + reader members. It reads the database directly by identifier (RDS isn't YOLO-tagged, so it isn't in the inventory). When no `database:` is declared the probe is skipped.
+
+**Exit code & severity.** Bare `audit` is a green/red health gate: it exits **non-zero on any error** and `0` otherwise. **Errors** (fail the run): unexpected resources, drift, and a database with **deletion protection off**. **Warnings** (never fail the run): a database that can't be read (it doesn't exist, or the tier was denied) — we can't confirm protection is on, only that it isn't confirmed off. Findings render in one block at the end, warnings then errors.
+
+> The RDS deletion-protection probe and the drift check are **bare `audit` only**. The scoped verbs below (`audit:environment`, `audit:app`) stay focused inventory tools — they classify tagged resources and flag unexpected ones (which still exit non-zero), but run no drift or RDS probe.
 
 ---
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -288,7 +288,7 @@ By default YOLO creates and names shared networking under `yolo-{env}-…`. To p
 
 ## `database`
 
-Declares the RDS instance or Aurora cluster the app connects to, so YOLO can chart it — the **Database** section of the app's CloudWatch dashboard and the **Database** tab of [`yolo status`](/reference/commands#yolo-status) (CPU, connections, freeable memory, read/write latency). Entirely optional: omit it and the database panels are simply dropped.
+Declares the RDS instance or Aurora cluster the app connects to, so YOLO can chart it — the **Database** section of the app's CloudWatch dashboard and the **Database** tab of [`yolo status`](/reference/commands#yolo-status) (CPU, connections, freeable memory, read/write latency) — and health-check it: [`yolo audit`](/reference/commands#yolo-audit) reads the same identifier to verify **deletion protection** is on (an error if it isn't) and report the instance/cluster basics. Entirely optional: omit it and the database panels and the audit probe are simply dropped.
 
 YOLO doesn't manage your database, so it can't discover the identifier on its own. It's declared in the manifest — rather than read from `DB_HOST` in the app's `.env` — because the dashboard is written by `yolo sync` under the admin tier, which is deliberately barred from reading app secrets; a manifest value is read identically by every tier, so the dashboard never drifts between who writes it and who checks it.
 

--- a/src/Audit/RdsInspection.php
+++ b/src/Audit/RdsInspection.php
@@ -1,0 +1,244 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Audit;
+
+use Codinglabs\Yolo\Aws\Rds;
+use Codinglabs\Yolo\Manifest;
+use Aws\Rds\Exception\RdsException;
+
+/**
+ * A read-only health snapshot of the database an app is wired to — the RDS
+ * instance or Aurora cluster DECLARED by the manifest `database:` key (see
+ * {@see Manifest::rdsTarget()}). It is NOT a YOLO-managed, YOLO-tagged resource,
+ * so it never shows up in the tag-based audit inventory; the audit health check
+ * looks it up directly by the manifest identifier instead.
+ *
+ * Two things matter to the health check:
+ *  - **deletion protection** — an unprotected production database is an error
+ *    (the audit exits non-zero on it), so a single fat-fingered console delete
+ *    can't take the app's data with it.
+ *  - **topology basics** — engine, version, size and (for Aurora) the writer +
+ *    reader members, surfaced as informational context, never a failure.
+ *
+ * Reads run under the audit's read-only Observer tier, which already grants
+ * `rds:Describe*`. When the declared database can't be read — it doesn't exist,
+ * or the tier was denied — the snapshot degrades to `readable: false` with a
+ * reason, which the command renders as a warning (never an error): we can't
+ * assert protection is off, only that we couldn't confirm it's on.
+ */
+final readonly class RdsInspection
+{
+    /**
+     * @param  array<int, array{identifier: string, role: string, class: string|null, promotionTier: int|null}>  $members
+     */
+    private function __construct(
+        public bool $readable,
+        public ?string $reason,
+        public string $identifier,
+        public bool $cluster,
+        public ?bool $deletionProtection,
+        public ?string $engine,
+        public ?string $engineVersion,
+        public ?string $status,
+        public ?string $instanceClass,
+        public ?int $allocatedStorage,
+        public ?bool $multiAz,
+        public array $members,
+    ) {}
+
+    /**
+     * Inspect the database the manifest declares, or null when none is declared
+     * (no `database:` key) — there is simply nothing to check.
+     */
+    public static function inspect(): ?self
+    {
+        $target = Manifest::rdsTarget();
+
+        if ($target === null) {
+            return null;
+        }
+
+        return $target['cluster']
+            ? self::inspectCluster($target['identifier'])
+            : self::inspectInstance($target['identifier']);
+    }
+
+    /**
+     * True only when we read the database AND deletion protection is explicitly on.
+     * An unreadable snapshot is never "protected" — but it's a warning, not the
+     * error an explicit `false` is (see the command's finding severities).
+     */
+    public function deletionProtectionEnabled(): bool
+    {
+        return $this->readable && $this->deletionProtection === true;
+    }
+
+    public function kind(): string
+    {
+        return $this->cluster ? 'Aurora cluster' : 'instance';
+    }
+
+    /**
+     * The informational rows for the basics table: label => value. Engine, version
+     * and status always; size/Multi-AZ for a plain instance; the member count for a
+     * cluster (the per-member writer/reader breakdown renders as its own table).
+     *
+     * @return array<string, string>
+     */
+    public function basics(): array
+    {
+        $rows = array_filter([
+            'Engine' => $this->engineLabel(),
+            'Status' => $this->status,
+        ]);
+
+        if ($this->cluster) {
+            $rows['Members'] = sprintf('%d (%d writer, %d reader)', count($this->members), $this->writerCount(), $this->readerCount());
+
+            return $rows;
+        }
+
+        return array_filter([
+            ...$rows,
+            'Class' => $this->instanceClass,
+            'Storage' => $this->allocatedStorage === null ? null : sprintf('%d GiB', $this->allocatedStorage),
+            'Multi-AZ' => $this->multiAz === null ? null : ($this->multiAz ? 'yes' : 'no'),
+        ]);
+    }
+
+    protected static function inspectInstance(string $identifier): self
+    {
+        try {
+            $instance = Rds::instance($identifier);
+        } catch (RdsException $exception) {
+            return self::unreadable($identifier, false, self::reason($exception));
+        }
+
+        if ($instance === null) {
+            return self::unreadable($identifier, false, 'no matching DB instance');
+        }
+
+        return new self(
+            readable: true,
+            reason: null,
+            identifier: $identifier,
+            cluster: false,
+            deletionProtection: (bool) ($instance['DeletionProtection'] ?? false),
+            engine: $instance['Engine'] ?? null,
+            engineVersion: $instance['EngineVersion'] ?? null,
+            status: $instance['DBInstanceStatus'] ?? null,
+            instanceClass: $instance['DBInstanceClass'] ?? null,
+            allocatedStorage: isset($instance['AllocatedStorage']) ? (int) $instance['AllocatedStorage'] : null,
+            multiAz: isset($instance['MultiAZ']) ? (bool) $instance['MultiAZ'] : null,
+            members: [],
+        );
+    }
+
+    protected static function inspectCluster(string $identifier): self
+    {
+        try {
+            $cluster = Rds::cluster($identifier);
+        } catch (RdsException $exception) {
+            return self::unreadable($identifier, true, self::reason($exception));
+        }
+
+        if ($cluster === null) {
+            return self::unreadable($identifier, true, 'no matching DB cluster');
+        }
+
+        // Per-member instance class is a best-effort nicety — an access gap on the
+        // instance describe just omits the sizes, never fails the cluster read.
+        try {
+            $classes = Rds::clusterInstanceClasses($identifier);
+        } catch (RdsException) {
+            $classes = [];
+        }
+
+        return new self(
+            readable: true,
+            reason: null,
+            identifier: $identifier,
+            cluster: true,
+            deletionProtection: (bool) ($cluster['DeletionProtection'] ?? false),
+            engine: $cluster['Engine'] ?? null,
+            engineVersion: $cluster['EngineVersion'] ?? null,
+            status: $cluster['Status'] ?? null,
+            instanceClass: null,
+            allocatedStorage: null,
+            multiAz: null,
+            members: self::members($cluster['DBClusterMembers'] ?? [], $classes),
+        );
+    }
+
+    /**
+     * Normalise DBClusterMembers into render-ready rows, writer(s) first then
+     * readers, each ordered by identifier — a stable, scannable order.
+     *
+     * @param  array<int, array<string, mixed>>  $rawMembers
+     * @param  array<string, string>  $classes
+     * @return array<int, array{identifier: string, role: string, class: string|null, promotionTier: int|null}>
+     */
+    protected static function members(array $rawMembers, array $classes): array
+    {
+        $members = array_map(static fn (array $member): array => [
+            'identifier' => $member['DBInstanceIdentifier'] ?? '—',
+            'role' => ($member['IsClusterWriter'] ?? false) ? 'writer' : 'reader',
+            'class' => $classes[$member['DBInstanceIdentifier'] ?? ''] ?? null,
+            'promotionTier' => isset($member['PromotionTier']) ? (int) $member['PromotionTier'] : null,
+        ], $rawMembers);
+
+        usort($members, static fn (array $a, array $b): int => [$a['role'] === 'reader', $a['identifier']] <=> [$b['role'] === 'reader', $b['identifier']]);
+
+        return $members;
+    }
+
+    protected static function unreadable(string $identifier, bool $cluster, string $reason): self
+    {
+        return new self(
+            readable: false,
+            reason: $reason,
+            identifier: $identifier,
+            cluster: $cluster,
+            deletionProtection: null,
+            engine: null,
+            engineVersion: null,
+            status: null,
+            instanceClass: null,
+            allocatedStorage: null,
+            multiAz: null,
+            members: [],
+        );
+    }
+
+    protected static function reason(RdsException $exception): string
+    {
+        return match (true) {
+            in_array($exception->getAwsErrorCode(), ['DBInstanceNotFound', 'DBClusterNotFound'], true) => 'no matching database in this account/region',
+            $exception->getStatusCode() === 403, $exception->getAwsErrorCode() === 'AccessDenied' => 'access denied reading the database',
+            default => $exception->getAwsErrorCode() ?? 'unknown error',
+        };
+    }
+
+    protected function engineLabel(): ?string
+    {
+        if ($this->engine === null) {
+            return null;
+        }
+
+        return $this->engineVersion === null
+            ? $this->engine
+            : sprintf('%s %s', $this->engine, $this->engineVersion);
+    }
+
+    protected function writerCount(): int
+    {
+        return count(array_filter($this->members, static fn (array $member): bool => $member['role'] === 'writer'));
+    }
+
+    protected function readerCount(): int
+    {
+        return count($this->members) - $this->writerCount();
+    }
+}

--- a/src/Aws/Rds.php
+++ b/src/Aws/Rds.php
@@ -19,6 +19,66 @@ class Rds
     }
 
     /**
+     * The live record for a plain (non-Aurora) DB instance, or null when the
+     * describe returns nothing. Read-only — surfaces deletion protection, the
+     * instance class/size, engine and Multi-AZ to the audit health probe. An
+     * unknown identifier throws RdsException (DBInstanceNotFound) straight through
+     * for the caller to classify (the probe degrades it to a warning).
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function instance(string $identifier): ?array
+    {
+        return Aws::rds()->describeDBInstances([
+            'DBInstanceIdentifier' => $identifier,
+        ])['DBInstances'][0] ?? null;
+    }
+
+    /**
+     * The live record for an Aurora DB cluster, including its member list (writer
+     * + readers via DBClusterMembers), or null when the describe returns nothing.
+     * Read-only. An unknown identifier throws RdsException (DBClusterNotFound)
+     * straight through for the caller to classify.
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function cluster(string $identifier): ?array
+    {
+        return Aws::rds()->describeDBClusters([
+            'DBClusterIdentifier' => $identifier,
+        ])['DBClusters'][0] ?? null;
+    }
+
+    /**
+     * The instance class for each member of an Aurora cluster, keyed by instance
+     * identifier — so the audit can show the writer's and readers' sizes. A single
+     * describe filtered to the cluster; read-only. Best-effort detail, so the probe
+     * tolerates an empty result.
+     *
+     * @return array<string, string>
+     */
+    public static function clusterInstanceClasses(string $clusterIdentifier): array
+    {
+        $classes = [];
+        $marker = null;
+
+        do {
+            $page = Aws::rds()->describeDBInstances(array_filter([
+                'Filters' => [['Name' => 'db-cluster-id', 'Values' => [$clusterIdentifier]]],
+                'Marker' => $marker,
+            ]));
+
+            foreach ($page['DBInstances'] ?? [] as $instance) {
+                $classes[$instance['DBInstanceIdentifier']] = $instance['DBInstanceClass'] ?? '—';
+            }
+
+            $marker = $page['Marker'] ?? null;
+        } while ($marker !== null);
+
+        return $classes;
+    }
+
+    /**
      * The identifiers of every live DB instance whose subnet group sits in the
      * given VPC. A network-shell teardown refuses while this isn't empty — the
      * database lives in the VPC's private subnets and pins the whole network, and

--- a/src/Commands/AbstractAuditCommand.php
+++ b/src/Commands/AbstractAuditCommand.php
@@ -7,6 +7,7 @@ use Codinglabs\Yolo\Aws\Ecs;
 use Codinglabs\Yolo\ConsoleUrl;
 use Codinglabs\Yolo\Audit\Audit;
 use Illuminate\Support\Collection;
+use Codinglabs\Yolo\Concerns\RecordsWarnings;
 use Codinglabs\Yolo\Contracts\ReadOnlyCommand;
 use Codinglabs\Yolo\Contracts\ReadsEnvironment;
 use Symfony\Component\Console\Input\InputOption;
@@ -15,6 +16,7 @@ use Symfony\Component\Console\Input\InputArgument;
 
 use function Laravel\Prompts\info;
 use function Laravel\Prompts\note;
+use function Laravel\Prompts\error;
 use function Laravel\Prompts\table;
 use function Laravel\Prompts\warning;
 
@@ -28,6 +30,19 @@ use function Laravel\Prompts\warning;
  */
 abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, ReadsEnvironment
 {
+    // Warnings reuse the step runner's deferred-warning buffer verbatim (record
+    // now, render in one block at the end) — a non-stepped command, same pattern.
+    use RecordsWarnings;
+
+    /**
+     * Health-check errors: anything that should fail the run (exit 1). Warnings
+     * (recordWarning, above) never affect the exit code. The split is the whole
+     * point of the audit-as-health-check exit contract.
+     *
+     * @var array<int, string>
+     */
+    protected array $errors = [];
+
     protected function configure(): void
     {
         $this
@@ -46,11 +61,91 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
 
         $report = Audit::classify($tagged, $this->liveApps($environment));
 
-        if ($this->option('json')) {
-            return $this->renderJson($report, $environment);
+        $json = (bool) $this->option('json');
+
+        $this->flagUnexpected($report);
+
+        if (! $json) {
+            $this->renderInventory($report, $environment);
         }
 
-        return $this->render($report, $environment);
+        // Bare `audit` overrides gatherHealth to add the drift + RDS probes; the
+        // scoped verbs (audit:environment / audit:app) keep inventory-only. Human
+        // runs render the probe tables inline; JSON gathers the same data silently
+        // for the payload. Either way the findings drive the exit code.
+        $health = $this->gatherHealth($environment, render: ! $json);
+
+        if ($json) {
+            return $this->renderJson($report, $environment, $health);
+        }
+
+        return $this->concludeHealth();
+    }
+
+    /**
+     * Health probes beyond the tag inventory. Returns a structured health block
+     * for the JSON payload (empty by default). No-op for the scoped audit verbs —
+     * they're focused inventory tools; {@see AuditCommand} overrides it to run the
+     * whole-stack drift check and the RDS deletion-protection probe. When $render
+     * is true the probes also print their human tables; when false (JSON) they
+     * stay silent and only the returned block and recorded findings carry through.
+     *
+     * @return array<string, mixed>
+     */
+    protected function gatherHealth(string $environment, bool $render): array
+    {
+        return [];
+    }
+
+    /**
+     * Record any unexpected resources in this command's scope as an error finding
+     * — it fails the run regardless of --unexpected (which only narrows the table,
+     * never what counts against the health verdict). Scope-aware so audit:app fails
+     * on that app's strays, not the whole environment's.
+     *
+     * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, unexpectedCount: int}  $report
+     */
+    protected function flagUnexpected(array $report): void
+    {
+        $unexpectedInScope = collect($report['resources'])
+            ->filter(fn (array $resource): bool => $this->includes($resource))
+            ->where('status', Audit::STATUS_UNEXPECTED)
+            ->count();
+
+        if ($unexpectedInScope > 0) {
+            $this->recordError(sprintf(
+                '%d resource(s) unexpected — not accounted for by YOLO. Check the Reason column before removing anything.',
+                $unexpectedInScope,
+            ));
+        }
+    }
+
+    /**
+     * Record a health-check error — a finding that fails the run (exit 1). Drift,
+     * unexpected resources and RDS deletion-protection-off are all errors.
+     */
+    protected function recordError(string $error): void
+    {
+        $this->errors[] = $error;
+    }
+
+    /**
+     * Replay the buffered warnings and errors in one block (warnings then errors,
+     * so the most serious lands last and nearest the prompt), then resolve the
+     * exit code: FAILURE if anything errored, SUCCESS otherwise. Mirrors the step
+     * runner's renderDeferredWarnings, with errors driving the code.
+     */
+    protected function concludeHealth(): int
+    {
+        foreach ($this->recordedWarnings() as $warning) {
+            warning($warning);
+        }
+
+        foreach ($this->errors as $error) {
+            error($error);
+        }
+
+        return $this->errors === [] ? self::SUCCESS : self::FAILURE;
     }
 
     /**
@@ -82,14 +177,18 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
     }
 
     /**
+     * Render the tag-inventory table (the unexpected-resource finding is recorded
+     * separately in flagUnexpected). Void — the exit code is resolved later in
+     * concludeHealth() from the accumulated findings, not from this render.
+     *
      * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, unexpectedCount: int}  $report
      */
-    protected function render(array $report, string $environment): int
+    protected function renderInventory(array $report, string $environment): void
     {
         if (empty($report['resources'])) {
             info(sprintf("Nothing tagged for '%s'.", $environment));
 
-            return self::SUCCESS;
+            return;
         }
 
         note(sprintf('Live apps: %s', $report['liveApps'] ? implode(', ', $report['liveApps']) : 'none'));
@@ -99,11 +198,7 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
         if ($rows->isEmpty()) {
             info($this->emptyFilterMessage($environment));
 
-            return self::SUCCESS;
-        }
-
-        if (! $this->option('unexpected') && $report['unexpectedCount'] > 0) {
-            warning(sprintf('%d resource(s) are unexpected — not accounted for by YOLO. Check the Reason column before removing anything.', $report['unexpectedCount']));
+            return;
         }
 
         table(
@@ -125,8 +220,6 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
             $report['okCount'],
             $report['unexpectedCount'],
         ));
-
-        return self::SUCCESS;
     }
 
     /**
@@ -134,11 +227,15 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
      * scripts): the same scope-filtered + `--unexpected`-filtered rows the table
      * would show, plus the environment, live apps and counts derived from those
      * rows — so the payload is internally consistent (unlike the human note,
-     * which prints the env-wide totals alongside a filtered table).
+     * which prints the env-wide totals alongside a filtered table). The `health`
+     * block carries the probe results (empty for the scoped verbs) and `findings`
+     * the same errors/warnings the human run prints, so a consumer sees exactly
+     * what drove the exit code.
      *
      * @param  array{resources: array<int, array<string, mixed>>, liveApps: array<int, string>, okCount: int, unexpectedCount: int}  $report
+     * @param  array<string, mixed>  $health
      */
-    protected function renderJson(array $report, string $environment): int
+    protected function renderJson(array $report, string $environment, array $health = []): int
     {
         $rows = $this->filtered($report['resources']);
 
@@ -148,9 +245,15 @@ abstract class AbstractAuditCommand extends Command implements ReadOnlyCommand, 
             'okCount' => $rows->where('status', Audit::STATUS_OK)->count(),
             'unexpectedCount' => $rows->where('status', Audit::STATUS_UNEXPECTED)->count(),
             'resources' => static::auditJsonRows($rows->all()),
+            'health' => $health,
+            'findings' => [
+                'errors' => array_values($this->errors),
+                'warnings' => array_values($this->recordedWarnings()),
+            ],
+            'healthy' => $this->errors === [],
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 
-        return self::SUCCESS;
+        return $this->errors === [] ? self::SUCCESS : self::FAILURE;
     }
 
     /**

--- a/src/Commands/AuditCommand.php
+++ b/src/Commands/AuditCommand.php
@@ -4,11 +4,26 @@ declare(strict_types=1);
 
 namespace Codinglabs\Yolo\Commands;
 
+use Laravel\Prompts\Prompt;
+use Codinglabs\Yolo\DeployCheck;
+use Codinglabs\Yolo\Audit\RdsInspection;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\ConsoleOutput;
+use Symfony\Component\Console\Output\BufferedOutput;
+
+use function Laravel\Prompts\info;
+use function Laravel\Prompts\note;
+use function Laravel\Prompts\table;
+
 /**
- * Top-level audit verb — shows every YOLO-tagged resource in an environment,
- * grouped by ownership scope (account → env → app). Mirrors how bare `sync`
- * orchestrates all three tiers; use `audit:environment` / `audit:app` to
- * narrow to one tier.
+ * Top-level audit verb — the environment health check. It shows every
+ * YOLO-tagged resource grouped by ownership scope (account → env → app) and,
+ * unlike the scoped verbs, also runs the deeper probes: a whole-stack drift
+ * check (`sync --check`) and the RDS deletion-protection / topology probe. Any
+ * error finding — an unexpected resource, drift, or a database with deletion
+ * protection off — exits non-zero; warnings never do. Mirrors how bare `sync`
+ * orchestrates all three tiers; use `audit:environment` / `audit:app` to narrow
+ * to one tier's inventory (no health probes).
  */
 class AuditCommand extends AbstractAuditCommand
 {
@@ -19,7 +34,7 @@ class AuditCommand extends AbstractAuditCommand
 
         $this
             ->setName('audit')
-            ->setDescription('Audit YOLO-tagged resources for an environment (account → environment → app) and flag anything not accounted for');
+            ->setDescription('Health-check an environment: audit YOLO-tagged resources (account → environment → app), check for drift, and verify RDS deletion protection');
     }
 
     protected function includes(array $resource): bool
@@ -34,5 +49,175 @@ class AuditCommand extends AbstractAuditCommand
         }
 
         return sprintf("Nothing tagged for '%s'.", $environment);
+    }
+
+    /**
+     * The health probes that make bare `audit` a health check rather than a plain
+     * inventory: the RDS deletion-protection / topology snapshot and the
+     * whole-stack drift verdict. Both record findings (errors fail the run); both
+     * return structured data for the JSON payload.
+     *
+     * @return array<string, mixed>
+     */
+    #[\Override]
+    protected function gatherHealth(string $environment, bool $render): array
+    {
+        return [
+            'rds' => $this->inspectRds($render),
+            'drift' => $this->checkDrift($environment, $render),
+        ];
+    }
+
+    /**
+     * Probe the manifest-declared database (instance or Aurora cluster). Deletion
+     * protection OFF is an error — a single fat-fingered console delete could take
+     * the app's data with it. An unreadable target is only a warning: we can't
+     * assert protection is off, just that we couldn't confirm it's on. Topology
+     * basics are informational. Returns the structured snapshot for `--json`, or
+     * null when no `database:` is declared (nothing to check).
+     *
+     * @return array<string, mixed>|null
+     */
+    protected function inspectRds(bool $render): ?array
+    {
+        $rds = RdsInspection::inspect();
+
+        if (! $rds instanceof RdsInspection) {
+            return null;
+        }
+
+        if (! $rds->readable) {
+            $this->recordWarning(sprintf(
+                'Could not inspect the database "%s" (%s) — deletion protection unconfirmed.',
+                $rds->identifier,
+                $rds->reason,
+            ));
+        } elseif (! $rds->deletionProtectionEnabled()) {
+            $this->recordError(sprintf(
+                'RDS %s "%s" has deletion protection DISABLED — a single console delete can take the data with it.',
+                $rds->kind(),
+                $rds->identifier,
+            ));
+        }
+
+        if ($render) {
+            $this->renderRds($rds);
+        }
+
+        return [
+            'identifier' => $rds->identifier,
+            'kind' => $rds->kind(),
+            'readable' => $rds->readable,
+            'reason' => $rds->reason,
+            'deletionProtection' => $rds->deletionProtection,
+            'engine' => $rds->engine,
+            'engineVersion' => $rds->engineVersion,
+            'status' => $rds->status,
+            'instanceClass' => $rds->instanceClass,
+            'allocatedStorage' => $rds->allocatedStorage,
+            'multiAz' => $rds->multiAz,
+            'members' => $rds->members,
+        ];
+    }
+
+    protected function renderRds(RdsInspection $rds): void
+    {
+        note(sprintf('Database: %s "%s"', ucfirst($rds->kind()), $rds->identifier));
+
+        if (! $rds->readable) {
+            // The recorded warning carries the why; nothing to tabulate.
+            return;
+        }
+
+        $protection = $rds->deletionProtectionEnabled()
+            ? '<fg=green>enabled</>'
+            : '<fg=red;options=bold>DISABLED</>';
+
+        $basics = collect($rds->basics())
+            ->map(fn (string $value, string $label): array => [$label, $value])
+            ->values()
+            ->all();
+
+        table(['Property', 'Value'], [
+            ['Deletion protection', $protection],
+            ...$basics,
+        ]);
+
+        if ($rds->members !== []) {
+            table(
+                ['Member', 'Role', 'Class', 'Tier'],
+                array_map(static fn (array $member): array => [
+                    $member['identifier'],
+                    $member['role'] === 'writer' ? '<fg=cyan>writer</>' : 'reader',
+                    $member['class'] ?? '—',
+                    $member['promotionTier'] === null ? '—' : (string) $member['promotionTier'],
+                ], $rds->members),
+            );
+        }
+    }
+
+    /**
+     * Run the whole-stack `sync --check` (account → environment → app) in-process
+     * to verdict drift, mirroring the deploy gate ({@see Steps\Deploy\EnsureInSyncStep}).
+     * It inherits the audit's read-only Observer cap — no escalation, no MFA — and
+     * runs inside {@see DeployCheck} so the admin-owned env-service reconcilers a
+     * read tier can't see are skipped (they're `yolo sync`'s job; the audit can't
+     * reconcile them anyway). Drift is an error; in human mode the buffered sync
+     * plan is flushed so the operator sees WHICH resources drifted.
+     *
+     * @return array{clean: bool}
+     */
+    protected function checkDrift(string $environment, bool $render): array
+    {
+        $console = $this->output;
+        $buffer = new BufferedOutput($console->getVerbosity(), $console->isDecorated());
+
+        $command = new SyncCommand();
+        $input = new ArrayInput([
+            'environment' => $environment,
+            '--check' => true,
+            '--no-progress' => true,
+        ], $command->getDefinition());
+        $input->setInteractive(false);
+
+        // sync renders through Laravel Prompts' own global output, not the command's
+        // — point it at the buffer, then restore a fresh default afterwards.
+        Prompt::setOutput($buffer);
+
+        try {
+            $clean = DeployCheck::during(fn (): int => $command->run($input, $buffer)) === SyncCommand::SUCCESS;
+        } catch (\Throwable $exception) {
+            // A plan crash (a step threw — e.g. an AWS read the observer tier can't
+            // make) isn't a drift verdict. Flush the per-step detail the plan
+            // buffered before the bare exception bubbles up, so the operator sees
+            // which step failed rather than a context-free stack trace.
+            if ($render) {
+                $console->write($buffer->fetch());
+            }
+
+            throw $exception;
+        } finally {
+            Prompt::setOutput(new ConsoleOutput());
+        }
+
+        if ($clean) {
+            if ($render) {
+                info(sprintf('%s is in sync.', $environment));
+            }
+
+            return ['clean' => true];
+        }
+
+        if ($render) {
+            $console->write($buffer->fetch());
+        }
+
+        $this->recordError(sprintf(
+            '%s has drifted from its declared state — run `yolo sync %s` to reconcile.',
+            $environment,
+            $environment,
+        ));
+
+        return ['clean' => false];
     }
 }

--- a/src/DeployCheck.php
+++ b/src/DeployCheck.php
@@ -5,12 +5,13 @@ declare(strict_types=1);
 namespace Codinglabs\Yolo;
 
 /**
- * Ambient flag: true only while the deploy preflight gate (EnsureInSyncStep) is
- * running its `sync --check`. The step runner consults it (via
+ * Ambient flag: true only while a read-only tier is running `sync --check` and
+ * must skip the admin-owned env-backed-service reconcilers it can't read — the
+ * deploy preflight gate (EnsureInSyncStep, deployer tier) and the `audit` health
+ * check (AuditCommand, Observer tier). The step runner consults it (via
  * ChecksIfCommandsShouldBeRunning::skipReason) to skip SkippedByDeployCheck
- * steps — admin-owned env-backed-service reconcilers the deployer tier can't
- * read. Kept out of the sync command itself so the gate reuses `sync` verbatim;
- * a direct `yolo sync` / `sync --check` (admin, CI drift) never sets it, so it
+ * steps. Kept out of the sync command itself so both reuse `sync` verbatim; a
+ * direct `yolo sync` / `sync --check` (admin, CI drift) never sets it, so it
  * keeps checking everything.
  */
 final class DeployCheck

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -942,6 +942,45 @@ class Manifest
         return $apex;
     }
 
+    /**
+     * The RDS target DECLARED by the flat `database:` manifest key. Accepts either
+     * a bare RDS identifier (a plain instance, charted via DBInstanceIdentifier) or
+     * a full endpoint hostname — which auto-detects an Aurora cluster
+     * (`.cluster-` in the host) vs a plain instance, and skips an RDS Proxy /
+     * non-RDS host. Null when nothing's declared.
+     *
+     * Read from the manifest, never the app's secret `.env`: every consumer (the
+     * CloudWatch dashboard body, the status TUI, the audit health probe) must
+     * resolve the same target under every RBAC tier, which a secret read can't
+     * guarantee. The dashboard tier-parity contract leans on this directly.
+     *
+     * @return array{identifier: string, cluster: bool}|null
+     */
+    public static function rdsTarget(): ?array
+    {
+        $database = static::get('database');
+
+        if (! is_string($database) || $database === '') {
+            return null;
+        }
+
+        // A bare value is a plain instance identifier; a full endpoint hostname
+        // self-describes its kind.
+        if (! str_ends_with($database, '.rds.amazonaws.com')) {
+            return ['identifier' => $database, 'cluster' => false];
+        }
+
+        // RDS Proxy endpoints don't map to a DB metric identifier.
+        if (str_contains($database, '.proxy-')) {
+            return null;
+        }
+
+        return [
+            'identifier' => strtok($database, '.'),
+            'cluster' => str_contains($database, '.cluster-'),
+        ];
+    }
+
     public static function isMultitenanted(): bool
     {
         return ! empty(static::get('tenants'));

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -210,7 +210,7 @@ class Dashboard implements Deletable
             // `tasks.queue: false` runs jobs inline (QUEUE_CONNECTION=sync) and YOLO
             // melts the SQS queue, so there's nothing to chart — omit the section.
             'queueDisabled' => Manifest::queueDisabled(),
-            'rds' => static::rdsTarget(),
+            'rds' => Manifest::rdsTarget(),
             'buckets' => static::bucketNames(),
             'taskLogGroup' => $web ? (new TaskLogGroup())->name() : null,
             // Each service definition contributes its own context entries —
@@ -278,46 +278,6 @@ class Dashboard implements Deletable
             (new AssetBucket())->name(),
             Manifest::has('bucket') ? Paths::s3AppBucket() : null,
         ])->filter()->values()->all();
-    }
-
-    /**
-     * The RDS metric target for the Database section, DECLARED by the flat
-     * `database:` manifest key. Accepts either a bare RDS identifier (charted as a
-     * plain instance via DBInstanceIdentifier) or a full endpoint hostname — which
-     * auto-detects an Aurora cluster (DBClusterIdentifier + Role=WRITER, so it
-     * follows failovers) vs an instance, and skips an RDS Proxy / non-RDS host.
-     *
-     * Read from the manifest, never the app's secret `.env`: the dashboard is
-     * written by `yolo sync` (the admin tier, deliberately barred from reading
-     * secrets) and checked by the deploy gate + status observer — so its desired
-     * body MUST resolve identically under every tier, which a secret read can't
-     * guarantee. Null when nothing's declared, omitting the section.
-     *
-     * @return array{identifier: string, cluster: bool}|null
-     */
-    public static function rdsTarget(): ?array
-    {
-        $database = Manifest::get('database');
-
-        if (! is_string($database) || $database === '') {
-            return null;
-        }
-
-        // A bare value is a plain instance identifier; a full endpoint hostname
-        // self-describes its kind.
-        if (! str_ends_with($database, '.rds.amazonaws.com')) {
-            return ['identifier' => $database, 'cluster' => false];
-        }
-
-        // RDS Proxy endpoints don't map to a DB metric identifier.
-        if (str_contains($database, '.proxy-')) {
-            return null;
-        }
-
-        return [
-            'identifier' => strtok($database, '.'),
-            'cluster' => str_contains($database, '.cluster-'),
-        ];
     }
 
     /**

--- a/src/Tui/Panels/DatabasePanel.php
+++ b/src/Tui/Panels/DatabasePanel.php
@@ -13,7 +13,6 @@ use Codinglabs\Yolo\Tui\Theme;
 use Codinglabs\Yolo\ConsoleUrl;
 use Codinglabs\Yolo\Tui\Viewport;
 use Codinglabs\Yolo\Aws\CloudWatch;
-use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
 
 /**
  * The app's database at a glance — the RDS instance/cluster declared by the
@@ -54,7 +53,7 @@ class DatabasePanel implements Panel
 
     public function gather(): void
     {
-        $this->target = Dashboard::rdsTarget();
+        $this->target = Manifest::rdsTarget();
         $this->series = self::EMPTY_SERIES;
 
         if ($this->target === null) {

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -468,9 +468,12 @@ function bindMockElastiCacheClient(array $byCommand, array &$captured): void
 
 /**
  * Bind a mock RDS client with command-routed responses, capturing every call.
- * Mirrors bindMockElastiCacheClient.
+ * A command's value may be a single Result/Throwable (repeated) or an array used
+ * as a queue (the last entry repeats once exhausted); a Throwable is returned as
+ * a rejection (e.g. a DescribeDBInstances DBInstanceNotFound). Mirrors
+ * bindMockElastiCacheClient.
  *
- * @param  array<string, Result|array<int, Result>>  $byCommand
+ * @param  array<string, Result|Throwable|array<int, Result|Throwable>>  $byCommand
  * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
  */
 function bindMockRdsClient(array $byCommand, array &$captured): void
@@ -495,7 +498,9 @@ function bindMockRdsClient(array $byCommand, array &$captured): void
                 $entry = $entry[$index];
             }
 
-            return Create::promiseFor($entry);
+            return $entry instanceof Throwable
+                ? Create::rejectionFor($entry)
+                : Create::promiseFor($entry);
         }
     };
 

--- a/tests/Unit/Audit/RdsInspectionTest.php
+++ b/tests/Unit/Audit/RdsInspectionTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Aws\Command as AwsCommand;
+use Aws\Rds\Exception\RdsException;
+use Codinglabs\Yolo\Audit\RdsInspection;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'database' => 'app-db']);
+});
+
+it('returns null when no database is declared — nothing to inspect', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+
+    expect(RdsInspection::inspect())->toBeNull();
+});
+
+it('reads a plain instance with deletion protection on, plus engine, class and storage basics', function (): void {
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new Result(['DBInstances' => [[
+            'DBInstanceIdentifier' => 'app-db',
+            'DeletionProtection' => true,
+            'Engine' => 'mysql',
+            'EngineVersion' => '8.0.39',
+            'DBInstanceStatus' => 'available',
+            'DBInstanceClass' => 'db.t3.medium',
+            'AllocatedStorage' => 50,
+            'MultiAZ' => true,
+        ]]]),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds)->not->toBeNull()
+        ->and($rds->cluster)->toBeFalse()
+        ->and($rds->kind())->toBe('instance')
+        ->and($rds->deletionProtectionEnabled())->toBeTrue()
+        ->and($rds->instanceClass)->toBe('db.t3.medium')
+        ->and($rds->allocatedStorage)->toBe(50)
+        ->and($rds->multiAz)->toBeTrue()
+        ->and($rds->basics())->toMatchArray([
+            'Engine' => 'mysql 8.0.39',
+            'Status' => 'available',
+            'Class' => 'db.t3.medium',
+            'Storage' => '50 GiB',
+            'Multi-AZ' => 'yes',
+        ]);
+});
+
+it('flags a plain instance with deletion protection off', function (): void {
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new Result(['DBInstances' => [[
+            'DBInstanceIdentifier' => 'app-db',
+            'DeletionProtection' => false,
+            'Engine' => 'mysql',
+        ]]]),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds->readable)->toBeTrue()
+        ->and($rds->deletionProtectionEnabled())->toBeFalse();
+});
+
+it('defaults deletion protection to off when the attribute is absent — fail safe', function (): void {
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new Result(['DBInstances' => [['DBInstanceIdentifier' => 'app-db']]]),
+    ], $captured);
+
+    expect(RdsInspection::inspect()->deletionProtectionEnabled())->toBeFalse();
+});
+
+it('reads an Aurora cluster: writer first then readers, with member classes and deletion protection', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'database' => 'app.cluster-abc123.ap-southeast-2.rds.amazonaws.com']);
+
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBClusters' => new Result(['DBClusters' => [[
+            'DBClusterIdentifier' => 'app',
+            'DeletionProtection' => true,
+            'Engine' => 'aurora-mysql',
+            'EngineVersion' => '8.0.mysql_aurora.3.05.2',
+            'Status' => 'available',
+            'DBClusterMembers' => [
+                ['DBInstanceIdentifier' => 'app-reader-1', 'IsClusterWriter' => false, 'PromotionTier' => 1],
+                ['DBInstanceIdentifier' => 'app-writer', 'IsClusterWriter' => true, 'PromotionTier' => 0],
+            ],
+        ]]]),
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'app-writer', 'DBInstanceClass' => 'db.r6g.large'],
+            ['DBInstanceIdentifier' => 'app-reader-1', 'DBInstanceClass' => 'db.r6g.large'],
+        ]]),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds->cluster)->toBeTrue()
+        ->and($rds->kind())->toBe('Aurora cluster')
+        ->and($rds->deletionProtectionEnabled())->toBeTrue()
+        ->and($rds->members)->toHaveCount(2)
+        // writer is sorted first, regardless of the order AWS returns members in
+        ->and($rds->members[0])->toMatchArray(['identifier' => 'app-writer', 'role' => 'writer', 'class' => 'db.r6g.large'])
+        ->and($rds->members[1])->toMatchArray(['identifier' => 'app-reader-1', 'role' => 'reader'])
+        ->and($rds->basics())->toMatchArray(['Members' => '2 (1 writer, 1 reader)']);
+});
+
+it('degrades to unreadable (a warning, never an error) when the database is not found', function (): void {
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new RdsException('not found', new AwsCommand('DescribeDBInstances'), ['code' => 'DBInstanceNotFound']),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds->readable)->toBeFalse()
+        // an unreadable target is never "protected" — but it's a warning, not the
+        // error an explicit false is.
+        ->and($rds->deletionProtectionEnabled())->toBeFalse()
+        ->and($rds->reason)->toContain('no matching database');
+});
+
+it('degrades to unreadable when the read is denied', function (): void {
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBInstances' => new RdsException('denied', new AwsCommand('DescribeDBInstances'), ['code' => 'AccessDenied']),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds->readable)->toBeFalse()
+        ->and($rds->reason)->toContain('access denied');
+});
+
+it('tolerates a member-class describe failure on a cluster — sizes omitted, not fatal', function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'database' => 'app.cluster-abc123.ap-southeast-2.rds.amazonaws.com']);
+
+    $captured = [];
+    bindMockRdsClient([
+        'DescribeDBClusters' => new Result(['DBClusters' => [[
+            'DBClusterIdentifier' => 'app',
+            'DeletionProtection' => true,
+            'Engine' => 'aurora-mysql',
+            'DBClusterMembers' => [
+                ['DBInstanceIdentifier' => 'app-writer', 'IsClusterWriter' => true],
+            ],
+        ]]]),
+        'DescribeDBInstances' => new RdsException('denied', new AwsCommand('DescribeDBInstances'), ['code' => 'AccessDenied']),
+    ], $captured);
+
+    $rds = RdsInspection::inspect();
+
+    expect($rds->readable)->toBeTrue()
+        ->and($rds->members)->toHaveCount(1)
+        ->and($rds->members[0]['class'])->toBeNull();
+});

--- a/tests/Unit/Commands/AuditHealthCheckTest.php
+++ b/tests/Unit/Commands/AuditHealthCheckTest.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Laravel\Prompts\Prompt;
+use Aws\Command as AwsCommand;
+use Codinglabs\Yolo\Audit\Audit;
+use Aws\Rds\Exception\RdsException;
+use Codinglabs\Yolo\Commands\AuditCommand;
+use Codinglabs\Yolo\Commands\AuditAppCommand;
+use Symfony\Component\Console\Input\ArrayInput;
+use Codinglabs\Yolo\Commands\AbstractAuditCommand;
+use Symfony\Component\Console\Output\BufferedOutput;
+use Codinglabs\Yolo\Commands\AuditEnvironmentCommand;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2', 'database' => 'app-db']);
+    // concludeHealth() prints findings via Laravel Prompts' global output — capture
+    // it so the suite stays quiet and the calls don't touch a real terminal.
+    Prompt::setOutput(new BufferedOutput());
+});
+
+/** @return array<int, string> */
+function healthCheckErrors(AbstractAuditCommand $command): array
+{
+    return (new ReflectionProperty($command, 'errors'))->getValue($command);
+}
+
+function callAuditMethod(AbstractAuditCommand $command, string $method, mixed ...$args): mixed
+{
+    return (new ReflectionMethod($command, $method))->invoke($command, ...$args);
+}
+
+describe('exit-code contract', function (): void {
+    it('exits 0 (healthy) when there are no findings', function (): void {
+        $command = new AuditEnvironmentCommand();
+
+        expect(callAuditMethod($command, 'concludeHealth'))->toBe(AuditEnvironmentCommand::SUCCESS);
+    });
+
+    it('exits 1 when an unexpected resource is in scope — any finding fails', function (): void {
+        $command = new AuditEnvironmentCommand();
+
+        callAuditMethod($command, 'flagUnexpected', [
+            'resources' => [
+                ['status' => Audit::STATUS_UNEXPECTED, 'scope' => Audit::SCOPE_ENV, 'app' => null],
+            ],
+        ]);
+
+        expect(callAuditMethod($command, 'concludeHealth'))->toBe(AuditEnvironmentCommand::FAILURE);
+    });
+
+    it('does not let warnings affect the exit code — only errors do', function (): void {
+        $command = new AuditEnvironmentCommand();
+
+        callAuditMethod($command, 'recordWarning', 'just so you know');
+
+        expect(healthCheckErrors($command))->toBeEmpty()
+            ->and(callAuditMethod($command, 'concludeHealth'))->toBe(AuditEnvironmentCommand::SUCCESS);
+    });
+
+    it('scopes the unexpected-resource finding to the audited app, not the whole env', function (): void {
+        $command = new AuditAppCommand();
+        $command->input = new ArrayInput(['environment' => 'testing', 'app' => 'mine'], $command->getDefinition());
+
+        callAuditMethod($command, 'flagUnexpected', [
+            'resources' => [
+                ['status' => Audit::STATUS_UNEXPECTED, 'scope' => Audit::SCOPE_APP, 'app' => 'someone-else'],
+            ],
+        ]);
+
+        // The stray belongs to another app, so it's out of scope — no error.
+        expect(healthCheckErrors($command))->toBeEmpty();
+    });
+});
+
+describe('RDS deletion-protection finding', function (): void {
+    it('records an error when deletion protection is off', function (): void {
+        $captured = [];
+        bindMockRdsClient([
+            'DescribeDBInstances' => new Result(['DBInstances' => [['DBInstanceIdentifier' => 'app-db', 'DeletionProtection' => false]]]),
+        ], $captured);
+
+        $command = new AuditCommand();
+        callAuditMethod($command, 'inspectRds', false);
+
+        expect(healthCheckErrors($command))->toHaveCount(1)
+            ->and(healthCheckErrors($command)[0])->toContain('deletion protection DISABLED');
+    });
+
+    it('records no finding when deletion protection is on', function (): void {
+        $captured = [];
+        bindMockRdsClient([
+            'DescribeDBInstances' => new Result(['DBInstances' => [['DBInstanceIdentifier' => 'app-db', 'DeletionProtection' => true]]]),
+        ], $captured);
+
+        $command = new AuditCommand();
+        callAuditMethod($command, 'inspectRds', false);
+
+        expect(healthCheckErrors($command))->toBeEmpty()
+            ->and($command->recordedWarnings())->toBeEmpty();
+    });
+
+    it('records a warning, not an error, when the database cannot be read', function (): void {
+        $captured = [];
+        bindMockRdsClient([
+            'DescribeDBInstances' => new RdsException('not found', new AwsCommand('DescribeDBInstances'), ['code' => 'DBInstanceNotFound']),
+        ], $captured);
+
+        $command = new AuditCommand();
+        callAuditMethod($command, 'inspectRds', false);
+
+        expect(healthCheckErrors($command))->toBeEmpty()
+            ->and($command->recordedWarnings())->toHaveCount(1)
+            ->and($command->recordedWarnings()[0])->toContain('deletion protection unconfirmed');
+    });
+
+    it('records nothing and returns null when no database is declared', function (): void {
+        writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+
+        $command = new AuditCommand();
+
+        expect(callAuditMethod($command, 'inspectRds', false))->toBeNull()
+            ->and(healthCheckErrors($command))->toBeEmpty();
+    });
+});

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -593,3 +593,30 @@ describe('unified autoscaling', function (): void {
         expect(Manifest::autoscales(ServerGroup::SCHEDULER))->toBeFalse();
     });
 });
+
+describe('rdsTarget', function (): void {
+    it('reads the RDS target from the flat manifest key — a bare value is an instance, a full endpoint auto-detects Aurora', function (): void {
+        // Sourced from the manifest, never the app's secret .env, so every
+        // consumer (dashboard writer, deploy gate, audit probe) resolves the SAME
+        // target under any RBAC tier — no identity-dependent drift.
+        writeManifest(['database' => 'my-db']);
+        expect(Manifest::rdsTarget())->toBe(['identifier' => 'my-db', 'cluster' => false]);
+
+        writeManifest(['database' => 'my-cluster.cluster-cabc123.ap-southeast-2.rds.amazonaws.com']);
+        expect(Manifest::rdsTarget())->toBe(['identifier' => 'my-cluster', 'cluster' => true]);
+
+        writeManifest(['database' => 'my-instance.cabc123.ap-southeast-2.rds.amazonaws.com']);
+        expect(Manifest::rdsTarget())->toBe(['identifier' => 'my-instance', 'cluster' => false]);
+    });
+
+    it('returns no RDS target when nothing is declared, the value is blank, or it is an RDS Proxy', function (): void {
+        writeManifest([]);
+        expect(Manifest::rdsTarget())->toBeNull();
+
+        writeManifest(['database' => '']);
+        expect(Manifest::rdsTarget())->toBeNull();
+
+        writeManifest(['database' => 'my-proxy.proxy-cabc.ap-southeast-2.rds.amazonaws.com']);
+        expect(Manifest::rdsTarget())->toBeNull();
+    });
+});

--- a/tests/Unit/Resources/CloudWatch/DashboardTest.php
+++ b/tests/Unit/Resources/CloudWatch/DashboardTest.php
@@ -96,31 +96,6 @@ it('names the dashboard per app + environment', function (): void {
     expect((new Dashboard())->name())->toBe('yolo-testing-my-app-dashboard');
 });
 
-it('reads the RDS target from the flat manifest key — a bare value is an instance, a full endpoint auto-detects Aurora', function (): void {
-    // Sourced from the manifest, never the app's secret .env, so the dashboard's
-    // writer (admin, barred from reading secrets) and the deploy gate resolve the
-    // SAME target — no identity-dependent drift.
-    writeManifest(['database' => 'my-db']);
-    expect(Dashboard::rdsTarget())->toBe(['identifier' => 'my-db', 'cluster' => false]);
-
-    writeManifest(['database' => 'my-cluster.cluster-cabc123.ap-southeast-2.rds.amazonaws.com']);
-    expect(Dashboard::rdsTarget())->toBe(['identifier' => 'my-cluster', 'cluster' => true]);
-
-    writeManifest(['database' => 'my-instance.cabc123.ap-southeast-2.rds.amazonaws.com']);
-    expect(Dashboard::rdsTarget())->toBe(['identifier' => 'my-instance', 'cluster' => false]);
-});
-
-it('returns no RDS target when nothing is declared, the value is blank, or it is an RDS Proxy', function (): void {
-    writeManifest([]);
-    expect(Dashboard::rdsTarget())->toBeNull();
-
-    writeManifest(['database' => '']);
-    expect(Dashboard::rdsTarget())->toBeNull();
-
-    writeManifest(['database' => 'my-proxy.proxy-cabc.ap-southeast-2.rds.amazonaws.com']);
-    expect(Dashboard::rdsTarget())->toBeNull();
-});
-
 it('parses the CloudWatch dimension suffix out of ELB ARNs', function (): void {
     expect(Dashboard::loadBalancerDimension('arn:aws:elasticloadbalancing:ap-southeast-2:111111111111:loadbalancer/app/yolo-testing/abc123'))
         ->toBe('app/yolo-testing/abc123');


### PR DESCRIPTION
## Hey, I made a thing! 🥳

Bare `yolo audit <env>` becomes a green/red **environment health check** instead of just a tag inventory.

**What problems are you solving?**

- **No single "is this environment healthy?" command.** `audit` only listed tagged resources; drift lived in `sync --check` and nothing checked the database. Now bare `audit` rolls up three checks and exits **non-zero on any error**:
  - **Unknown resources** — existing tag inventory; unexpected resources are now an *error* finding.
  - **Drift** — whole-stack `sync --check` run in-process, reusing the deploy gate's pattern (`EnsureInSyncStep`). Inherits the read-only Observer cap (no MFA, no escalation) and runs inside `DeployCheck` so admin-owned env-service reconcilers a read tier can't see are skipped (`yolo sync` is their drift check).
  - **RDS deletion protection** — new `Audit\RdsInspection`, manifest-driven via the shared `Manifest::rdsTarget()`. Works for a plain MySQL instance and an Aurora cluster (writer + readers). Deletion protection **off** is an error; an unreadable database is a warning.
- **Severity split** — errors fail (exit 1), warnings never do — reusing the `RecordsWarnings` buffer for deferred rendering. `--json` carries a `health` block, `findings`, and a `healthy` flag.
- Scoped verbs (`audit:environment` / `audit:app`) stay inventory-only.

**Is there anything the reviewer needs to know to deploy this?**

- **No new IAM.** The Observer tier already grants `rds:Describe*`; RDS and the BYO data bucket aren't tag-inventoried, so the probe reads RDS directly from the manifest `database:` key.
- **`rdsTarget()` moved** from `CloudWatch\Dashboard` to `Manifest` (now shared by the dashboard, the status TUI, and the audit probe); its tests moved to `ManifestTest`. Behaviour unchanged.
- **`audit --json` now runs a full `sync --check`** — a cost bump for the `/yolo` skill, which calls it for cheap inventory. Left integral (health is health); flag if it feels heavy and we'll gate drift behind a flag.
- **Unexpected resources now exit 1.** Previously every `audit` exited 0. This is the intended health-gate behaviour, but it means a benign stray will hold CI red until cleaned up.
- **S3 deletion protection deferred** — S3 has no native flag, the data bucket is BYO/create-only and often unreadable by the tier; it's a separate enforcement feature.
- MockHandler tests prove request shape only; the drift check under the Observer tier should get a real-env smoke before the first staging deploy leans on it.

🤖 Generated with [Claude Code](https://claude.ai/code)