### PR TITLE
Gate the external-database ingress rule on an active or declared peering

### DIFF
--- a/src/Aws/Ec2.php
+++ b/src/Aws/Ec2.php
@@ -152,6 +152,24 @@ class Ec2
     }
 
     /**
+     * Whether an ACTIVE peering connection joins the two VPCs, either
+     * orientation, YOLO-owned or not — a security group in one VPC can only
+     * reference a group in the other once this is true.
+     */
+    public static function activePeeringBetween(string $vpcId, string $otherVpcId): bool
+    {
+        return collect(Aws::ec2()->describeVpcPeeringConnections([
+            'Filters' => [['Name' => 'status-code', 'Values' => ['active']]],
+        ])['VpcPeeringConnections'] ?? [])->contains(function (array $connection) use ($vpcId, $otherVpcId): bool {
+            $requesterVpcId = $connection['RequesterVpcInfo']['VpcId'] ?? null;
+            $accepterVpcId = $connection['AccepterVpcInfo']['VpcId'] ?? null;
+
+            return ($requesterVpcId === $vpcId && $accepterVpcId === $otherVpcId)
+                || ($requesterVpcId === $otherVpcId && $accepterVpcId === $vpcId);
+        });
+    }
+
+    /**
      * A VPC by its id, or null when it doesn't exist — a declared peer VPC is
      * operator input, so absence is reported as pending drift, never a crash.
      *

--- a/src/Steps/Sync/App/SyncExternalDatabaseIngressStep.php
+++ b/src/Steps/Sync/App/SyncExternalDatabaseIngressStep.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Illuminate\Support\Arr;
+use Codinglabs\Yolo\Aws\Ec2;
 use Codinglabs\Yolo\Aws\Rds;
 use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\EnvManifest;
 use Aws\Rds\Exception\RdsException;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
@@ -60,6 +62,24 @@ class SyncExternalDatabaseIngressStep implements SkippedByDeployCheck, Step
             return StepResult::SKIPPED;
         }
 
+        $databaseVpcId = $instance['DBSubnetGroup']['VpcId'] ?? null;
+
+        // A cross-VPC security-group reference is only valid over an ACTIVE
+        // peering, so an external database whose VPC is neither peered nor
+        // declared for peering gets a nudge, not a mid-apply AWS error. A
+        // declared-but-not-yet-active peer proceeds: the env tier activates it
+        // earlier in the same sync, so by the time this step's apply runs the
+        // reference is valid (and the plan pass reports the pending rule).
+        if ($databaseVpcId === null || ! $this->reachable($databaseVpcId)) {
+            $this->recordWarning(sprintf(
+                'The database "%s" is externally hosted (%s) with no peering to its VPC — the 3306-from-task-SG rule was not written. Declare the VPC in the env manifest `peering` list to bridge it.',
+                $target['identifier'],
+                $databaseVpcId ?? 'unknown VPC',
+            ));
+
+            return StepResult::SKIPPED;
+        }
+
         $securityGroupIds = collect($instance['VpcSecurityGroups'] ?? [])
             ->pluck('VpcSecurityGroupId')
             ->filter()
@@ -98,5 +118,24 @@ class SyncExternalDatabaseIngressStep implements SkippedByDeployCheck, Step
         } catch (ResourceDoesNotExistException) {
             return false;
         }
+    }
+
+    /**
+     * Whether the database's VPC is reachable for a cross-VPC SG reference —
+     * an active peering already joins it to the env VPC (YOLO-owned or not),
+     * or the env manifest declares it, meaning this same sync's environment
+     * tier brings the peering active before this step's apply runs.
+     */
+    protected function reachable(string $databaseVpcId): bool
+    {
+        try {
+            if (Ec2::activePeeringBetween((new Vpc())->arn(), $databaseVpcId)) {
+                return true;
+            }
+        } catch (ResourceDoesNotExistException) {
+            // No env VPC yet (greenfield) — fall through to the declaration.
+        }
+
+        return in_array($databaseVpcId, EnvManifest::peering(), true);
     }
 }

--- a/tests/Unit/Steps/Network/SyncExternalDatabaseIngressStepTest.php
+++ b/tests/Unit/Steps/Network/SyncExternalDatabaseIngressStepTest.php
@@ -24,12 +24,24 @@ function bindExternalInstance(array $securityGroupIds, string $vpcId = 'vpc-exte
     ], $captured);
 }
 
+/** An active peering joining the env VPC and the database's VPC. */
+function activePeeringResult(): Result
+{
+    return new Result(['VpcPeeringConnections' => [[
+        'VpcPeeringConnectionId' => 'pcx-1',
+        'Status' => ['Code' => 'active'],
+        'RequesterVpcInfo' => ['VpcId' => 'vpc-env'],
+        'AccepterVpcInfo' => ['VpcId' => 'vpc-external'],
+    ]]]);
+}
+
 it('authorises 3306 from the task SG on the external database\'s discovered security group', function (): void {
     bindExternalInstance(['sg-external']);
 
     $captured = [];
     bindMockEc2Client([
         'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-env']]]),
+        'DescribeVpcPeeringConnections' => activePeeringResult(),
         'DescribeSecurityGroups' => new Result(['SecurityGroups' => [
             ['GroupName' => 'yolo-testing-my-app-ecs-task-security-group', 'GroupId' => 'sg-task'],
         ]]),
@@ -51,6 +63,7 @@ it('reports pending on the plan pass without writing', function (): void {
     $captured = [];
     bindMockEc2Client([
         'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-env']]]),
+        'DescribeVpcPeeringConnections' => activePeeringResult(),
         'DescribeSecurityGroups' => new Result(['SecurityGroups' => [
             ['GroupName' => 'yolo-testing-my-app-ecs-task-security-group', 'GroupId' => 'sg-task'],
         ]]),
@@ -82,6 +95,7 @@ it('warns and skips when the external database carries more than one security gr
     $captured = [];
     bindMockEc2Client([
         'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-env']]]),
+        'DescribeVpcPeeringConnections' => activePeeringResult(),
     ], $captured);
 
     $step = new SyncExternalDatabaseIngressStep();
@@ -90,6 +104,47 @@ it('warns and skips when the external database carries more than one security gr
         ->and($step->recordedWarnings())->toHaveCount(1)
         ->and($step->recordedWarnings()[0])->toContain('ambiguous')
         ->and(collect($captured)->pluck('name'))->not->toContain('AuthorizeSecurityGroupIngress');
+});
+
+it('warns and skips an external database whose VPC is neither peered nor declared', function (): void {
+    bindExternalInstance(['sg-external']);
+
+    $s3Captured = [];
+    bindRoutedS3Client(['GetObject' => new Result(['Body' => 'peering: []'])], $s3Captured);
+
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-env']]]),
+        'DescribeVpcPeeringConnections' => new Result(['VpcPeeringConnections' => []]),
+    ], $captured);
+
+    $step = new SyncExternalDatabaseIngressStep();
+
+    expect($step([]))->toBe(StepResult::SKIPPED)
+        ->and($step->recordedWarnings()[0])->toContain('no peering')
+        ->and(collect($captured)->pluck('name'))->not->toContain('AuthorizeSecurityGroupIngress');
+});
+
+it('proceeds when the peering is declared but not yet active — the env tier activates it this sync', function (): void {
+    bindExternalInstance(['sg-external'], vpcId: 'vpc-0abc123');
+
+    $s3Captured = [];
+    bindRoutedS3Client(['GetObject' => new Result(['Body' => "peering:\n  - vpc-0abc123\n"])], $s3Captured);
+
+    $captured = [];
+    bindMockEc2Client([
+        'DescribeVpcs' => new Result(['Vpcs' => [['VpcId' => 'vpc-env']]]),
+        'DescribeVpcPeeringConnections' => new Result(['VpcPeeringConnections' => []]),
+        'DescribeSecurityGroups' => new Result(['SecurityGroups' => [
+            ['GroupName' => 'yolo-testing-my-app-ecs-task-security-group', 'GroupId' => 'sg-task'],
+        ]]),
+        'DescribeSecurityGroupRules' => new Result(['SecurityGroupRules' => []]),
+    ], $captured);
+
+    $step = new SyncExternalDatabaseIngressStep();
+
+    expect($step(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC)
+        ->and($step->changes())->not->toBeEmpty();
 });
 
 it('skips when no database is declared', function (): void {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

The external-database ingress step (#175) assumed a peering already joined the database's VPC — but a cross-VPC security-group reference is only valid over an **active** peering, so on an external database with no peering (a legitimate pre-migration posture: `database:` declared, bridge not yet built) a full `yolo sync` failed mid-apply with an AWS error instead of degrading.

The step now resolves reachability before writing:

- **Active peering** between the env VPC and the database's VPC (either orientation, YOLO-owned or hand-made) → write the rule as before.
- **Declared but not yet active** (the VPC is in the env manifest `peering` list) → proceed: the environment tier activates the peering earlier in the same sync, so the reference is valid by the time this step's apply runs — and the plan pass reports the pending rule rather than silently deferring (the two-pass contract).
- **Neither** → warn ("declare the VPC in the env manifest `peering` list") and skip. No mid-apply crash, and the nudge points at the fix.

**Is there anything the reviewer needs to know to deploy this?**

- This unblocks the common migration sequence: an app can update its yolo dependency and sync *before* the peering is declared without the apply erroring — it just warns until `peering:` lands.
- New `Ec2::activePeeringBetween()` helper (one describe filtered to active, both orientations checked).
- No manifest or behaviour change for apps with no `database:` or an in-VPC database. Pest 1,633 green (2 new cases: unpeered-warns, declared-not-yet-active-proceeds), PHPStan L5, Rector, Pint clean.

🤖 Generated with [Claude Code](https://claude.ai/code)