### PR TITLE
fix(iam): grant ec2:Accept* to the admin tier for peering acceptance

### DIFF
--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -193,7 +193,7 @@ class AdminPolicy implements Deletable, Resource, SynchronisesConfiguration
                     'Resource' => '*',
                     'Action' => [
                         // compute / networking
-                        'ec2:Create*', 'ec2:Delete*', 'ec2:Modify*',
+                        'ec2:Create*', 'ec2:Delete*', 'ec2:Modify*', 'ec2:Accept*',
                         'ec2:Associate*', 'ec2:Disassociate*',
                         'ec2:Attach*', 'ec2:Detach*',
                         'ec2:Authorize*', 'ec2:Revoke*',

--- a/src/Steps/Build/CopyApplicationStep.php
+++ b/src/Steps/Build/CopyApplicationStep.php
@@ -63,7 +63,7 @@ class CopyApplicationStep implements LongRunning
             command: [
                 'rsync',
                 '-avq',
-                ...array_map(fn ($item): string => "--include=$item", $include),
+                ...array_map(fn (string $item): string => "--include=$item", $include),
                 ...array_map(fn (string $item): string => "--exclude=$item", $exclude),
                 '.',
                 Paths::build(),

--- a/tests/Unit/Resources/Iam/AdminPolicyTest.php
+++ b/tests/Unit/Resources/Iam/AdminPolicyTest.php
@@ -33,6 +33,7 @@ it('grants the write surface for the services YOLO provisions', function (): voi
     expect(adminActions())->toContain(
         'ecs:Create*',
         'ec2:Create*',
+        'ec2:Accept*',
         'elasticloadbalancing:Create*',
         'application-autoscaling:RegisterScalableTarget',
         'application-autoscaling:PutScalingPolicy',


### PR DESCRIPTION
## Summary

- Grants `ec2:Accept*` to the admin tier's mutation statement. The statement covers the `Create*/Delete*/Modify*/Associate*/Disassociate*/Attach*/Detach*/Authorize*/Revoke*` verb families, but peering acceptance is its own verb — so the first declared `peering:` sync creates the connection, then 403s on `ec2:AcceptVpcPeeringConnection` accepting its own same-account request. Asserted in `AdminPolicyTest`.
- Types the `--include` closure param in `CopyApplicationStep` — toolchain drift, not a behaviour change: a Rector released after main's last Analyse run extends `AddArrayFunctionClosureParamTypeRector` to this pre-existing line, so every fresh branch fails CI on it.

## Anything the reviewer needs to know

- After merge, the next `yolo sync` rewrites the live admin policy; a peering connection stranded in pending-acceptance by the 403 is accepted on the re-run. If the accept still 403s on that first re-run (policy step ordering / IAM propagation), a second sync completes it.
- No resource-scope change — `Accept*` joins an existing `Resource: *` statement that is already fenced to the services YOLO provisions.

🤖 Generated with [Claude Code](https://claude.ai/code)