### PR TITLE
fix(status): pin scaling-policy display order in the overview

### DIFF
--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -212,6 +212,11 @@ trait RendersServiceStatus
             ApplicationAutoScaling::scalingPolicies(ScalableTarget::resourceId($group)),
         )));
 
+        // DescribeScalingPolicies returns policies in no guaranteed order, so pin a
+        // canonical one — otherwise the overview reshuffles cpu/concurrency/burst
+        // between redraws.
+        usort($policies, static fn (array $a, array $b): int => static::policyRank($a['metric']) <=> static::policyRank($b['metric']));
+
         return [...$bounds, 'policies' => $policies];
     }
 
@@ -242,6 +247,21 @@ trait RendersServiceStatus
             ?? (str_contains($policy['PolicyName'] ?? '', 'concurrency') ? 'concurrency' : 'custom');
 
         return ['metric' => $metric, 'target' => (float) ($config['TargetValue'] ?? 0)];
+    }
+
+    /**
+     * The display position of a scaling policy in the overview: cpu, then
+     * concurrency, then burst/backlog, then anything unrecognised.
+     */
+    protected static function policyRank(string $metric): int
+    {
+        return match ($metric) {
+            'ECSServiceAverageCPUUtilization' => 0,
+            'concurrency' => 1,
+            'burst' => 2,
+            'backlog' => 3,
+            default => 4,
+        };
     }
 
     protected static function cpuTargetFrom(?array $scaling): ?float

--- a/tests/Unit/Commands/StatusCommandTest.php
+++ b/tests/Unit/Commands/StatusCommandTest.php
@@ -95,6 +95,26 @@ it('describes scaling bounds, policies, or a fixed/singleton service', function 
     expect(StatusCommand::formatScaling($queue, ServerGroup::QUEUE))->toBe('0–10 auto (backlog)');
 });
 
+it('ranks scaling policies into a stable display order', function (): void {
+    $probe = new class()
+    {
+        use RendersServiceStatus;
+
+        public function rank(string $metric): int
+        {
+            return self::policyRank($metric);
+        }
+    };
+
+    // DescribeScalingPolicies has no ordering guarantee, so the overview sorts by
+    // rank — cpu, concurrency, burst, backlog, then anything unrecognised.
+    $shuffled = ['burst', 'custom', 'concurrency', 'backlog', 'ECSServiceAverageCPUUtilization'];
+
+    usort($shuffled, fn (string $a, string $b): int => $probe->rank($a) <=> $probe->rank($b));
+
+    expect($shuffled)->toBe(['ECSServiceAverageCPUUtilization', 'concurrency', 'burst', 'backlog', 'custom']);
+});
+
 it('reduces a live policy to its metric and target', function (): void {
     $probe = new class()
     {


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- On the `status` overview tab, the web tier's scaling-policy summary (`cpu 65%, concurrency 23, burst`) reshuffled between redraws — `DescribeScalingPolicies` returns policies in no guaranteed order, and `gatherScaling()` rendered them as-received, causing a layout shift on each poll.
- Policies are now sorted through a canonical rank before rendering: cpu → concurrency → burst → backlog → anything unrecognised. A test pins the order.

**Is there anything the reviewer needs to know to deploy this?**
- Nothing — display-only change in the status renderer, no AWS calls or sync behaviour touched.

🤖 Generated with [Claude Code](https://claude.ai/code)