### PR TITLE
fix(typesense): nothing pre-selected in the scout:reimport picker

### DIFF
--- a/src/Runtime/Commands/ScoutReimportCommand.php
+++ b/src/Runtime/Commands/ScoutReimportCommand.php
@@ -125,12 +125,16 @@ class ScoutReimportCommand extends Command
                 return [];
             }
 
+            // Nothing pre-selected, on purpose: a pre-selected-everything
+            // default turns a bare Enter — or a prompt that can't actually
+            // interact (a shell without a real TTY silently resolves the
+            // DEFAULT) — into a full rebuild of every collection. Selecting
+            // is the deliberate act; --all is the explicit everything.
             $discovered = array_values(multiselect(
                 label: 'Which models should be rebuilt?',
                 options: $discovered,
-                default: $discovered,
-                required: true,
-                hint: 'Every rebuild swaps in beside the live index — zero search downtime.',
+                required: 'Select at least one model (space selects, enter confirms) — or run with --all.',
+                hint: 'Space selects, enter confirms. Every rebuild swaps in beside the live index — zero search downtime.',
             ));
         }
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

The `scout:reimport` interactive picker pre-selected **every** searchable model. That default is a trap twice over:

1. A bare Enter submits the pre-selected set — the multiselect's confirm key, one keystroke from "rebuild everything".
2. Worse: in a shell without a real TTY (a container exec session, for instance), Laravel Prompts can't interact and **silently resolves the default** — so the picker renders, no input is possible, and every collection rebuilds. That's exactly the accidental-everything the `--all` flag exists to make explicit, sneaking in through the prompt.

Now nothing is pre-selected: choosing models is the deliberate act (space selects, enter confirms — the hint says so), `--all` remains the explicit everything, and a promptless environment fails the `required` validation loudly instead of rebuilding the world.

**Is there anything the reviewer needs to know to deploy this?**

Nothing — runtime-only, one prompt default. Apps pick it up with their next composer update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)