### PR TITLE
Require a domain for web apps — retire headless-web mode

### DIFF
--- a/docs/guide/domains.md
+++ b/docs/guide/domains.md
@@ -51,30 +51,21 @@ That's safe by design:
 
 ## Headless apps
 
-An app with no public web front — a background worker, a queue consumer, an internal job runner — can run **headless**: omit `domain` and any tenant domains.
+An app with no public web front — a background worker, a queue consumer, an internal job runner — runs **headless**: omit `domain` (and any tenant domains) *and* the web tier. A headless app is a [web-less worker app](/reference/manifest#where-each-role-runs) — a standalone `tasks.queue` and/or `tasks.scheduler` with no `tasks.web`:
 
 ```yaml
 environments:
   production:
-    # no domain / tenants → headless
-    tasks:
-      web:
-        autoscaling: true
-```
-
-This one still declares `tasks.web`: the queue worker and scheduler ride inside the web container by default ([where each role runs](/reference/manifest#where-each-role-runs)), so "headless" isn't about dropping the web tier — it's about not exposing it. With no domain to route, YOLO skips the hosted zone, certificate, ALB attachment, and DNS; the container still deploys and still processes queued and scheduled work, it just has no public URL.
-
-Headless is the **domain axis**. You can also drop the web tier itself — the **topology axis**: a [web-less worker app](/reference/manifest#where-each-role-runs) declares no `tasks.web` (or `web: false`) and runs a standalone `tasks.queue` and/or `tasks.scheduler` instead, so you're not paying for an idle web server in front of a pure worker:
-
-```yaml
-environments:
-  production:
-    # no domain → headless; no web task → a scheduler-only worker app
+    # no domain → nothing exposed; no web task → a scheduler-only worker app
     tasks:
       web: false
       queue: false
       scheduler: true
 ```
+
+With no domain there is no hosted zone, certificate, ALB attachment, or DNS — and nothing that needs them. The worker still deploys, consumes its queue and fires its schedule; it just has no URL.
+
+A **web task always requires a domain**: the task security group only accepts traffic from the load balancer, and without a domain no listener rule ever routes to the service — a web server nobody can reach, burning a Fargate task. A `tasks.web` block with no `domain` (or, multi-tenant, no tenant domains) is refused at validation. A worker app may still *declare* a `domain` — it's metadata, and YOLO keeps the hosted zone and certificate provisioned (unattached) so the web tier can return later.
 
 Need an image that builds but runs no container at all? Omit the `tasks` block entirely — see [App modes](/reference/manifest#app-modes).
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -9,7 +9,7 @@ You don't need prior YOLO knowledge. Each step links to a deeper page if you wan
 - **PHP 8.3+** and **Composer**
 - **Docker**, running locally — YOLO builds your container image on your machine
 - An **AWS account** and an **access key for your IAM user** — step 3's `yolo configure` turns it into a named profile with short-lived sessions. (Already have a named profile in `~/.aws/config`? That works too — just don't use the `default` profile.)
-- **For a public app:** a domain you can manage in **Route 53** on that account. (You can skip this and run a [headless app](/guide/domains#headless-apps) with no public URL.)
+- **For a web app:** a domain you can manage in **Route 53** on that account — a web task requires one. (A [worker app](/guide/domains#headless-apps) — a standalone queue/scheduler with no web task — needs no domain.)
 
 ::: tip The whole thing in one line
 Once you've done the setup below, day-to-day it's just:

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -17,7 +17,7 @@ environments:
     region: ap-southeast-2       # required
 
     # --- Routing (see /guide/domains) ---
-    domain: example.com    # public domain; omit domain + tenants for a headless app
+    domain: example.com    # public domain — required for a web app; omit for a worker app
     #                      # the apex is derived automatically from the matching Route 53 zone
     #
     # Multi-tenant instead of a single domain (mutually exclusive with domain):
@@ -155,7 +155,7 @@ These live directly under an environment and determine how the app is reached. S
 
 ### `domain`
 
-The canonical public domain the app is served on (e.g. `app.example.com`). When it's one half of the apex/`www` pair (the apex itself, or `www.{apex}`), YOLO serves it and 301-redirects the other half to it. Omit for a [headless app](/guide/domains#headless-apps).
+The canonical public domain the app is served on (e.g. `app.example.com`). When it's one half of the apex/`www` pair (the apex itself, or `www.{apex}`), YOLO serves it and 301-redirects the other half to it. **Required for a web app** — a `tasks.web` block with no domain (or, multi-tenant, no tenant domains) is refused, since no listener rule would ever route to it. Omit it for a [worker app](/guide/domains#headless-apps); declaring one there is allowed (the zone + certificate stay provisioned, unattached).
 
 The apex (registrable root, naming the Route 53 hosted zone) is **derived automatically** — there is no `apex` key. YOLO walks the domain's label-suffixes longest-first and uses the longest one that already has a hosted zone in the account (so `app.example.com` resolves to the `example.com` zone). When no ancestor zone exists yet, the domain itself is the apex (sync then creates the zone), with any leading `www.` stripped. See [Domains](/guide/domains).
 
@@ -349,7 +349,7 @@ In the placement table below, `queue: true` is shorthand for "queue extracted" �
 
 The scheduler rides the worker container (the `web` + `queue` row) rather than getting its own task — there's no point paying for a separate one-task service for cron when the queue is already a managed tier. Because cron then runs on the autoscaling queue, guard scheduled tasks with `->onOneServer()`, or add `tasks.scheduler` for a true singleton. A queue that hosts the scheduler can't scale to zero — cron would stop when it idled — so its floor stays at `1` (an explicit `tasks.queue.autoscaling.min: 0` there is rejected).
 
-The last three rows are **web-less worker apps**: a pure queue consumer, a scheduled-job runner, or both. They get the same shared plumbing a web app does (ECR, cluster, task role, security groups, database access, log group) with no ALB attachment, target group, CDN, or web autoscaling. A scheduler-only app runs no worker anywhere, so its queue behaves exactly like `queue: false` — jobs run inline (`QUEUE_CONNECTION=sync`, enforced at build) and no SQS queue is provisioned. Web-less apps are usually also [headless](/guide/domains#headless-apps) (no `domain`); acceptance-test a first deploy by watching the service actually consume its queue or fire its schedule — there's no health-checked URL to probe.
+The last three rows are **web-less worker apps**: a pure queue consumer, a scheduled-job runner, or both. They get the same shared plumbing a web app does (ECR, cluster, task role, security groups, database access, log group) with no ALB attachment, target group, CDN, or web autoscaling. A scheduler-only app runs no worker anywhere, so its queue behaves exactly like `queue: false` — jobs run inline (`QUEUE_CONNECTION=sync`, enforced at build) and no SQS queue is provisioned. Worker apps are the [headless](/guide/domains#headless-apps) shape — they need no `domain` (declaring one anyway is fine; it's metadata) — while a web task always requires one. Acceptance-test a worker's first deploy by watching the service actually consume its queue or fire its schedule — there's no health-checked URL to probe.
 
 **Disabling the queue (`queue: false`)** means no worker runs anywhere, so jobs can't be processed off-request: YOLO bakes `QUEUE_CONNECTION=sync` (jobs run inline at dispatch) and **fails the build** if your `.env` pins it to anything else, rather than ship an app that black-holes queued work. **Disabling the scheduler (`scheduler: false`)** stops `schedule:run` running anywhere — framework and package maintenance that rides cron (model pruning, `auth:clear-resets`, Telescope/Pulse pruning, …) silently stops, so `sync` surfaces a warning. Reach for these only when the app genuinely has no background work.
 
@@ -478,7 +478,7 @@ Your manifest implies one of three modes:
 |---|---|---|
 | **Solo** | `domain` set at the environment level | One app, one hosted zone + certificate, served on its domain. |
 | **Multi-tenant** | `tenants` set (no env-level `domain`) | Per-tenant domains and queues; certs attach per tenant via SNI. |
-| **Headless** | no `domain` or tenant domains | No ALB attachment or DNS. Still deploys and processes queues/scheduled work. |
+| **Headless** | no `domain` or tenant domains | A [worker app](#where-each-role-runs) — no web task (web requires a domain), no ALB attachment or DNS. Still deploys and processes queued/scheduled work. |
 
 The mode is the **domain axis** — whether and how the app is exposed. The `tasks` block sets the orthogonal **topology axis**: a web service, a [web-less worker app](#where-each-role-runs) (a standalone queue and/or scheduler with no web container), or a build-only app (no `tasks` at all).
 

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -153,8 +153,31 @@ abstract class Command extends SymfonyCommand
             && $this->ensureSessionDriverValid()
             && $this->ensureServicesValid()
             && $this->ensureTasksRunnable()
+            && $this->ensureWebReachable()
             && $this->ensureAutoscalingDeclared()
             && $this->ensureSchedulerHostNotScaleToZero();
+    }
+
+    /**
+     * A web task must be reachable: the task security group only accepts ingress
+     * from the ALB, and with no domain no listener rule ever points at the
+     * service — a web server nobody can reach, burning a Fargate task. So a solo
+     * web app must declare `domain`, and a multi-tenant web app needs at least
+     * one tenant domain. An app with no public host runs as a worker instead
+     * (standalone queue/scheduler, no web task).
+     */
+    protected function ensureWebReachable(): bool
+    {
+        if (! Manifest::hasWeb() || ! Manifest::isHeadless()) {
+            return true;
+        }
+
+        error(
+            "yolo.yml declares `tasks.web` but no `domain` — a web task with no public host serves nothing (no listener rule ever routes to it).\n"
+            . 'Declare `domain` (or a tenant domain), or drop `tasks.web` and run a worker app (standalone tasks.queue / tasks.scheduler).'
+        );
+
+        return false;
     }
 
     /**

--- a/src/Resources/Ecs/EcsService.php
+++ b/src/Resources/Ecs/EcsService.php
@@ -297,12 +297,12 @@ class EcsService implements Deletable, Resource
     }
 
     /**
-     * Whether this service sits behind the ALB — web only, and only when the app
-     * isn't headless (no domain → no ALB to attach to).
+     * Whether this service sits behind the ALB — web only. A web task always
+     * attaches (it requires a domain, so the ALB path always exists).
      */
     protected function attachesToLoadBalancer(): bool
     {
-        return $this->group->attachesToLoadBalancer() && ! Manifest::isHeadless();
+        return $this->group->attachesToLoadBalancer();
     }
 
     protected function reconcilesGracePeriod(): bool

--- a/src/ShutdownTimings.php
+++ b/src/ShutdownTimings.php
@@ -65,12 +65,12 @@ final class ShutdownTimings
 
     /**
      * Seconds the entrypoint keeps serving after SIGTERM before forwarding the
-     * stop — the window the ALB needs to stop routing. Zero when headless: with
-     * no target group there's nothing to drain, so forward the stop immediately.
+     * stop — the window the ALB needs to stop routing. Every web app sits behind
+     * the ALB (a web task requires a domain), so the drain is always the web grace.
      */
     public static function drain(): int
     {
-        return Manifest::isHeadless() ? 0 : self::webGrace();
+        return self::webGrace();
     }
 
     /**

--- a/stubs/yolo.yml.stub
+++ b/stubs/yolo.yml.stub
@@ -2,9 +2,10 @@ name: {NAME}
 
 environments:
   {ENVIRONMENT}:
-    # Public domain. Omit for a headless app (no ALB / DNS). The apex (registrable
-    # root) is derived automatically from the longest domain suffix that has a
-    # Route 53 hosted zone, so a subdomain like app.example.com just works.
+    # Public domain — required for a web app (tasks.web). Omit it only for a
+    # worker app (a standalone tasks.queue / tasks.scheduler with no web task).
+    # The apex (registrable root) is derived automatically from the longest domain
+    # suffix that has a Route 53 hosted zone, so app.example.com just works.
     # domain: app.example.com
 
     # Source ref this environment deploys from — drives the local deploy guard

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -130,6 +130,41 @@ it('accepts a web-less worker app with a standalone queue or scheduler', functio
     'queue + scheduler worker' => [['web' => false, 'queue' => ['autoscaling' => true], 'scheduler' => true]],
 ]);
 
+it('refuses a web task with no public host — web requires a domain', function (array $manifest): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        ...$manifest,
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('no `domain`');
+})->with([
+    // No listener rule ever routes to a domain-less web task — it's a web
+    // server nobody can reach. Workers (no web task) are the headless shape.
+    'solo, no domain' => [['tasks' => ['web' => ['autoscaling' => true]]]],
+    'multi-tenant, no tenant domains' => [[
+        'tenants' => ['alpha' => [], 'beta' => []],
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]],
+]);
+
+it('accepts a web task when a public host exists', function (array $manifest): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        ...$manifest,
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+})->with([
+    'solo with a domain' => [['domain' => 'example.com', 'tasks' => ['web' => ['autoscaling' => true]]]],
+    // One routed tenant is enough — a domain-less sibling may be mid-onboarding.
+    'multi-tenant with one tenant domain' => [[
+        'tenants' => ['alpha' => ['domain' => 'alpha.example.com'], 'beta' => []],
+        'tasks' => ['web' => ['autoscaling' => true]],
+    ]],
+]);
+
 it('accepts a manifest with no tasks at all (a build-only app)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
@@ -259,6 +294,7 @@ it('accepts every known service as a consumed service', function (): void {
 it('accepts the known shape of every task group', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => [
             'web' => [
                 'cpu' => '512', 'memory' => '1024', 'platform' => 'linux/amd64',
@@ -283,6 +319,7 @@ it('accepts the known shape of every task group', function (): void {
 it('bails on an unrecognised key inside a task group', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['nonsense' => true]],
     ]);
 
@@ -293,6 +330,7 @@ it('bails on an unrecognised key inside a task group', function (): void {
 it('bails when a web config map omits autoscaling', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['cpu' => '512']],
     ]);
 
@@ -306,6 +344,7 @@ it('bails when a web config map omits autoscaling', function (): void {
 it('bails on the bare `tasks.web: true` shorthand — web needs an explicit autoscaling decision', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => true],
     ]);
 
@@ -316,6 +355,7 @@ it('bails on the bare `tasks.web: true` shorthand — web needs an explicit auto
 it('bails when a standalone queue omits autoscaling', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['spot' => true]],
     ]);
 
@@ -329,6 +369,7 @@ it('bails when a standalone queue omits autoscaling', function (): void {
 it('bails on the bare `tasks.queue: true` shorthand', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => true],
     ]);
 
@@ -350,6 +391,7 @@ it('demands no autoscaling declaration of a disabled web tier', function (): voi
 it('keeps the bare `tasks.scheduler: true` shorthand — the scheduler never scales', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'scheduler' => true],
     ]);
 
@@ -359,6 +401,7 @@ it('keeps the bare `tasks.scheduler: true` shorthand — the scheduler never sca
 it('bails when the scheduler rides a queue explicitly set to scale to zero', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 0]]],
     ]);
 
@@ -372,6 +415,7 @@ it('bails when the scheduler rides a queue explicitly set to scale to zero', fun
 it('accepts a scheduler-hosting queue with a standing floor of one', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 1]]],
     ]);
 
@@ -381,6 +425,7 @@ it('accepts a scheduler-hosting queue with a standing floor of one', function ()
 it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => true]],
     ]);
 
@@ -390,6 +435,7 @@ it('accepts a scheduler-hosting queue with no explicit floor (defaults to one)',
 it('accepts a scale-to-zero queue when the scheduler is its own service', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
         'tasks' => ['web' => ['autoscaling' => true], 'queue' => ['autoscaling' => ['min' => 0]], 'scheduler' => true],
     ]);
 

--- a/tests/Unit/Commands/InitCommandTest.php
+++ b/tests/Unit/Commands/InitCommandTest.php
@@ -43,9 +43,11 @@ it('scaffolds web autoscaling on by default', function (): void {
 it('scaffolds a manifest that satisfies the autoscaling-required integrity gate', function (): void {
     // The stub declares an explicit `autoscaling`, so the scaffold a fresh app gets
     // must pass `ensureManifestIntegrity` rather than tripping the new requirement.
+    // The domain is filled the way `init` does interactively (its prompt writes it
+    // after scaffolding) — a web task without one is refused.
     file_put_contents(Paths::manifest(), str_replace(
-        ['{NAME}', '{ENVIRONMENT}', '{AWS_ACCOUNT_ID}', '{AWS_REGION}'],
-        ['my-app', 'production', '111111111111', 'ap-southeast-2'],
+        ['{NAME}', '{ENVIRONMENT}', '{AWS_ACCOUNT_ID}', '{AWS_REGION}', '# domain: app.example.com'],
+        ['my-app', 'production', '111111111111', 'ap-southeast-2', 'domain: app.example.com'],
         file_get_contents(Paths::stubs('yolo.yml.stub'))
     ));
     Helpers::app()->instance('environment', 'production');

--- a/tests/Unit/ShutdownTimingsTest.php
+++ b/tests/Unit/ShutdownTimingsTest.php
@@ -30,15 +30,6 @@ it('drains for the manifest web shutdown-grace-period', function (): void {
     expect(ShutdownTimings::drain())->toBe(45);
 });
 
-it('skips the drain entirely when headless (no ALB to drain)', function (): void {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45]],
-    ]);
-
-    expect(ShutdownTimings::drain())->toBe(0);
-});
-
 it('bundles the web server, scheduler and queue worker into the web container for a plain web app', function (): void {
     // The scheduler's grace defaults to the whole stop window (Fargate's 120s
     // cap minus the 5s buffer) — its stop overlaps the other programs'.
@@ -127,17 +118,6 @@ it('sizes the web stop timeout as the slower of the drain track and the schedule
     // max(drain 15 + slowest other program 60, scheduler 115) + 5 buffer —
     // never the sum, so the in-flight schedule:run keeps the whole window.
     expect(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB))->toBe(120);
-});
-
-it('drops the ALB drain window from the web stop timeout when headless', function (): void {
-    // Scheduler extracted so the drain track is what sizes the budget.
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => true, 'scheduler' => true],
-    ]);
-
-    // no drain window: 0 + max(web 15, queue 60) + 5 buffer.
-    expect(ShutdownTimings::stopTimeoutFor(ServerGroup::WEB))->toBe(65);
 });
 
 it('allows graces that exactly fill the Fargate stop ceiling', function (): void {

--- a/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
@@ -144,21 +144,6 @@ it('tracks the manifest web shutdown-grace-period for the drain duration', funct
     expect(generatedEntrypointScript())->toContain("sleep 45\n");
 });
 
-it('omits the ALB drain window when headless — no target to drain', function (): void {
-    writeManifest([
-        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        'tasks' => ['web' => ['shutdown-grace-period' => 45], 'scheduler' => true],
-    ]);
-
-    $script = generatedEntrypointScript();
-
-    // Still supervises + traps so the stop is forwarded cleanly, just no lame-duck
-    // ALB sleep window.
-    expect($script)->not->toContain('sleep 45');
-    expect($script)->toContain('trap drain TERM');
-    expect($script)->toContain('kill -TERM "$child"');
-});
-
 it('emits no web branch and defaults the role to scheduler for a scheduler-only worker app', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',

--- a/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
+++ b/tests/Unit/Steps/Fargate/SyncEcsServiceStepTest.php
@@ -83,20 +83,7 @@ describe('serviceNeedsUpdate when headless', function (): void {
 });
 
 describe('updatePayload', function (): void {
-    it('omits healthCheckGracePeriodSeconds when headless', function (): void {
-        writeManifest([
-            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-            'tasks' => ['web' => true],
-        ]);
-
-        // which require live AWS lookups, so we can't fully invoke it here. updatePayload is
-        // purely manifest-driven (no AWS lookups), so it pins the headless conditional shape.
-        $payload = (new EcsService())->updatePayload();
-
-        expect($payload)->not->toHaveKey('healthCheckGracePeriodSeconds');
-    });
-
-    it('includes healthCheckGracePeriodSeconds when not headless', function (): void {
+    it('includes healthCheckGracePeriodSeconds from the manifest', function (): void {
         writeManifest([
             'account-id' => '111111111111', 'region' => 'ap-southeast-2',
             'domain' => 'example.com',


### PR DESCRIPTION
## Hey, I made a thing! 🥳
Great! Now please answer the following questions to help out your assigned reviewer:

**What problems are you solving?**
- A `tasks.web` app with no `domain` (headless-web mode) is a web server nobody can ever reach: the task SG only accepts ALB ingress and no listener rule routes to it. Its only purpose was hosting the bundled queue/scheduler in an idle container — the workaround standalone worker apps just obsoleted — so the shape now refuses at validation instead of silently burning a Fargate task.
- The axes are now clean: `domain` + `tasks.web` → exposed web app; no `domain` + standalone queue/scheduler → worker app (the headless shape); no `tasks` → build-only. A multi-tenant web app needs at least one tenant domain (a domain-less sibling tenant mid-onboarding stays allowed). A worker app may still declare a `domain` — it's metadata; the zone + certificate stay provisioned, unattached.
- Dead web-headless branches removed with it: the entrypoint's zero-drain path (`ShutdownTimings::drain()`) and the web service's headless LB-attachment gate (`EcsService`). `isHeadless()` itself stays load-bearing — it's what keeps a worker app's sync from provisioning zone/cert/ALB pieces.
- Docs and the `init` stub updated to the new semantics (domains guide, manifest reference, App modes, getting started).

**Is there anything the reviewer needs to know to deploy this?**
- **Stacked on #186** (web-less worker apps) — merge that first; GitHub will retarget this to `main` when it lands.
- Validation change only — no AWS behaviour changes for any domained web app. Anyone actually running a domain-less web app would be refused on their next command and should convert to a worker app (drop `tasks.web`, extract `tasks.queue`/`tasks.scheduler`).
- Full suite (1775), PHPStan, Rector, Pint and the docs build are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)