### PR TITLE
Per-tenant queue workers + manifest-driven priority queue tiers

### DIFF
--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -26,6 +26,7 @@ use Codinglabs\Yolo\Resources\Iam\AppObserverRole;
 use Symfony\Component\Console\Input\InputInterface;
 use Codinglabs\Yolo\Contracts\RunsOnBaseCredentials;
 use Symfony\Component\Console\Output\OutputInterface;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Concerns\ChecksIfCommandsShouldBeRunning;
 use Symfony\Component\Console\Command\Command as SymfonyCommand;
 
@@ -155,7 +156,37 @@ abstract class Command extends SymfonyCommand
             && $this->ensureTasksRunnable()
             && $this->ensureWebReachable()
             && $this->ensureAutoscalingDeclared()
-            && $this->ensureSchedulerHostNotScaleToZero();
+            && $this->ensureSchedulerHostNotScaleToZero()
+            && $this->ensureQueueIsolationValid();
+    }
+
+    /**
+     * `queue-isolation` (`dedicated` | `shared`) only means something for a
+     * multi-tenant app — it decides whether the queue layer fans out per tenant. On a
+     * solo app there's a single scope and nothing to isolate, so the key is refused
+     * rather than silently ignored. Manifest::queueIsolation() validates the value.
+     */
+    protected function ensureQueueIsolationValid(): bool
+    {
+        if (! Manifest::has('queue-isolation')) {
+            return true;
+        }
+
+        if (! Manifest::isMultitenanted()) {
+            error('yolo.yml declares `queue-isolation` but no `tenants` — the strategy only applies to a multi-tenant app. Remove it, or declare tenants.');
+
+            return false;
+        }
+
+        try {
+            Manifest::queueIsolation();
+        } catch (IntegrityCheckException $e) {
+            error($e->getMessage());
+
+            return false;
+        }
+
+        return true;
     }
 
     /**

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -163,12 +163,19 @@ class SyncAppCommand extends SyncSteppedCommand
                 // cert/DNS + queues — runs before Fargate so the SSL certificate
                 // exists before the HTTPS listener that needs it. Solo gets an
                 // env-level apex zone + cert; multi-tenant has none (certs attach
-                // per tenant via SNI), so it fans out landlord + per-tenant queues.
+                // per tenant via SNI). A `dedicated` multi-tenant app fans queues out
+                // landlord + per-tenant; a `shared` one provisions a single queue set
+                // at the app name (the solo shape), matching the fansQueuesPerTenant()
+                // gate its worker programs key off.
                 ...Manifest::isMultitenanted()
-                    ? [
-                        Steps\Sync\App\Landlord\SyncQueueStep::class,
-                        Steps\Sync\App\Tenant\SyncQueueStep::class,
-                    ]
+                    ? (Manifest::fansQueuesPerTenant()
+                        ? [
+                            Steps\Sync\App\Landlord\SyncQueueStep::class,
+                            Steps\Sync\App\Tenant\SyncQueueStep::class,
+                        ]
+                        : [
+                            Steps\Sync\App\Shared\SyncQueueStep::class,
+                        ])
                     : [
                         Steps\Sync\App\Solo\SyncHostedZoneStep::class,
                         Steps\Sync\App\Solo\SyncSslCertificateStep::class,

--- a/src/Concerns/ProvisionsScopedQueues.php
+++ b/src/Concerns/ProvisionsScopedQueues.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Codinglabs\Yolo\Concerns;
+
+use Codinglabs\Yolo\Helpers;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\Sqs\Queue;
+
+/**
+ * Syncs every SQS queue a scope owns — one per declared `queues:` tier, or the
+ * single un-suffixed queue when no tiers are declared. Shared by the solo,
+ * landlord and per-tenant SyncQueueStep so all three fan out over tiers
+ * identically, and over the same names Helpers::queueChain builds the worker's
+ * --queue from (queues provisioned == queues drained, never a drift).
+ */
+trait ProvisionsScopedQueues
+{
+    use SynchronisesResource;
+
+    protected function syncScopedQueues(?string $scope, array $options): StepResult
+    {
+        $results = array_map(
+            fn (string $name): StepResult => $this->syncResource(new Queue($name), $options),
+            Helpers::queueNames($scope),
+        );
+
+        // Surface the most significant outcome across the tiers so the plan→apply
+        // orchestrator keeps the step for apply whenever any tier still needs work —
+        // a WOULD_CREATE/WOULD_SYNC on one tier must not be masked by a clean SYNCED
+        // on another (the pending-only prune would then skip the apply).
+        foreach ([StepResult::CREATED, StepResult::WOULD_CREATE, StepResult::WOULD_SYNC] as $rank) {
+            if (in_array($rank, $results, true)) {
+                return $rank;
+            }
+        }
+
+        return StepResult::SYNCED;
+    }
+}

--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -411,7 +411,7 @@ trait RendersServiceStatus
      */
     protected static function queueNames(): array
     {
-        if (Manifest::isMultitenanted()) {
+        if (Manifest::fansQueuesPerTenant()) {
             $scopes = ['landlord' => 'landlord'];
 
             foreach (array_keys(Manifest::tenants()) as $tenantId) {

--- a/src/Concerns/RendersServiceStatus.php
+++ b/src/Concerns/RendersServiceStatus.php
@@ -403,20 +403,31 @@ trait RendersServiceStatus
 
     /**
      * The app's queue names, keyed by a short label: `queue` for a solo app, or
-     * `landlord` plus each tenant id for a multi-tenant one.
+     * `landlord` plus each tenant id for a multi-tenant one. When a `queues:` block
+     * declares priority tiers each scope's label carries the tier suffix
+     * (`landlord-high`, `landlord-default`, …) so the status table lists every queue.
      *
      * @return array<string, string>
      */
     protected static function queueNames(): array
     {
-        if (! Manifest::isMultitenanted()) {
-            return ['queue' => Helpers::keyedResourceName()];
+        if (Manifest::isMultitenanted()) {
+            $scopes = ['landlord' => 'landlord'];
+
+            foreach (array_keys(Manifest::tenants()) as $tenantId) {
+                $scopes[$tenantId] = $tenantId;
+            }
+        } else {
+            $scopes = ['queue' => null];
         }
 
-        $names = ['landlord' => Helpers::keyedResourceName('landlord')];
+        $tiers = Manifest::queueTiers();
+        $names = [];
 
-        foreach (array_keys(Manifest::tenants()) as $tenantId) {
-            $names[$tenantId] = Helpers::keyedResourceName($tenantId);
+        foreach ($scopes as $label => $scope) {
+            foreach (Helpers::queueNames($scope) as $index => $name) {
+                $names[$tiers === [] ? $label : "{$label}-{$tiers[$index]}"] = $name;
+            }
         }
 
         return $names;

--- a/src/Enums/QueueIsolation.php
+++ b/src/Enums/QueueIsolation.php
@@ -7,22 +7,22 @@ namespace Codinglabs\Yolo\Enums;
 /**
  * How a multi-tenant app's tenants map onto SQS queues and worker programs.
  *
- * - Dedicated (default): each tenant gets its own queue(s) — `…-{tenant}[-tier]` —
- *   and supervisord runs one queue:work program per tenant (plus landlord), so a
- *   whale tenant's backlog can't starve the others. Fair, but N tenants means N
- *   worker programs and N queues per tier — it scales to dozens, not hundreds.
+ * - Shared (default): every tenant shares one queue set at the app's own name
+ *   (`…[-tier]`, the same shape a solo app has), with the tenant carried in the job
+ *   payload. One worker per tier drains all tenants, so it scales to any tenant count.
+ *   Cross-tenant fairness is the trade — a whale floods the shared queue — but that's
+ *   the right default; per-tenant isolation is the exception you opt into.
  *
- * - Shared: every tenant shares one queue set at the app's own name (`…[-tier]`,
- *   the same shape a solo app has), with the tenant carried in the job payload. One
- *   worker program per tier drains all tenants, so it scales to any tenant count —
- *   at the cost of cross-tenant fairness (a whale floods the shared queue). The
- *   right default for a high-tenant-count app.
+ * - Dedicated: each tenant gets its own queue(s) — `…-{tenant}[-tier]` — and
+ *   supervisord runs one queue:work program per tenant (plus landlord), so a whale
+ *   tenant's backlog can't starve the others. Fair, but N tenants means N worker
+ *   programs and N queues per tier — it scales to dozens, not hundreds.
  *
  * Orthogonal to LPX-587's per-tenant `dedicated: true`, which is a third axis — one
  * tenant getting its own independently-scaled ECS service.
  */
 enum QueueIsolation: string
 {
-    case Dedicated = 'dedicated';
     case Shared = 'shared';
+    case Dedicated = 'dedicated';
 }

--- a/src/Enums/QueueIsolation.php
+++ b/src/Enums/QueueIsolation.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Enums;
+
+/**
+ * How a multi-tenant app's tenants map onto SQS queues and worker programs.
+ *
+ * - Dedicated (default): each tenant gets its own queue(s) — `…-{tenant}[-tier]` —
+ *   and supervisord runs one queue:work program per tenant (plus landlord), so a
+ *   whale tenant's backlog can't starve the others. Fair, but N tenants means N
+ *   worker programs and N queues per tier — it scales to dozens, not hundreds.
+ *
+ * - Shared: every tenant shares one queue set at the app's own name (`…[-tier]`,
+ *   the same shape a solo app has), with the tenant carried in the job payload. One
+ *   worker program per tier drains all tenants, so it scales to any tenant count —
+ *   at the cost of cross-tenant fairness (a whale floods the shared queue). The
+ *   right default for a high-tenant-count app.
+ *
+ * Orthogonal to LPX-587's per-tenant `dedicated: true`, which is a third axis — one
+ * tenant getting its own independently-scaled ECS service.
+ */
+enum QueueIsolation: string
+{
+    case Dedicated = 'dedicated';
+    case Shared = 'shared';
+}

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -123,7 +123,8 @@ class Helpers
      * queues by. With no `queues:` block the scope has a single un-suffixed queue at
      * its existing name (solo `yolo-{env}-{app}`, tenant `yolo-{env}-{app}-{id}`), so
      * apps that never declared tiers are unchanged; a `queues: [high, default]` block
-     * fans each scope out to `…-{scope}-high` / `…-{scope}-default`.
+     * fans each scope out to `…-{scope}-high` plus the naked `…-{scope}` (the `default`
+     * tier is Laravel's default queue, so the base name stays put).
      *
      * Provisioning (SyncQueueStep) and the worker's --queue chain (queueChain) both
      * read this, so the queues created and the queues drained can never drift.
@@ -158,20 +159,23 @@ class Helpers
     }
 
     /**
-     * The default queue a producer's un-routed jobs land on for a scope — the last
-     * tier in priority order (the base queue that sits below `high`), or the single
-     * queue when no tiers are declared. This is what a solo app pins as SQS_QUEUE.
+     * The default queue a producer's un-routed jobs land on for a scope — the `default`
+     * tier, i.e. the naked scope name (a solo app's `yolo-{env}-{app}`, a tenant's
+     * `yolo-{env}-{app}-{id}`), or the single queue when no tiers are declared. This is
+     * what a solo app pins as SQS_QUEUE, and it never changes when tiers are added.
      */
     public static function defaultQueueName(?string $scope = null): string
     {
-        $names = static::queueNames($scope);
-
-        return end($names);
+        return static::queueName($scope, 'default');
     }
 
     protected static function queueName(?string $scope, ?string $tier = null): string
     {
-        $suffix = implode('-', array_filter([$scope, $tier]));
+        // The `default` tier is Laravel's default queue — it maps to the naked scope
+        // name, so declaring a `queues:` block never renames the base queue an app
+        // already dispatches to; only the higher-priority lanes carry a `-{tier}`
+        // suffix (`…-{scope}-high`).
+        $suffix = implode('-', array_filter([$scope, $tier === 'default' ? null : $tier]));
 
         return static::keyedResourceName($suffix !== '' ? $suffix : null);
     }

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -117,6 +117,66 @@ class Helpers
     }
 
     /**
+     * Every SQS queue name for a scope, one per declared tier in priority order.
+     * Scope is null for a solo app, `'landlord'` or a tenant id for a multi-tenant
+     * one — the same discriminator the sync/dashboard/status paths already key
+     * queues by. With no `queues:` block the scope has a single un-suffixed queue at
+     * its existing name (solo `yolo-{env}-{app}`, tenant `yolo-{env}-{app}-{id}`), so
+     * apps that never declared tiers are unchanged; a `queues: {high:, default:}`
+     * block fans each scope out to `…-{scope}-high` / `…-{scope}-default`.
+     *
+     * Provisioning (SyncQueueStep) and the worker's --queue chain (queueChain) both
+     * read this, so the queues created and the queues drained can never drift.
+     *
+     * @return array<int, string>
+     */
+    public static function queueNames(?string $scope = null): array
+    {
+        $tiers = Manifest::queueTiers();
+
+        if ($tiers === []) {
+            return [static::queueName($scope)];
+        }
+
+        return array_map(fn (string $tier): string => static::queueName($scope, $tier), $tiers);
+    }
+
+    /**
+     * The worker's `--queue` value for a scope: every tier for that scope in
+     * priority order, comma-joined so `queue:work` drains them strict-priority (the
+     * comma list's one-queue-at-a-time semantics, high before default). A solo app
+     * with no declared tiers returns null — the bare worker, matching the
+     * pre-`queues:` behaviour (no `--queue` flag, drains the pinned SQS_QUEUE).
+     */
+    public static function queueChain(?string $scope = null): ?string
+    {
+        if ($scope === null && Manifest::queueTiers() === []) {
+            return null;
+        }
+
+        return implode(',', static::queueNames($scope));
+    }
+
+    /**
+     * The default queue a producer's un-routed jobs land on for a scope — the last
+     * tier in priority order (the base queue that sits below `high`), or the single
+     * queue when no tiers are declared. This is what a solo app pins as SQS_QUEUE.
+     */
+    public static function defaultQueueName(?string $scope = null): string
+    {
+        $names = static::queueNames($scope);
+
+        return end($names);
+    }
+
+    protected static function queueName(?string $scope, ?string $tier = null): string
+    {
+        $suffix = implode('-', array_filter([$scope, $tier]));
+
+        return static::keyedResourceName($suffix !== '' ? $suffix : null);
+    }
+
+    /**
      * S3 bucket names live in a single global namespace shared by every AWS
      * account, so unlike other resource names they carry the account id as a
      * discriminator — without it, whichever account creates yolo-{env}-… first

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -122,8 +122,8 @@ class Helpers
      * one — the same discriminator the sync/dashboard/status paths already key
      * queues by. With no `queues:` block the scope has a single un-suffixed queue at
      * its existing name (solo `yolo-{env}-{app}`, tenant `yolo-{env}-{app}-{id}`), so
-     * apps that never declared tiers are unchanged; a `queues: {high:, default:}`
-     * block fans each scope out to `…-{scope}-high` / `…-{scope}-default`.
+     * apps that never declared tiers are unchanged; a `queues: [high, default]` block
+     * fans each scope out to `…-{scope}-high` / `…-{scope}-default`.
      *
      * Provisioning (SyncQueueStep) and the worker's --queue chain (queueChain) both
      * read this, so the queues created and the queues drained can never drift.

--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -120,11 +120,10 @@ class Helpers
      * Every SQS queue name for a scope, one per declared tier in priority order.
      * Scope is null for a solo app, `'landlord'` or a tenant id for a multi-tenant
      * one — the same discriminator the sync/dashboard/status paths already key
-     * queues by. With no `queues:` block the scope has a single un-suffixed queue at
-     * its existing name (solo `yolo-{env}-{app}`, tenant `yolo-{env}-{app}-{id}`), so
-     * apps that never declared tiers are unchanged; a `queues: [high, default]` block
-     * fans each scope out to `…-{scope}-high` plus the naked `…-{scope}` (the `default`
-     * tier is Laravel's default queue, so the base name stays put).
+     * queues by. With no `queues:` block the scope has a single un-suffixed queue
+     * (solo `yolo-{env}-{app}`, tenant `yolo-{env}-{app}-{id}`); a `queues: [high,
+     * default]` block fans each scope out to `…-{scope}-high` plus the naked `…-{scope}`
+     * (the `default` tier is Laravel's default queue, so it takes the base scope name).
      *
      * Provisioning (SyncQueueStep) and the worker's --queue chain (queueChain) both
      * read this, so the queues created and the queues drained can never drift.
@@ -172,9 +171,8 @@ class Helpers
     protected static function queueName(?string $scope, ?string $tier = null): string
     {
         // The `default` tier is Laravel's default queue — it maps to the naked scope
-        // name, so declaring a `queues:` block never renames the base queue an app
-        // already dispatches to; only the higher-priority lanes carry a `-{tier}`
-        // suffix (`…-{scope}-high`).
+        // name (the queue an app dispatches un-routed jobs to); only the
+        // higher-priority lanes carry a `-{tier}` suffix (`…-{scope}-high`).
         $suffix = implode('-', array_filter([$scope, $tier === 'default' ? null : $tier]));
 
         return static::keyedResourceName($suffix !== '' ? $suffix : null);

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -1069,16 +1069,17 @@ class Manifest
     }
 
     /**
-     * The declared SQS queue tiers, in priority order — the keys of the `queues:`
-     * block. Declaration order IS the strict-priority order the worker drains them
-     * in (a leading `high` tier is polled to empty before the next), so the map is
-     * read ordered, not sorted. An absent `queues:` block returns `[]`: the app
-     * keeps its single implicit queue at the pre-`queues:` name (Helpers::queueNames),
-     * so existing apps are never forced to migrate.
+     * The declared SQS queue tiers, in priority order — a list of tier names under
+     * the `queues:` block. List order IS the strict-priority order the worker drains
+     * them in (a leading `high` tier is polled to empty before the next). An absent
+     * block returns `[]`: the app keeps its single implicit queue at the pre-`queues:`
+     * name (Helpers::queueNames), so existing apps are never forced to migrate.
      *
-     * Tier values are reserved for future per-queue configuration and ignored today
-     * — sensible defaults (14-day retention, the AWS-default visibility timeout) are
-     * hardcoded on the Queue resource rather than exposed as knobs no consumer needs.
+     * Tiers are names only. Per-queue configuration (visibility timeout, retention,
+     * alarms) isn't a knob any consumer needs yet — sensible defaults are hardcoded on
+     * the Queue resource — so a map form (`queues: {high: …}`) is rejected rather than
+     * half-supported. When real per-tier config lands it introduces the map form
+     * alongside this list, not in place of it, so the list stays valid.
      *
      * @return array<int, string>
      */
@@ -1086,23 +1087,18 @@ class Manifest
     {
         $queues = static::get('queues');
 
-        if (! is_array($queues)) {
+        if (! is_array($queues) || $queues === []) {
             return [];
         }
 
-        // The tier NAME is load-bearing — it becomes the queue's resource suffix and
-        // the worker's `--queue` value. A YAML list (`queues: [high, default]`) has
-        // no names, only indices, so array_keys would silently yield `0`/`1` and
-        // provision `…-0` / `…-1`. Priority order is already the map's declaration
-        // order, so a list is always a mistake — fail loudly rather than ship it.
-        if ($queues !== [] && array_is_list($queues)) {
+        if (! array_is_list($queues)) {
             throw new IntegrityCheckException(
-                'The manifest `queues:` block must be a map of tier name → config '
-                . '(e.g. `queues:\\n  high:\\n  default:`), not a list — the tier name becomes the '
-                . 'queue resource suffix and the worker `--queue` value.',
+                'The manifest `queues:` block must be a list of tier names in priority '
+                . "order (e.g. `queues:\n  - high\n  - default`). Per-queue configuration "
+                . 'is not supported yet, so the map form is rejected.',
             );
         }
 
-        return array_keys($queues);
+        return array_map(static fn ($tier): string => (string) $tier, $queues);
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -1016,27 +1016,28 @@ class Manifest
     }
 
     /**
-     * How a multi-tenant app's queues fan out — `dedicated` (per-tenant, the default)
-     * or `shared` (one queue set for all tenants). Solo apps have a single scope, so
-     * the knob is meaningless for them (ensureQueueIsolationValid rejects it there).
-     * An unknown value hard-fails rather than silently falling back.
+     * How a multi-tenant app's queues fan out — `shared` (one queue set for all
+     * tenants, the default) or `dedicated` (a queue set and worker program per tenant).
+     * Solo apps have a single scope, so the knob is meaningless for them
+     * (ensureQueueIsolationValid rejects it there). An unknown value hard-fails rather
+     * than silently falling back.
      */
     public static function queueIsolation(): QueueIsolation
     {
-        $value = static::get('queue-isolation', QueueIsolation::Dedicated->value);
+        $value = static::get('queue-isolation', QueueIsolation::Shared->value);
 
         return QueueIsolation::tryFrom($value) ?? throw new IntegrityCheckException(sprintf(
-            'Unknown queue-isolation "%s" — expected "dedicated" or "shared".',
+            'Unknown queue-isolation "%s" — expected "shared" or "dedicated".',
             $value,
         ));
     }
 
     /**
      * Whether the queue layer fans out per tenant — one SQS queue set and one worker
-     * program per tenant. True only for a multi-tenant app on the `dedicated` strategy;
-     * a `shared` multi-tenant app collapses to the solo queue shape (one queue set, the
-     * tenant carried in the job payload), so every per-tenant queue branch keys off
-     * this rather than isMultitenanted() alone.
+     * program per tenant. True only for a multi-tenant app that opts into the
+     * `dedicated` strategy; by default a multi-tenant app is `shared` — one queue set
+     * at the app name, the tenant carried in the job payload — so every per-tenant
+     * queue branch keys off this rather than isMultitenanted() alone.
      */
     public static function fansQueuesPerTenant(): bool
     {
@@ -1102,8 +1103,8 @@ class Manifest
      * The declared SQS queue tiers, in priority order — a list of tier names under
      * the `queues:` block. List order IS the strict-priority order the worker drains
      * them in (a leading `high` tier is polled to empty before the next). An absent
-     * block returns `[]`: the app keeps its single implicit queue at the pre-`queues:`
-     * name (Helpers::queueNames), so existing apps are never forced to migrate.
+     * block returns `[]`: the app runs a single queue at its own name
+     * (Helpers::queueNames).
      *
      * Tiers are names only. Per-queue configuration (visibility timeout, retention,
      * alarms) isn't a knob any consumer needs yet — sensible defaults are hardcoded on

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -50,6 +50,7 @@ class Manifest
         'account-id', 'region',
         'domain', 'branch', 'tag', 'repository',
         'tenants.*',
+        'queues.*',
         'bucket',
         'services',
         'database',
@@ -1065,5 +1066,43 @@ class Manifest
         }
 
         return $tenants;
+    }
+
+    /**
+     * The declared SQS queue tiers, in priority order — the keys of the `queues:`
+     * block. Declaration order IS the strict-priority order the worker drains them
+     * in (a leading `high` tier is polled to empty before the next), so the map is
+     * read ordered, not sorted. An absent `queues:` block returns `[]`: the app
+     * keeps its single implicit queue at the pre-`queues:` name (Helpers::queueNames),
+     * so existing apps are never forced to migrate.
+     *
+     * Tier values are reserved for future per-queue configuration and ignored today
+     * — sensible defaults (14-day retention, the AWS-default visibility timeout) are
+     * hardcoded on the Queue resource rather than exposed as knobs no consumer needs.
+     *
+     * @return array<int, string>
+     */
+    public static function queueTiers(): array
+    {
+        $queues = static::get('queues');
+
+        if (! is_array($queues)) {
+            return [];
+        }
+
+        // The tier NAME is load-bearing — it becomes the queue's resource suffix and
+        // the worker's `--queue` value. A YAML list (`queues: [high, default]`) has
+        // no names, only indices, so array_keys would silently yield `0`/`1` and
+        // provision `…-0` / `…-1`. Priority order is already the map's declaration
+        // order, so a list is always a mistake — fail loudly rather than ship it.
+        if ($queues !== [] && array_is_list($queues)) {
+            throw new IntegrityCheckException(
+                'The manifest `queues:` block must be a map of tier name → config '
+                . '(e.g. `queues:\\n  high:\\n  default:`), not a list — the tier name becomes the '
+                . 'queue resource suffix and the worker `--queue` value.',
+            );
+        }
+
+        return array_keys($queues);
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -8,6 +8,7 @@ use Codinglabs\Yolo\Aws\Route53;
 use Symfony\Component\Yaml\Yaml;
 use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Enums\QueueIsolation;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
 class Manifest
@@ -51,6 +52,7 @@ class Manifest
         'domain', 'branch', 'tag', 'repository',
         'tenants.*',
         'queues.*',
+        'queue-isolation',
         'bucket',
         'services',
         'database',
@@ -1011,6 +1013,34 @@ class Manifest
     public static function isMultitenanted(): bool
     {
         return ! empty(static::get('tenants'));
+    }
+
+    /**
+     * How a multi-tenant app's queues fan out — `dedicated` (per-tenant, the default)
+     * or `shared` (one queue set for all tenants). Solo apps have a single scope, so
+     * the knob is meaningless for them (ensureQueueIsolationValid rejects it there).
+     * An unknown value hard-fails rather than silently falling back.
+     */
+    public static function queueIsolation(): QueueIsolation
+    {
+        $value = static::get('queue-isolation', QueueIsolation::Dedicated->value);
+
+        return QueueIsolation::tryFrom($value) ?? throw new IntegrityCheckException(sprintf(
+            'Unknown queue-isolation "%s" — expected "dedicated" or "shared".',
+            $value,
+        ));
+    }
+
+    /**
+     * Whether the queue layer fans out per tenant — one SQS queue set and one worker
+     * program per tenant. True only for a multi-tenant app on the `dedicated` strategy;
+     * a `shared` multi-tenant app collapses to the solo queue shape (one queue set, the
+     * tenant carried in the job payload), so every per-tenant queue branch keys off
+     * this rather than isMultitenanted() alone.
+     */
+    public static function fansQueuesPerTenant(): bool
+    {
+        return static::isMultitenanted() && static::queueIsolation() === QueueIsolation::Dedicated;
     }
 
     public static function isHeadless(): bool

--- a/src/ProcessCommands.php
+++ b/src/ProcessCommands.php
@@ -61,9 +61,19 @@ class ProcessCommands
         return $command;
     }
 
-    public static function queue(): string
+    /**
+     * The queue worker. A solo app runs the bare command against the pinned
+     * SQS_QUEUE; a multi-tenant app (and any app declaring a `queues:` block) passes
+     * an explicit `--queue=` value so one program drains one scope's queues — the
+     * per-tenant/per-tier fan-out GenerateSupervisorConfigStep builds. A comma list
+     * drains strict-priority (high before default), which is the intra-scope
+     * priority feature; fairness across scopes comes from a separate program each.
+     */
+    public static function queue(?string $queue = null): string
     {
-        return 'php artisan queue:work --tries=3 --max-time=3600';
+        $command = 'php artisan queue:work --tries=3 --max-time=3600';
+
+        return $queue === null ? $command : "{$command} --queue={$queue}";
     }
 
     /**

--- a/src/Resources/ApplicationAutoScaling/QueueBacklogPolicy.php
+++ b/src/Resources/ApplicationAutoScaling/QueueBacklogPolicy.php
@@ -89,7 +89,13 @@ class QueueBacklogPolicy
      */
     public function configuration(): array
     {
-        $queueName = Helpers::keyedResourceName();
+        // Scale on the base (default-tier) queue's backlog. With no `queues:` block
+        // this is the app's single queue (unchanged); with priority tiers it's the
+        // base queue below `high` — the high tier is meant to stay near-empty, so
+        // the base backlog is the throughput signal. (A multi-tenant standalone
+        // queue has no single aggregate metric here — that combination is a separate
+        // concern.)
+        $queueName = Helpers::defaultQueueName();
         $cluster = (new EcsCluster())->name();
         $service = (new EcsService(ServerGroup::QUEUE))->name();
 

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -248,20 +248,21 @@ class Dashboard implements Deletable
 
     /**
      * The app's SQS queue names, matching the queue steps: one for a solo app, or
-     * the landlord queue plus one per tenant for a multi-tenant app.
+     * the landlord queue plus one per tenant for a multi-tenant app — each fanned
+     * across every declared `queues:` tier so the dashboard graphs every queue the
+     * app actually provisions, not just its base queue.
      *
      * @return array<int, string>
      */
     protected static function queueNames(): array
     {
         if (Manifest::isMultitenanted()) {
-            return [
-                Helpers::keyedResourceName('landlord'),
-                ...collect(Manifest::tenants())->keys()->map(fn (string $id): string => Helpers::keyedResourceName($id))->all(),
-            ];
+            return collect(['landlord', ...array_keys(Manifest::tenants())])
+                ->flatMap(fn (string $scope): array => Helpers::queueNames($scope))
+                ->all();
         }
 
-        return [Helpers::keyedResourceName()];
+        return Helpers::queueNames();
     }
 
     /**

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -256,7 +256,7 @@ class Dashboard implements Deletable
      */
     protected static function queueNames(): array
     {
-        if (Manifest::isMultitenanted()) {
+        if (Manifest::fansQueuesPerTenant()) {
             return collect(['landlord', ...array_keys(Manifest::tenants())])
                 ->flatMap(fn (string $scope): array => Helpers::queueNames($scope))
                 ->all();

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -135,7 +135,10 @@ class ConfigureEnvAndVersionStep implements Step
             $defaults['SQS_PREFIX'] = sprintf('https://sqs.%s.amazonaws.com/%s', Manifest::get('region'), Aws::accountId());
 
             if (! Manifest::isMultitenanted()) {
-                $defaults['SQS_QUEUE'] = Helpers::keyedResourceName();
+                // The default queue a producer's un-routed jobs land on — the app's
+                // single queue, or the base tier when a `queues:` block declares
+                // priority tiers (jobs explicitly ->onQueue() the higher tiers).
+                $defaults['SQS_QUEUE'] = Helpers::defaultQueueName();
             }
         } else {
             $this->ensureSyncQueueConnection($envPath);

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -125,19 +125,21 @@ class ConfigureEnvAndVersionStep implements Step
         // tasks.queue, or a headless worker — point the connection at the SQS queue
         // YOLO provisions (it owns the name + URL so the app can't target the wrong
         // one; the task role carries access), so producers (web requests, scheduled
-        // jobs) and the worker share one queue. Solo pins SQS_QUEUE; multitenancy
-        // resolves the per-tenant queue at runtime, so it isn't pinned. With no worker
-        // anywhere (tasks.queue: false, or a worker-less app) jobs would pile into a
-        // queue nothing drains, so force `sync` (run inline at dispatch) — and ENFORCE
-        // it: a non-sync override would silently break, so hard-fail rather than ship.
+        // jobs) and the worker share one queue. Solo and shared-queue apps pin
+        // SQS_QUEUE; a dedicated multi-tenant app resolves the per-tenant queue at
+        // runtime, so it isn't pinned. With no worker anywhere (tasks.queue: false, or
+        // a worker-less app) jobs would pile into a queue nothing drains, so force
+        // `sync` (run inline at dispatch) — and ENFORCE it: a non-sync override would
+        // silently break, so hard-fail rather than ship.
         if (Manifest::queueHost() instanceof ServerGroup) {
             $defaults['QUEUE_CONNECTION'] = 'sqs';
             $defaults['SQS_PREFIX'] = sprintf('https://sqs.%s.amazonaws.com/%s', Manifest::get('region'), Aws::accountId());
 
-            if (! Manifest::isMultitenanted()) {
+            if (! Manifest::fansQueuesPerTenant()) {
                 // The default queue a producer's un-routed jobs land on — the app's
-                // single queue, or the base tier when a `queues:` block declares
-                // priority tiers (jobs explicitly ->onQueue() the higher tiers).
+                // (or a shared multi-tenant app's) base queue, or the higher tier a job
+                // explicitly ->onQueue()s. A dedicated multi-tenant app derives the
+                // per-tenant queue at runtime instead, so nothing is pinned there.
                 $defaults['SQS_QUEUE'] = Helpers::defaultQueueName();
             }
         } else {

--- a/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
+++ b/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
@@ -155,7 +155,11 @@ SH,
         }
 
         if (Manifest::hasStandaloneQueue()) {
-            $cmd = Manifest::schedulerHost() === ServerGroup::QUEUE
+            // supervisord when the queue task runs more than one process: co-hosting
+            // the scheduler (queue:work + supercronic), or multi-tenant (one worker
+            // program per tenant + landlord). A solo queue-only task is a single
+            // exec'd worker — the supervise-and-forward wrapper is its whole drain.
+            $cmd = Manifest::schedulerHost() === ServerGroup::QUEUE || Manifest::isMultitenanted()
                 ? 'supervisord -c /app/docker/supervisord.queue.conf -n'
                 : ProcessCommands::queue();
 

--- a/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
+++ b/src/Steps/Build/Fargate/GenerateEntrypointScriptStep.php
@@ -156,10 +156,11 @@ SH,
 
         if (Manifest::hasStandaloneQueue()) {
             // supervisord when the queue task runs more than one process: co-hosting
-            // the scheduler (queue:work + supercronic), or multi-tenant (one worker
-            // program per tenant + landlord). A solo queue-only task is a single
-            // exec'd worker — the supervise-and-forward wrapper is its whole drain.
-            $cmd = Manifest::schedulerHost() === ServerGroup::QUEUE || Manifest::isMultitenanted()
+            // the scheduler (queue:work + supercronic), or fanning queues out per
+            // tenant (one worker program per tenant + landlord). A solo or shared-queue
+            // task is a single exec'd worker — the supervise-and-forward wrapper is its
+            // whole drain.
+            $cmd = Manifest::schedulerHost() === ServerGroup::QUEUE || Manifest::fansQueuesPerTenant()
                 ? 'supervisord -c /app/docker/supervisord.queue.conf -n'
                 : ProcessCommands::queue();
 

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -85,12 +85,12 @@ class GenerateSupervisorConfigStep implements Step
         }
 
         // A standalone queue needs supervisord when it runs more than one process:
-        // when it co-hosts the scheduler (queue:work + supercronic), OR when it's
-        // multi-tenant (one queue:work program per tenant + landlord — a single
-        // exec'd process can't fan out). A solo queue-only service stays a single
-        // exec'd process (no config), dispatched directly by the entrypoint.
+        // when it co-hosts the scheduler (queue:work + supercronic), OR when it fans
+        // queues out per tenant (one queue:work program per tenant + landlord — a
+        // single exec'd process can't fan out). A solo or shared-queue service runs a
+        // single exec'd worker (no config), dispatched directly by the entrypoint.
         if (Manifest::schedulerHost() === ServerGroup::QUEUE
-            || (Manifest::hasStandaloneQueue() && Manifest::isMultitenanted())) {
+            || (Manifest::hasStandaloneQueue() && Manifest::fansQueuesPerTenant())) {
             $this->writeConfig('docker/supervisord.queue.conf', ServerGroup::QUEUE);
         }
 
@@ -187,7 +187,10 @@ class GenerateSupervisorConfigStep implements Step
      */
     protected function queuePrograms(): array
     {
-        if (! Manifest::isMultitenanted()) {
+        // Solo and shared-queue apps run a single program draining the app's own queue
+        // set (a bare worker, or a tier chain); only a dedicated multi-tenant app fans
+        // into one program per scope.
+        if (! Manifest::fansQueuesPerTenant()) {
             return ['queue' => Helpers::queueChain()];
         }
 

--- a/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
+++ b/src/Steps/Build/Fargate/GenerateSupervisorConfigStep.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Steps\Build\Fargate;
 
 use RuntimeException;
 use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\ProcessCommands;
@@ -83,10 +84,13 @@ class GenerateSupervisorConfigStep implements Step
             $this->writeCaddyfile();
         }
 
-        // A standalone queue only needs supervisord when it co-hosts the scheduler
-        // (queue:work + supercronic = two processes). A queue-only service runs a single
-        // exec'd process — no config — so the entrypoint dispatches it directly.
-        if (Manifest::schedulerHost() === ServerGroup::QUEUE) {
+        // A standalone queue needs supervisord when it runs more than one process:
+        // when it co-hosts the scheduler (queue:work + supercronic), OR when it's
+        // multi-tenant (one queue:work program per tenant + landlord — a single
+        // exec'd process can't fan out). A solo queue-only service stays a single
+        // exec'd process (no config), dispatched directly by the entrypoint.
+        if (Manifest::schedulerHost() === ServerGroup::QUEUE
+            || (Manifest::hasStandaloneQueue() && Manifest::isMultitenanted())) {
             $this->writeConfig('docker/supervisord.queue.conf', ServerGroup::QUEUE);
         }
 
@@ -146,14 +150,70 @@ class GenerateSupervisorConfigStep implements Step
         //              it back if it crashes, and Inertia renders client-side while it's down
         //  - scheduler supercronic firing an ephemeral schedule:run each minute (not a
         //              schedule:work daemon — the trigger halts cleanly on shutdown)
-        //  - queue     queue:work, with a longer stop wait so an in-flight job can finish
+        //  - queue     queue:work, with a longer stop wait so an in-flight job can finish.
+        //              A multi-tenant app fans this into one program per scope
+        //              (landlord + each tenant), each draining that scope's queues —
+        //              see queuePrograms(); everything else is a single 'queue' block.
         foreach (['web', 'ssr', 'scheduler', 'queue'] as $program) {
-            if (isset($graces[$program])) {
-                $blocks[] = $this->program($program, $this->command($program, $colocatesWebServer), stopwaitsecs: $graces[$program]);
+            if (! isset($graces[$program])) {
+                continue;
             }
+
+            if ($program === 'queue') {
+                foreach ($this->queuePrograms() as $name => $chain) {
+                    $blocks[] = $this->program($name, $this->queueCommand($chain, $colocatesWebServer), stopwaitsecs: $graces['queue']);
+                }
+
+                continue;
+            }
+
+            $blocks[] = $this->program($program, $this->command($program, $colocatesWebServer), stopwaitsecs: $graces[$program]);
         }
 
         return implode("\n\n", $blocks) . "\n";
+    }
+
+    /**
+     * The queue-worker program(s) for this container, as `[program name => --queue
+     * chain]`. A solo app runs one `queue` program (bare, or a tier chain when it
+     * declares `queues:`); a multi-tenant app runs one program per scope —
+     * `queue_landlord` plus `queue_<tenant>` — each draining only that scope's
+     * queues, so a whale tenant's backlog can't starve the others (the fairness the
+     * naive `--queue=t1,t2,…` comma list would lose to strict priority). Each
+     * program's chain comes from Helpers::queueChain, the same source the SQS queues
+     * are provisioned from, so the worker never polls a queue that wasn't created.
+     *
+     * @return array<string, string|null>
+     */
+    protected function queuePrograms(): array
+    {
+        if (! Manifest::isMultitenanted()) {
+            return ['queue' => Helpers::queueChain()];
+        }
+
+        $programs = ['queue_landlord' => Helpers::queueChain('landlord')];
+
+        foreach (array_keys(Manifest::tenants()) as $tenantId) {
+            $programs["queue_{$tenantId}"] = Helpers::queueChain($tenantId);
+        }
+
+        return $programs;
+    }
+
+    /**
+     * A queue program's command line: `queue:work` (with the scope's `--queue`
+     * chain) niced into the background tier when it shares the web container. Every
+     * per-scope program niced the same — they're all the queue tier — so the lookup
+     * is keyed on 'queue', not the fanned-out program name.
+     */
+    protected function queueCommand(?string $chain, bool $colocatesWebServer): string
+    {
+        $command = ProcessCommands::queue($chain);
+        $nice = $this->niceLevel('queue', $colocatesWebServer);
+
+        return $nice === null
+            ? $command
+            : sprintf('nice -n %d %s', $nice, $command);
     }
 
     /**

--- a/src/Steps/Sync/App/Landlord/SyncQueueStep.php
+++ b/src/Steps/Sync/App/Landlord/SyncQueueStep.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Landlord;
 
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Resources\Sqs\Queue;
-use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Concerns\ProvisionsScopedQueues;
 use Codinglabs\Yolo\Contracts\ExecutesMultitenancyStep;
 
 class SyncQueueStep implements ExecutesMultitenancyStep
 {
-    use SynchronisesResource;
+    use ProvisionsScopedQueues;
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new Queue(Helpers::keyedResourceName('landlord')), $options);
+        return $this->syncScopedQueues('landlord', $options);
     }
 }

--- a/src/Steps/Sync/App/Shared/SyncQueueStep.php
+++ b/src/Steps/Sync/App/Shared/SyncQueueStep.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Sync\App\Shared;
+
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\ProvisionsScopedQueues;
+use Codinglabs\Yolo\Contracts\ExecutesMultitenancyStep;
+
+/**
+ * The queue set for a multi-tenant app on the `shared` strategy — one set at the
+ * app's own name (`yolo-{env}-{app}[-tier]`), the same shape a solo app has, drained
+ * by a single worker with the tenant carried in the job payload. Wired in place of
+ * the per-tenant landlord + tenant queue steps when queue-isolation is `shared`.
+ */
+class SyncQueueStep implements ExecutesMultitenancyStep
+{
+    use ProvisionsScopedQueues;
+
+    public function __invoke(array $options): StepResult
+    {
+        return $this->syncScopedQueues(null, $options);
+    }
+}

--- a/src/Steps/Sync/App/Solo/SyncQueueStep.php
+++ b/src/Steps/Sync/App/Solo/SyncQueueStep.php
@@ -4,19 +4,17 @@ declare(strict_types=1);
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Solo;
 
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
-use Codinglabs\Yolo\Resources\Sqs\Queue;
 use Codinglabs\Yolo\Contracts\ExecutesSoloStep;
-use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Concerns\ProvisionsScopedQueues;
 
 class SyncQueueStep implements ExecutesSoloStep, Step
 {
-    use SynchronisesResource;
+    use ProvisionsScopedQueues;
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new Queue(Helpers::keyedResourceName()), $options);
+        return $this->syncScopedQueues(null, $options);
     }
 }

--- a/src/Steps/Sync/App/Tenant/SyncQueueStep.php
+++ b/src/Steps/Sync/App/Tenant/SyncQueueStep.php
@@ -4,18 +4,16 @@ declare(strict_types=1);
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Tenant;
 
-use Codinglabs\Yolo\Helpers;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Steps\TenantStep;
-use Codinglabs\Yolo\Resources\Sqs\Queue;
-use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Concerns\ProvisionsScopedQueues;
 
 class SyncQueueStep extends TenantStep
 {
-    use SynchronisesResource;
+    use ProvisionsScopedQueues;
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new Queue(Helpers::keyedResourceName($this->tenantId())), $options);
+        return $this->syncScopedQueues($this->tenantId(), $options);
     }
 }

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -464,3 +464,36 @@ it('rejects the reserved app name `services` — it collides with the env servic
 
     expect(test()->promptOutput->fetch())->toContain('reserved');
 });
+
+it('bails when queue-isolation is set on a solo app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'queue-isolation' => 'shared',
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('queue-isolation');
+});
+
+it('bails on an unknown queue-isolation value', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tenants' => ['acme' => []],
+        'queue-isolation' => 'sometimes',
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('queue-isolation');
+});
+
+it('passes for a shared multi-tenant app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tenants' => ['acme' => []],
+        'queue-isolation' => 'shared',
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});

--- a/tests/Unit/Commands/StatusCommandTest.php
+++ b/tests/Unit/Commands/StatusCommandTest.php
@@ -233,7 +233,12 @@ it('lists the solo queue, or landlord + tenants when multi-tenant', function ():
     writeManifest([]);
     expect($probe->names())->toBe(['queue' => 'yolo-testing-my-app']);
 
+    // A shared multi-tenant app (the default) shows the one shared queue.
     writeManifest(['tenants' => ['acme' => [], 'globex' => []]]);
+    expect($probe->names())->toBe(['queue' => 'yolo-testing-my-app']);
+
+    // A dedicated one shows the landlord queue plus one per tenant.
+    writeManifest(['tenants' => ['acme' => [], 'globex' => []], 'queue-isolation' => 'dedicated']);
     expect($probe->names())->toBe([
         'landlord' => 'yolo-testing-my-app-landlord',
         'acme' => 'yolo-testing-my-app-acme',

--- a/tests/Unit/Commands/SyncCommandCollationTest.php
+++ b/tests/Unit/Commands/SyncCommandCollationTest.php
@@ -161,7 +161,22 @@ it('provisions the SQS queue and queue service for a web-less worker app with a 
         ->not->toContain(Steps\Sync\App\SyncTargetGroupStep::class);
 });
 
-it('swaps the Solo steps for Landlord + Tenant steps on a multi-tenant app', function (): void {
+it('swaps the Solo steps for Landlord + Tenant queue steps on a dedicated multi-tenant app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tenants' => ['alpha' => []],
+        'queue-isolation' => 'dedicated',
+    ]);
+
+    $appSteps = (new SyncCommand())->scopes()['app'];
+
+    expect($appSteps)->toContain(Steps\Sync\App\Landlord\SyncQueueStep::class)
+        ->and($appSteps)->toContain(Steps\Sync\App\Tenant\SyncQueueStep::class)
+        ->and($appSteps)->not->toContain(Steps\Sync\App\Shared\SyncQueueStep::class)
+        ->and($appSteps)->not->toContain(Steps\Sync\App\Solo\SyncHostedZoneStep::class);
+});
+
+it('provisions one shared queue set on a shared multi-tenant app — the default', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tenants' => ['alpha' => []],
@@ -169,8 +184,11 @@ it('swaps the Solo steps for Landlord + Tenant steps on a multi-tenant app', fun
 
     $appSteps = (new SyncCommand())->scopes()['app'];
 
-    expect($appSteps)->toContain(Steps\Sync\App\Landlord\SyncQueueStep::class)
-        ->and($appSteps)->toContain(Steps\Sync\App\Tenant\SyncQueueStep::class)
+    // Shared is the default, so a plain multi-tenant app gets the single shared queue
+    // step, not the per-tenant landlord + tenant fan-out — and still no solo DNS.
+    expect($appSteps)->toContain(Steps\Sync\App\Shared\SyncQueueStep::class)
+        ->and($appSteps)->not->toContain(Steps\Sync\App\Landlord\SyncQueueStep::class)
+        ->and($appSteps)->not->toContain(Steps\Sync\App\Tenant\SyncQueueStep::class)
         ->and($appSteps)->not->toContain(Steps\Sync\App\Solo\SyncHostedZoneStep::class);
 });
 

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -161,3 +161,51 @@ describe('payloadHasDifferences', function (): void {
         ))->toBeTrue();
     });
 });
+
+describe('queue names', function (): void {
+    it('is a single un-suffixed queue per scope with no queues: block', function (): void {
+        writeManifest([]);
+
+        // solo — one queue at the pre-queues: name, and no --queue chain (the bare worker)
+        expect(Helpers::queueNames())->toBe(['yolo-testing-my-app']);
+        expect(Helpers::queueChain())->toBeNull();
+        expect(Helpers::defaultQueueName())->toBe('yolo-testing-my-app');
+
+        // multi-tenant scopes keep their existing per-scope names, and a per-scope
+        // worker draining exactly that one queue
+        expect(Helpers::queueNames('landlord'))->toBe(['yolo-testing-my-app-landlord']);
+        expect(Helpers::queueChain('landlord'))->toBe('yolo-testing-my-app-landlord');
+        expect(Helpers::queueNames('acme'))->toBe(['yolo-testing-my-app-acme']);
+        expect(Helpers::queueChain('acme'))->toBe('yolo-testing-my-app-acme');
+    });
+
+    it('fans each scope out over declared tiers in priority order', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+
+        expect(Helpers::queueNames())->toBe([
+            'yolo-testing-my-app-high',
+            'yolo-testing-my-app-default',
+        ]);
+        expect(Helpers::queueNames('landlord'))->toBe([
+            'yolo-testing-my-app-landlord-high',
+            'yolo-testing-my-app-landlord-default',
+        ]);
+        expect(Helpers::queueNames('acme'))->toBe([
+            'yolo-testing-my-app-acme-high',
+            'yolo-testing-my-app-acme-default',
+        ]);
+    });
+
+    it('chains the tiers comma-separated so queue:work drains them strict-priority', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+
+        expect(Helpers::queueChain('acme'))
+            ->toBe('yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
+    });
+
+    it('resolves the default queue to the base (last) tier a producer lands un-routed jobs on', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+
+        expect(Helpers::defaultQueueName())->toBe('yolo-testing-my-app-default');
+    });
+});

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -180,7 +180,7 @@ describe('queue names', function (): void {
     });
 
     it('fans each scope out over declared tiers in priority order', function (): void {
-        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+        writeManifest(['queues' => ['high', 'default']]);
 
         expect(Helpers::queueNames())->toBe([
             'yolo-testing-my-app-high',
@@ -197,14 +197,14 @@ describe('queue names', function (): void {
     });
 
     it('chains the tiers comma-separated so queue:work drains them strict-priority', function (): void {
-        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+        writeManifest(['queues' => ['high', 'default']]);
 
         expect(Helpers::queueChain('acme'))
             ->toBe('yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
     });
 
     it('resolves the default queue to the base (last) tier a producer lands un-routed jobs on', function (): void {
-        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+        writeManifest(['queues' => ['high', 'default']]);
 
         expect(Helpers::defaultQueueName())->toBe('yolo-testing-my-app-default');
     });

--- a/tests/Unit/HelpersTest.php
+++ b/tests/Unit/HelpersTest.php
@@ -179,20 +179,22 @@ describe('queue names', function (): void {
         expect(Helpers::queueChain('acme'))->toBe('yolo-testing-my-app-acme');
     });
 
-    it('fans each scope out over declared tiers in priority order', function (): void {
+    it('suffixes the higher tiers but leaves the default tier as the naked scope name', function (): void {
         writeManifest(['queues' => ['high', 'default']]);
 
+        // `default` is Laravel's default queue — the naked scope name, so declaring
+        // tiers only adds the `-high` lane; the base queue name is unchanged.
         expect(Helpers::queueNames())->toBe([
             'yolo-testing-my-app-high',
-            'yolo-testing-my-app-default',
+            'yolo-testing-my-app',
         ]);
         expect(Helpers::queueNames('landlord'))->toBe([
             'yolo-testing-my-app-landlord-high',
-            'yolo-testing-my-app-landlord-default',
+            'yolo-testing-my-app-landlord',
         ]);
         expect(Helpers::queueNames('acme'))->toBe([
             'yolo-testing-my-app-acme-high',
-            'yolo-testing-my-app-acme-default',
+            'yolo-testing-my-app-acme',
         ]);
     });
 
@@ -200,12 +202,13 @@ describe('queue names', function (): void {
         writeManifest(['queues' => ['high', 'default']]);
 
         expect(Helpers::queueChain('acme'))
-            ->toBe('yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
+            ->toBe('yolo-testing-my-app-acme-high,yolo-testing-my-app-acme');
     });
 
-    it('resolves the default queue to the base (last) tier a producer lands un-routed jobs on', function (): void {
+    it('resolves the default queue to the naked scope name a producer lands un-routed jobs on', function (): void {
         writeManifest(['queues' => ['high', 'default']]);
 
-        expect(Helpers::defaultQueueName())->toBe('yolo-testing-my-app-default');
+        expect(Helpers::defaultQueueName())->toBe('yolo-testing-my-app');
+        expect(Helpers::defaultQueueName('acme'))->toBe('yolo-testing-my-app-acme');
     });
 });

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Enums\ServerGroup;
+use Codinglabs\Yolo\Enums\QueueIsolation;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 
 describe('has and get', function (): void {
@@ -126,6 +127,41 @@ describe('queue tiers', function (): void {
         writeManifest(['queues' => ['high' => null, 'default' => null]]);
 
         expect(fn (): array => Manifest::queueTiers())->toThrow(IntegrityCheckException::class);
+    });
+});
+
+describe('queue isolation', function (): void {
+    it('defaults a multi-tenant app to dedicated per-tenant queues', function (): void {
+        writeManifest(['tenants' => ['acme' => [], 'globex' => []]]);
+
+        expect(Manifest::queueIsolation())->toBe(QueueIsolation::Dedicated);
+        expect(Manifest::fansQueuesPerTenant())->toBeTrue();
+    });
+
+    it('shares queues across tenants when isolation is shared', function (): void {
+        writeManifest([
+            'tenants' => ['acme' => [], 'globex' => []],
+            'queue-isolation' => 'shared',
+        ]);
+
+        expect(Manifest::queueIsolation())->toBe(QueueIsolation::Shared);
+        // shared collapses to the solo queue shape — the layer does not fan per tenant
+        expect(Manifest::fansQueuesPerTenant())->toBeFalse();
+    });
+
+    it('never fans queues per tenant for a solo app', function (): void {
+        writeManifest([]);
+
+        expect(Manifest::fansQueuesPerTenant())->toBeFalse();
+    });
+
+    it('hard-fails on an unknown isolation value', function (): void {
+        writeManifest([
+            'tenants' => ['acme' => []],
+            'queue-isolation' => 'sometimes',
+        ]);
+
+        expect(fn (): QueueIsolation => Manifest::queueIsolation())->toThrow(IntegrityCheckException::class);
     });
 });
 

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -131,22 +131,22 @@ describe('queue tiers', function (): void {
 });
 
 describe('queue isolation', function (): void {
-    it('defaults a multi-tenant app to dedicated per-tenant queues', function (): void {
+    it('defaults a multi-tenant app to shared queues', function (): void {
         writeManifest(['tenants' => ['acme' => [], 'globex' => []]]);
-
-        expect(Manifest::queueIsolation())->toBe(QueueIsolation::Dedicated);
-        expect(Manifest::fansQueuesPerTenant())->toBeTrue();
-    });
-
-    it('shares queues across tenants when isolation is shared', function (): void {
-        writeManifest([
-            'tenants' => ['acme' => [], 'globex' => []],
-            'queue-isolation' => 'shared',
-        ]);
 
         expect(Manifest::queueIsolation())->toBe(QueueIsolation::Shared);
         // shared collapses to the solo queue shape — the layer does not fan per tenant
         expect(Manifest::fansQueuesPerTenant())->toBeFalse();
+    });
+
+    it('fans queues per tenant when isolation is dedicated', function (): void {
+        writeManifest([
+            'tenants' => ['acme' => [], 'globex' => []],
+            'queue-isolation' => 'dedicated',
+        ]);
+
+        expect(Manifest::queueIsolation())->toBe(QueueIsolation::Dedicated);
+        expect(Manifest::fansQueuesPerTenant())->toBeTrue();
     });
 
     it('never fans queues per tenant for a solo app', function (): void {

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -125,7 +125,7 @@ describe('queue tiers', function (): void {
     it('rejects a queues: list — the tier name is load-bearing, indices would provision …-0/…-1', function (): void {
         writeManifest(['queues' => ['high', 'default']]);
 
-        expect(fn () => Manifest::queueTiers())->toThrow(IntegrityCheckException::class);
+        expect(fn (): array => Manifest::queueTiers())->toThrow(IntegrityCheckException::class);
     });
 });
 

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -103,6 +103,32 @@ describe('multitenancy', function (): void {
     });
 });
 
+describe('queue tiers', function (): void {
+    it('declares no tiers without a queues: block', function (): void {
+        writeManifest([]);
+
+        expect(Manifest::queueTiers())->toBe([]);
+    });
+
+    it('reads the declared tiers in manifest (priority) order', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+
+        expect(Manifest::queueTiers())->toBe(['high', 'default']);
+    });
+
+    it('accepts the queues: block through the manifest validator', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+
+        expect(Manifest::unknownKeys())->toBe([]);
+    });
+
+    it('rejects a queues: list — the tier name is load-bearing, indices would provision …-0/…-1', function (): void {
+        writeManifest(['queues' => ['high', 'default']]);
+
+        expect(fn () => Manifest::queueTiers())->toThrow(IntegrityCheckException::class);
+    });
+});
+
 describe('cache + session defaults', function (): void {
     it('defaults web apps to the shared redis cache and redis sessions', function (): void {
         writeManifest([

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -110,20 +110,20 @@ describe('queue tiers', function (): void {
         expect(Manifest::queueTiers())->toBe([]);
     });
 
-    it('reads the declared tiers in manifest (priority) order', function (): void {
-        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+    it('reads the declared tiers as a list in priority order', function (): void {
+        writeManifest(['queues' => ['high', 'default']]);
 
         expect(Manifest::queueTiers())->toBe(['high', 'default']);
     });
 
-    it('accepts the queues: block through the manifest validator', function (): void {
-        writeManifest(['queues' => ['high' => null, 'default' => null]]);
+    it('accepts the queues: list through the manifest validator', function (): void {
+        writeManifest(['queues' => ['high', 'default']]);
 
         expect(Manifest::unknownKeys())->toBe([]);
     });
 
-    it('rejects a queues: list — the tier name is load-bearing, indices would provision …-0/…-1', function (): void {
-        writeManifest(['queues' => ['high', 'default']]);
+    it('rejects a queues: map — per-queue config is not supported yet', function (): void {
+        writeManifest(['queues' => ['high' => null, 'default' => null]]);
 
         expect(fn (): array => Manifest::queueTiers())->toThrow(IntegrityCheckException::class);
     });

--- a/tests/Unit/ProcessCommandsTest.php
+++ b/tests/Unit/ProcessCommandsTest.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\ProcessCommands;
+
+describe('queue', function (): void {
+    it('is the bare worker against the pinned SQS_QUEUE when no queue is given', function (): void {
+        expect(ProcessCommands::queue())
+            ->toBe('php artisan queue:work --tries=3 --max-time=3600');
+    });
+
+    it('appends an explicit --queue for a scoped or tiered worker', function (): void {
+        expect(ProcessCommands::queue('yolo-testing-my-app-acme'))
+            ->toBe('php artisan queue:work --tries=3 --max-time=3600 --queue=yolo-testing-my-app-acme');
+    });
+
+    it('passes a comma chain straight through so queue:work drains it strict-priority', function (): void {
+        expect(ProcessCommands::queue('yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default'))
+            ->toBe('php artisan queue:work --tries=3 --max-time=3600 --queue=yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
+    });
+});

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -270,7 +270,7 @@ it('hard-fails when QUEUE_CONNECTION is non-sync but no worker runs', function (
         ->toThrow(IntegrityCheckException::class);
 });
 
-it('does not pin SQS_QUEUE for a multitenant app (worker resolves it per tenant)', function (): void {
+it('does not pin SQS_QUEUE for a dedicated multitenant app (worker resolves it per tenant)', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => true],
@@ -290,6 +290,32 @@ it('does not pin SQS_QUEUE for a multitenant app (worker resolves it per tenant)
 
     expect($env)->toContain('QUEUE_CONNECTION=sqs');
     expect($env)->not->toContain('SQS_QUEUE=');
+});
+
+it('pins SQS_QUEUE to the shared queue for a shared multitenant app', function (): void {
+    // Shared collapses to the solo queue shape: one queue at the app name that every
+    // tenant's jobs land on (the tenant rides the payload), so the base queue is pinned
+    // exactly like a solo app — the per-tenant runtime resolution is what shared drops.
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => true],
+        'tenants' => ['acme' => ['domain' => 'acme.test']],
+        'queue-isolation' => 'shared',
+    ]);
+
+    if (! is_dir(Paths::build())) {
+        mkdir(Paths::build(), 0755, true);
+    }
+    if (file_exists(Paths::build('.env.testing'))) {
+        unlink(Paths::build('.env.testing'));
+    }
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('QUEUE_CONNECTION=sqs');
+    expect($env)->toContain('SQS_QUEUE=yolo-testing-my-app');
 });
 
 it('respects an AWS_BUCKET already set in the .env', function (): void {

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -275,6 +275,7 @@ it('does not pin SQS_QUEUE for a dedicated multitenant app (worker resolves it p
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => true],
         'tenants' => ['acme' => ['domain' => 'acme.test']],
+        'queue-isolation' => 'dedicated',
     ]);
 
     if (! is_dir(Paths::build())) {

--- a/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
@@ -184,6 +184,21 @@ it('defaults the role to queue for a web-less worker app whose queue hosts the s
     expect($script)->not->toContain('scheduler) cmd=');
 });
 
+it('runs a multi-tenant standalone queue under supervisord even when the scheduler is its own service', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        // A solo app with this shape runs a single exec'd worker; multi-tenancy needs
+        // supervisord to run one queue:work program per tenant, so it routes there.
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
+        'tenants' => ['acme' => []],
+    ]);
+
+    $script = generatedEntrypointScript();
+
+    expect($script)->toContain("queue)     cmd='supervisord -c /app/docker/supervisord.queue.conf -n'");
+    expect($script)->not->toContain("queue)     cmd='php artisan queue:work");
+});
+
 it('forwards SIGTERM to the child and waits for a clean shutdown', function (): void {
     $script = generatedEntrypointScript();
 

--- a/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateEntrypointScriptStepTest.php
@@ -187,10 +187,12 @@ it('defaults the role to queue for a web-less worker app whose queue hosts the s
 it('runs a multi-tenant standalone queue under supervisord even when the scheduler is its own service', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
-        // A solo app with this shape runs a single exec'd worker; multi-tenancy needs
-        // supervisord to run one queue:work program per tenant, so it routes there.
+        // A solo app with this shape runs a single exec'd worker; a dedicated
+        // multi-tenant app needs supervisord to run one queue:work program per tenant,
+        // so it routes there.
         'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
         'tenants' => ['acme' => []],
+        'queue-isolation' => 'dedicated',
     ]);
 
     $script = generatedEntrypointScript();

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -489,9 +489,10 @@ it('chains each per-tenant program over the declared priority tiers', function (
     $config = generatedSupervisorConfig();
 
     // The comma list drains high before default — strict priority is now the
-    // intra-tenant feature, one program still isolating each tenant.
-    expect($config)->toContain('--queue=yolo-testing-my-app-landlord-high,yolo-testing-my-app-landlord-default');
-    expect($config)->toContain('--queue=yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
+    // intra-tenant feature, one program still isolating each tenant. The `default`
+    // tier is the naked scope queue, so the chain ends on the base tenant queue.
+    expect($config)->toContain('--queue=yolo-testing-my-app-landlord-high,yolo-testing-my-app-landlord');
+    expect($config)->toContain('--queue=yolo-testing-my-app-acme-high,yolo-testing-my-app-acme');
 });
 
 it('chains a solo worker over the declared tiers, keeping the single queue program', function (): void {
@@ -504,7 +505,7 @@ it('chains a solo worker over the declared tiers, keeping the single queue progr
     $config = generatedSupervisorConfig();
 
     expect($config)->toContain('[program:queue]');
-    expect($config)->toContain('--queue=yolo-testing-my-app-high,yolo-testing-my-app-default');
+    expect($config)->toContain('--queue=yolo-testing-my-app-high,yolo-testing-my-app');
 });
 
 it('runs a multi-tenant standalone queue under supervisord even without a co-hosted scheduler', function (): void {

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -483,7 +483,7 @@ it('chains each per-tenant program over the declared priority tiers', function (
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => false]],
         'tenants' => ['acme' => []],
-        'queues' => ['high' => null, 'default' => null],
+        'queues' => ['high', 'default'],
     ]);
 
     $config = generatedSupervisorConfig();
@@ -498,7 +498,7 @@ it('chains a solo worker over the declared tiers, keeping the single queue progr
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => false]],
-        'queues' => ['high' => null, 'default' => null],
+        'queues' => ['high', 'default'],
     ]);
 
     $config = generatedSupervisorConfig();

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -456,6 +456,78 @@ it('does not run the ssr renderer by default', function (): void {
     expect(generatedSupervisorConfig())->not->toContain('[program:ssr]');
 });
 
+it('fans the bundled queue worker into one program per scope for a multi-tenant app', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => false]],
+        'tenants' => ['acme' => [], 'globex' => []],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // One worker program per scope — landlord plus each tenant — so a whale tenant's
+    // backlog can't starve the others; there is no single bare `queue` program.
+    expect($config)->toContain('[program:queue_landlord]');
+    expect($config)->toContain('[program:queue_acme]');
+    expect($config)->toContain('[program:queue_globex]');
+    expect($config)->not->toContain('[program:queue]');
+
+    // Each program drains only its own scope's queue.
+    expect($config)->toContain('--queue=yolo-testing-my-app-landlord');
+    expect($config)->toContain('--queue=yolo-testing-my-app-acme');
+    expect($config)->toContain('--queue=yolo-testing-my-app-globex');
+});
+
+it('chains each per-tenant program over the declared priority tiers', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => false]],
+        'tenants' => ['acme' => []],
+        'queues' => ['high' => null, 'default' => null],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // The comma list drains high before default — strict priority is now the
+    // intra-tenant feature, one program still isolating each tenant.
+    expect($config)->toContain('--queue=yolo-testing-my-app-landlord-high,yolo-testing-my-app-landlord-default');
+    expect($config)->toContain('--queue=yolo-testing-my-app-acme-high,yolo-testing-my-app-acme-default');
+});
+
+it('chains a solo worker over the declared tiers, keeping the single queue program', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => false]],
+        'queues' => ['high' => null, 'default' => null],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    expect($config)->toContain('[program:queue]');
+    expect($config)->toContain('--queue=yolo-testing-my-app-high,yolo-testing-my-app-default');
+});
+
+it('runs a multi-tenant standalone queue under supervisord even without a co-hosted scheduler', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        // queue and scheduler both extracted into their own services: a solo app's
+        // queue task would be a single exec'd worker, but multi-tenancy needs
+        // supervisord to run one program per tenant.
+        'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
+        'tenants' => ['acme' => []],
+    ]);
+
+    (new GenerateSupervisorConfigStep('testing'))();
+
+    $queue = file_get_contents(Paths::build('docker/supervisord.queue.conf'));
+    expect($queue)->toContain('[program:queue_landlord]');
+    expect($queue)->toContain('[program:queue_acme]');
+    // The scheduler is its own service, so it isn't in the queue container.
+    expect($queue)->not->toContain('[program:scheduler]');
+    // Standalone queue: no web server to protect, so the workers run un-niced.
+    expect($queue)->not->toContain('nice');
+});
+
 it('never bundles a saturation program — burst metrics ride the request, not a supervised loop', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -456,11 +456,12 @@ it('does not run the ssr renderer by default', function (): void {
     expect(generatedSupervisorConfig())->not->toContain('[program:ssr]');
 });
 
-it('fans the bundled queue worker into one program per scope for a multi-tenant app', function (): void {
+it('fans the bundled queue worker into one program per scope for a dedicated multi-tenant app', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => false]],
         'tenants' => ['acme' => [], 'globex' => []],
+        'queue-isolation' => 'dedicated',
     ]);
 
     $config = generatedSupervisorConfig();
@@ -483,6 +484,7 @@ it('chains each per-tenant program over the declared priority tiers', function (
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         'tasks' => ['web' => ['autoscaling' => false]],
         'tenants' => ['acme' => []],
+        'queue-isolation' => 'dedicated',
         'queues' => ['high', 'default'],
     ]);
 
@@ -531,10 +533,11 @@ it('runs a multi-tenant standalone queue under supervisord even without a co-hos
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',
         // queue and scheduler both extracted into their own services: a solo app's
-        // queue task would be a single exec'd worker, but multi-tenancy needs
-        // supervisord to run one program per tenant.
+        // queue task would be a single exec'd worker, but a dedicated multi-tenant app
+        // needs supervisord to run one program per tenant.
         'tasks' => ['web' => true, 'queue' => true, 'scheduler' => true],
         'tenants' => ['acme' => []],
+        'queue-isolation' => 'dedicated',
     ]);
 
     (new GenerateSupervisorConfigStep('testing'))();

--- a/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
+++ b/tests/Unit/Steps/Build/Fargate/GenerateSupervisorConfigStepTest.php
@@ -508,6 +508,25 @@ it('chains a solo worker over the declared tiers, keeping the single queue progr
     expect($config)->toContain('--queue=yolo-testing-my-app-high,yolo-testing-my-app');
 });
 
+it('runs one shared queue program for a shared multi-tenant app, not one per tenant', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'tasks' => ['web' => ['autoscaling' => false]],
+        'tenants' => ['acme' => [], 'globex' => []],
+        'queue-isolation' => 'shared',
+        'queues' => ['high', 'default'],
+    ]);
+
+    $config = generatedSupervisorConfig();
+
+    // Shared collapses to the solo queue shape — a single program draining the app's
+    // own queue set (tenant rides the job payload), no per-tenant fan-out.
+    expect($config)->toContain('[program:queue]');
+    expect($config)->not->toContain('[program:queue_landlord]');
+    expect($config)->not->toContain('[program:queue_acme]');
+    expect($config)->toContain('--queue=yolo-testing-my-app-high,yolo-testing-my-app');
+});
+
 it('runs a multi-tenant standalone queue under supervisord even without a co-hosted scheduler', function (): void {
     writeManifest([
         'account-id' => '111111111111', 'region' => 'ap-southeast-2',


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

- **Multi-tenant queues were never drained.** The Fargate queue task ran one bare `queue:work`, which consumes only the default `SQS_QUEUE`. A multi-tenant app provisions a queue per tenant (+ landlord), so every per-tenant queue silently piled up with nothing draining it. (An app-side override was papering over this; yolo needs to own it.)
- **Per-tenant fairness needs care.** The obvious fix — one worker with `--queue=t1,t2,…` — is a *strict-priority* comma list, so a whale tenant's backlog would block every tenant behind it. That's a design constraint, not a bug that shipped: it's why the worker runs one program per scope, not a shared comma list.
- **No priority lane, and no way to trade fairness for scale** at high tenant counts.

**What this does**

- **Per-scope worker programs.** Supervisord emits one `queue:work` per scope — `queue_landlord` + `queue_<tenant>` — each draining only that scope's queue. Solo apps keep the single bare worker. A multi-tenant standalone queue task now runs under supervisord (a single exec'd process can't fan out).
- **Priority tiers — `queues:` is a priority-ordered list.**
  ```yaml
  queues:
    - high
    - default
  ```
  List order is strict-priority. Each scope fans out to `…-{scope}-high` plus the naked `…-{scope}` — the `default` tier **is** Laravel's default queue, so it maps to the naked scope name and the base queue an app already dispatches to is never renamed. The worker chains `--queue=…-{scope}-high,…-{scope}`, so the comma list's strict priority becomes the *intra-scope* feature. Names only — per-queue config (visibility timeout, retention, alarms) is deferred; a map form is rejected.
- **`queue-isolation` — shared (default) vs dedicated.** A plain multi-tenant app gets **one shared queue at the app name** — every tenant's jobs share it, the tenant rides the payload, one worker drains all of them. It scales to any tenant count. Per-tenant isolation is the explicit opt-in:
  - `shared` (default): one queue set at `yolo-{env}-{app}[-tier]`, tenant in the payload.
  - `dedicated`: one queue set + one worker program per tenant (`…-{tenant}[-tier]`). Fair — a whale can't starve the others — but scales to dozens, not hundreds.

  Shared collapses the multi-tenant queue layer to the solo shape, so a single `fansQueuesPerTenant()` predicate gates every per-tenant branch (provisioning, worker programs, the `SQS_QUEUE` pin, the entrypoint, dashboard + status).

**Is there anything the reviewer needs to know to deploy this?**

- **This queue behaviour has never deployed (pre-1.0), so there's no compatibility to keep** — the defaults are chosen on merit, not to match old behaviour. A multi-tenant app that wants the previous per-tenant queues sets `queue-isolation: dedicated`.
- **App-side implication.** `shared` expects the app to dispatch to the one app-name queue with the tenant in the job payload (spatie's default). `dedicated` expects the app's own per-tenant queue names — yolo provisions `yolo-{env}-{app}-{tenant}` (+ `-high`) to match, and the naked-`default` mapping keeps that base name identical whether or not tiers are declared.
- **Validation, not silent fallback:** `queue-isolation` is rejected on a solo app and on an unknown value; a `queues:` map (vs list) is rejected. All hard-fail with a pointed message.
- **Deferred** (hardcoded sensible defaults, no speculative knobs): per-queue visibility-timeout / retention / depth-alarms, arbitrary N-queue configs, DLQ, and per-queue autoscaling for a shared standalone queue.

🤖 Generated with [Claude Code](https://claude.ai/code)
