### PR TITLE
Strip internal Linear ticket reference from QueueIsolation docblock

### DIFF
--- a/src/Enums/QueueIsolation.php
+++ b/src/Enums/QueueIsolation.php
@@ -18,7 +18,7 @@ namespace Codinglabs\Yolo\Enums;
  *   tenant's backlog can't starve the others. Fair, but N tenants means N worker
  *   programs and N queues per tier — it scales to dozens, not hundreds.
  *
- * Orthogonal to LPX-587's per-tenant `dedicated: true`, which is a third axis — one
+ * Orthogonal to a per-tenant `dedicated: true` setting, which is a third axis — one
  * tenant getting its own independently-scaled ECS service.
  */
 enum QueueIsolation: string


### PR DESCRIPTION
## Summary
- yolo is a public repo — this line's docblock referenced an internal Linear issue key, which the repo's own contribution rules forbid in any pushed artefact.
- Reworded the comment to describe the per-tenant `dedicated: true` axis generically, with no ticket reference. No behaviour change.

## Test plan
- [x] `./vendor/bin/pint --dirty` — passed, no formatting changes needed
- [x] `./vendor/bin/pest` — 1814 passed, 0 failed