### PR TITLE
fix(run): base64-encode one-off commands to survive the ECS Exec shell hop

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -463,6 +463,8 @@ yolo run <environment> [--command="<cmd>"] [--group=<groups>]
 
 Each group is its own ECS service when extracted, and `run` execs into the container named after the group. A bundled queue/scheduler runs inside the web container, so a `--group=queue` lookup that finds no standalone queue service simply falls through to the next group.
 
+A `--command` string is base64-encoded before it reaches ECS Exec and decoded once, right before it runs — quote it for your own shell as normal and it arrives on the container byte-for-byte, so a namespaced one-liner (`--command="php artisan tinker --execute='\App\Foo::bar()'"`) survives intact instead of losing its backslashes somewhere between here and the container.
+
 **Requirements:** the AWS [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed locally. ECS Exec is on by default (`enable-execute-command` defaults to `true`); it must not have been disabled (`enable-execute-command: false`) on the target group in the manifest.
 
 ```bash

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -113,7 +113,14 @@ class RunCommand extends Command implements DeployerCommand
         // profile — ecs:ExecuteCommand lives on the deployer role, not the
         // operator's own identity. See Command::subprocessEnv().
         $process = new Process(
-            static::executeCommandArgs($cluster, $task, $command, $container, Manifest::get('region'), $this->subprocessProfile()),
+            static::executeCommandArgs(
+                $cluster,
+                $task,
+                $interactive ? $command : static::encodeCommand($command),
+                $container,
+                Manifest::get('region'),
+                $this->subprocessProfile(),
+            ),
             env: $this->subprocessEnv(),
             timeout: null,
         );
@@ -130,6 +137,24 @@ class RunCommand extends Command implements DeployerCommand
         }
 
         return $process->run(fn ($type, string|iterable $buffer) => $this->output->write($buffer));
+    }
+
+    /**
+     * A one-off `--command` string crosses at least one more real shell parse
+     * after this process's own — ECS Exec runs it on the container side via its
+     * own `sh -c`, and POSIX shell rules apply there exactly as they would to
+     * anything else typed at a prompt: an unquoted backslash is itself consumed
+     * ("\App\Foo" -> "AppFoo"), which is how a namespaced PHP one-liner
+     * (`--execute=\App\Foo::bar()`) turns into a "Class not found" once it lands.
+     * Base64-encoding the command sidesteps that hop entirely — the payload is
+     * pure `[A-Za-z0-9+/=]`, which no shell reinterprets, and it's decoded back
+     * to the exact original bytes only once, right before it actually runs.
+     * Never applied to the interactive `/bin/sh` shell — its stdin has to stay
+     * wired to the operator's terminal, not a decode pipeline.
+     */
+    public static function encodeCommand(string $command): string
+    {
+        return sprintf('echo %s | base64 -d | sh', base64_encode($command));
     }
 
     /**

--- a/tests/Unit/Commands/RunCommandTest.php
+++ b/tests/Unit/Commands/RunCommandTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Symfony\Component\Process\Process;
 use Codinglabs\Yolo\Commands\RunCommand;
 
 it('builds the execute-command invocation with a profile', function (): void {
@@ -51,4 +52,62 @@ it('omits --profile when none is configured (e.g. running on AWS)', function ():
 
     expect($args)->not->toContain('--profile');
     expect($args)->toContain('--command', 'php artisan migrate --force');
+});
+
+it('encodes a one-off command as a base64 decode-and-run pipeline', function (): void {
+    $command = "php artisan tinker --execute='\\App\\Models\\Foo::bar()'";
+
+    $encoded = RunCommand::encodeCommand($command);
+
+    expect($encoded)->toBe('echo ' . base64_encode($command) . ' | base64 -d | sh');
+    expect($encoded)->toMatch('/^echo [A-Za-z0-9+\/=]+ \| base64 -d \| sh$/');
+});
+
+it('survives a naive re-quoting hop that mangles a namespaced one-liner', function (): void {
+    // A namespaced PHP one-liner, properly single-quoted for the one shell
+    // that's meant to finally run it — the exact "Class not found" shape from
+    // the bug report reduces to this: printf stands in for `php artisan
+    // tinker --execute=...`, and `\App\Foo` stands in for the namespaced class.
+    $command = "printf %s '\\App\\Foo'";
+
+    // Confirm that shape is correct for a single parse — this is what the
+    // documented workaround (attach interactively, paste the command
+    // directly) gets right: exactly one shell reads it, so the single quotes
+    // do their job.
+    $direct = new Process(['sh', '-c', $command]);
+    $direct->mustRun();
+    expect($direct->getOutput())->toBe('\App\Foo');
+
+    // Simulate the extra hop between the terminal and the container: something
+    // in the chain (the AWS CLI, the SSM plugin, ECS's own exec wrapper — the
+    // exact culprit is opaque and undocumented) re-embeds the command inside
+    // another single-quoted shell string, the way a wrapper built by naive
+    // string concatenation would. `$command` already contains single quotes
+    // of its own, so they collide with the wrapper's — the shell closes the
+    // outer quote early, spilling `\App\Foo` into unquoted territory where a
+    // bare backslash is consumed rather than preserved.
+    $naivelyReEmbed = fn (string $text): string => "sh -c '{$text}'";
+
+    $mangled = new Process(['sh', '-c', $naivelyReEmbed($command)]);
+    $mangled->mustRun();
+    expect($mangled->getOutput())->toBe('AppFoo');
+
+    // The fix: wrap it first. The payload is pure `[A-Za-z0-9+/=]` — no single
+    // quotes, no backslashes — so the same naive re-embedding has nothing to
+    // collide with, and the original bytes reach the final decode intact.
+    $wrapped = RunCommand::encodeCommand($command);
+    expect($wrapped)->not->toContain("'");
+
+    $fixed = new Process(['sh', '-c', $naivelyReEmbed($wrapped)]);
+    $fixed->mustRun();
+    expect($fixed->getOutput())->toBe('\App\Foo');
+});
+
+it('propagates the exit code of the decoded command through the pipeline', function (): void {
+    $wrapped = RunCommand::encodeCommand('exit 7');
+
+    $process = new Process(['sh', '-c', $wrapped]);
+    $process->run();
+
+    expect($process->getExitCode())->toBe(7);
 });


### PR DESCRIPTION
## Summary

- `yolo run <env> --command="..."` sends the command string through an extra shell re-parse somewhere between the AWS CLI and the container's own `sh -c`. A command with embedded quotes and backslashes — a namespaced PHP one-liner passed to `tinker --execute=`, for example — can come out the other side mangled (a stray backslash silently consumed, turning a real class into a typo). Pasting the identical command into an interactive `yolo run` shell works fine, because that's only a single parse.
- Fix: base64-encode the command before it's handed to `aws ecs execute-command`, and decode it once, right before it actually runs (`echo <base64> | base64 -d | sh`). The payload in transit is pure `[A-Za-z0-9+/=]`, so no shell hop along the way has anything to reinterpret. Only the one-off `--command` path changes — the interactive `/bin/sh` shell is untouched, since its stdin needs to stay wired straight to the operator's terminal.
- Docs updated with a one-line note on `yolo run`.

## Test plan

- [x] Added a regression test that reproduces the mangling with a real `sh` process (a naive re-quoting hop that collides with a command's own single quotes) and shows the base64-wrapped form surviving the identical hop byte-for-byte.
- [x] Added coverage for the encode format and for exit-code propagation through the decode pipeline.
- [x] `./vendor/bin/pest` — 1835 passed
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `./vendor/bin/rector process --dry-run` — clean
- [x] `./vendor/bin/pint` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)