### PR TITLE
fix(build): pass APP_URL to build hooks

### DIFF
--- a/docs/guide/environment-files.md
+++ b/docs/guide/environment-files.md
@@ -43,6 +43,8 @@ This writes `.env.production` to your project root. Use it to review what's curr
 
 ## How it's used at deploy time
 
-You don't reference the env file in your `deploy` command — it's automatic. During `yolo build`, YOLO retrieves `.env.<environment>` from S3, stamps in the build's `APP_VERSION` (and `ASSET_URL`, mirrored into `VITE_ASSET_URL` so Vite sees the same prefix, when a CDN is configured), and bakes it into the image as `/app/.env`. Your `build` hooks (e.g. `npm run build`) run against that environment, and the running container uses it directly.
+You don't reference the env file in your `deploy` command — it's automatic. During `yolo build`, YOLO retrieves `.env.<environment>` from S3, stamps in the build's `APP_VERSION` (and `ASSET_URL`, mirrored into `VITE_ASSET_URL` so Vite sees the same prefix, when a CDN is configured), and bakes it into the image as `/app/.env`. The running container uses it directly.
+
+Your `build` hooks (e.g. `npm run build`) do **not** see that whole environment. The file is moved aside while they run, and each hook receives an allowlist of it instead — `APP_ENV`, `APP_URL`, `ASSET_URL` and every `VITE_*` key — so a hook can compile assets and bake the right origin into its output without being able to reach a live service (database, cache, queue) from the build host. To get another value to a hook, pass it through a `VITE_*` key.
 
 The bucket itself (`yolo-{account-id}-{env}-{app}-config`) is provisioned by [`yolo sync`](/guide/provisioning). Bucket names carry the AWS account id because S3 names are globally unique across every account — without it, the first account to claim a name owns it and every other account's sync fails.

--- a/src/Steps/ExecuteBuildCommandStep.php
+++ b/src/Steps/ExecuteBuildCommandStep.php
@@ -35,6 +35,7 @@ class ExecuteBuildCommandStep implements ExecutesCommandStep, LongRunning, RunsO
                     ->filter(fn ($value, $key): bool => in_array($key, [
                         'APP_ENV', // for npm
                         'ASSET_URL', // for vite
+                        'APP_URL', // for artisan hooks that bake in URLs
                     ]) || Str::startsWith($key, 'VITE_'))
                     ->toArray(),
                 ...[

--- a/tests/Unit/Steps/ExecuteBuildCommandStepTest.php
+++ b/tests/Unit/Steps/ExecuteBuildCommandStepTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\ExecuteBuildCommandStep;
+
+/**
+ * The build hook's env is an allowlist, not the whole file: the staged env
+ * holds live credentials, and a hook must not be able to reach a real service
+ * from the build host. These cases pin both halves — what crosses, and what
+ * must not.
+ *
+ * The step runs a real child process, so the assertions come from a script
+ * that dumps the env it was actually handed. Symfony merges that env into the
+ * parent's, so the withholding cases assert on keys the staged file defines
+ * and the surrounding shell does not.
+ */
+function runBuildHookDumpingEnv(string $stagedEnv): array
+{
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+
+    if (! is_dir(Paths::build())) {
+        mkdir(Paths::build(), 0755, true);
+    }
+
+    file_put_contents(Paths::build('.env.testing.tmp'), $stagedEnv);
+    file_put_contents(Paths::build('dump-env.sh'), "#!/bin/sh\nenv > env.dump\n");
+    chmod(Paths::build('dump-env.sh'), 0755);
+
+    $result = (new ExecuteBuildCommandStep('testing', './dump-env.sh'))();
+
+    expect($result)->toBe(StepResult::SUCCESS);
+
+    // Split by hand rather than through Dotenv: Symfony merges the given env
+    // into the parent's, so the dump also carries whatever the developer's (or
+    // CI's) shell holds, which need not be dotenv-parseable.
+    $dumped = [];
+
+    foreach (explode("\n", (string) file_get_contents(Paths::build('env.dump'))) as $line) {
+        if (str_contains($line, '=')) {
+            [$key, $value] = explode('=', $line, 2);
+            $dumped[$key] = $value;
+        }
+    }
+
+    foreach (['.env.testing.tmp', 'dump-env.sh', 'env.dump'] as $file) {
+        unlink(Paths::build($file));
+    }
+
+    return $dumped;
+}
+
+it('passes APP_URL to build hooks so baked artefacts carry the real origin', function (): void {
+    // Regression guard: a hook that bakes URLs into its output (a route
+    // manifest, an SSR bundle, a sitemap) reads APP_URL. Without it Laravel
+    // falls back to http://localhost and that origin ships inside the build.
+    $env = runBuildHookDumpingEnv("APP_URL=https://app.example.com\n");
+
+    expect($env)->toHaveKey('APP_URL')
+        ->and($env['APP_URL'])->toBe('https://app.example.com');
+});
+
+it('passes the build-facing keys through and withholds everything else', function (): void {
+    $env = runBuildHookDumpingEnv(implode("\n", [
+        'APP_ENV=production',
+        'APP_URL=https://app.example.com',
+        'ASSET_URL=https://cdn.example.com/builds/1',
+        'VITE_ASSET_URL=https://cdn.example.com/builds/1',
+        'DB_PASSWORD=hunter2',
+        'AWS_SECRET_ACCESS_KEY=shhh',
+        'REDIS_HOST=cache.internal',
+    ]) . "\n");
+
+    expect($env)
+        ->toHaveKeys(['APP_ENV', 'APP_URL', 'ASSET_URL', 'VITE_ASSET_URL'])
+        ->not->toHaveKey('DB_PASSWORD')
+        ->not->toHaveKey('AWS_SECRET_ACCESS_KEY')
+        ->not->toHaveKey('REDIS_HOST');
+});


### PR DESCRIPTION
## Problem

Build hooks receive an allowlist of the staged env (`APP_ENV`, `ASSET_URL`, `VITE_*`) rather than the whole file — deliberately, so a hook can't reach a live database, cache or queue from the build host.

`APP_URL` wasn't on that list. Any hook that bakes URLs into an artefact — a route manifest, a prerendered or SSR bundle, a sitemap — therefore booted with Laravel's `http://localhost` fallback and baked that origin into its output. The image's own `.env` is correct, so the app is configured right and nothing in it looks wrong; only the pre-built artefact carries the bad origin, and server-rendered markup then serves it to crawlers. Silent by construction.

## Change

- Add `APP_URL` to the build-hook allowlist in `ExecuteBuildCommandStep`. It names the app and doesn't reach anything, so the quarantine's guarantee is unchanged.
- Correct `docs/guide/environment-files.md`, which claimed build hooks "run against that environment" — they never have. The docs now state the allowlist and how to get another value through (a `VITE_*` key).

## Tests

New `tests/Unit/Steps/ExecuteBuildCommandStepTest.php` runs the step against a real child process that dumps the env it was handed, and asserts both halves of the contract:

- `APP_URL` crosses (verified failing before this change)
- the build-facing keys cross and staged secrets do not

`1946 passed`, Pint and PHPStan clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)