### PR TITLE
fix: resolve the real bucket name for AWS_BUCKET, not the raw manifest value

### DIFF
--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -149,7 +149,12 @@ class ConfigureEnvAndVersionStep implements Step
         }
 
         if (Manifest::has('bucket')) {
-            $defaults['AWS_BUCKET'] = Manifest::get('bucket');
+            // Paths::s3AppBucket(), not the raw manifest value: `bucket: true`
+            // means YOLO names and owns the bucket (Helpers::keyedBucketName),
+            // so the manifest value is the literal boolean `true` — writing it
+            // straight into AWS_BUCKET bakes the string "1" into the image,
+            // an invalid bucket name every S3 write then fails against.
+            $defaults['AWS_BUCKET'] = Paths::s3AppBucket();
             $defaults['FILESYSTEM_DISK'] = 's3';
         }
 

--- a/src/Steps/Build/ConfigureEnvAndVersionStep.php
+++ b/src/Steps/Build/ConfigureEnvAndVersionStep.php
@@ -149,11 +149,6 @@ class ConfigureEnvAndVersionStep implements Step
         }
 
         if (Manifest::has('bucket')) {
-            // Paths::s3AppBucket(), not the raw manifest value: `bucket: true`
-            // means YOLO names and owns the bucket (Helpers::keyedBucketName),
-            // so the manifest value is the literal boolean `true` — writing it
-            // straight into AWS_BUCKET bakes the string "1" into the image,
-            // an invalid bucket name every S3 write then fails against.
             $defaults['AWS_BUCKET'] = Paths::s3AppBucket();
             $defaults['FILESYSTEM_DISK'] = 's3';
         }

--- a/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
+++ b/tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php
@@ -3,6 +3,7 @@
 use Aws\Result;
 use Dotenv\Dotenv;
 use Codinglabs\Yolo\Paths;
+use Codinglabs\Yolo\Helpers;
 use GuzzleHttp\Psr7\Response;
 use Aws\Command as AwsCommand;
 use Aws\S3\Exception\S3Exception;
@@ -119,6 +120,26 @@ it('injects AWS_BUCKET from the manifest when the .env does not define it', func
     (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
 
     expect(file_get_contents(Paths::build('.env.testing')))->toContain('AWS_BUCKET=my-app-bucket');
+});
+
+it('injects the resolved keyed bucket name, not the literal manifest value, when the bucket is YOLO-managed', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2', 'bucket' => true,
+    ]);
+
+    if (! is_dir(Paths::build())) {
+        mkdir(Paths::build(), 0755, true);
+    }
+    if (file_exists(Paths::build('.env.testing'))) {
+        unlink(Paths::build('.env.testing'));
+    }
+
+    (new ConfigureEnvAndVersionStep('testing'))(['app-version' => '26.21.5.0611']);
+
+    $env = file_get_contents(Paths::build('.env.testing'));
+
+    expect($env)->toContain('AWS_BUCKET=' . Helpers::keyedBucketName('data'));
+    expect($env)->not->toContain('AWS_BUCKET=1');
 });
 
 it('does not inject AWS_BUCKET when the manifest does not define one', function (): void {


### PR DESCRIPTION
## Summary
- A YOLO-managed app bucket (`bucket: true`) means the manifest value is the literal boolean `true`, not a name. `Paths::s3AppBucket()` is what resolves it to the actual keyed bucket YOLO creates, but the build step's env-injection was writing `Manifest::get('bucket')` straight into `AWS_BUCKET` — baking the string `"1"` into every such app's image.
- Every S3 write on an app with `bucket: true` then fails against an invalid bucket name, and it's easy to miss: existing coverage only ever exercised the bring-your-own bucket-name case.
- Fix: use `Paths::s3AppBucket()`, the same resolver every other bucket-consuming call site already goes through — no behaviour change for BYO buckets, which already resolved correctly.

## Test plan
- [x] New regression test: `bucket: true` now asserts `AWS_BUCKET` equals the resolved keyed name and explicitly does not contain the literal `"1"`.
- [x] `vendor/bin/pest tests/Unit/Steps/Build/ConfigureEnvAndVersionStepTest.php` — 35/35 passed.
- [x] Full suite: `vendor/bin/pest --parallel` — 1947/1947 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)