### PR TITLE
Exclude local editor and AI tooling from the build context

### DIFF
--- a/src/Steps/Build/CopyApplicationStep.php
+++ b/src/Steps/Build/CopyApplicationStep.php
@@ -37,7 +37,9 @@ class CopyApplicationStep implements LongRunning
             '.git',
             '.github',
             '.phpunit.cache',
+            '.claude',
             '.idea',
+            '.vscode',
             '.yolo',
             'public/hot',
             'public/assets/next/*',
@@ -54,8 +56,10 @@ class CopyApplicationStep implements LongRunning
             // files
             '*.DS_Store',
             '.env.*',
+            '.mcp.json',
             '.php-cs-fixer.cache',
             '.phpunit.result.cache',
+            'CLAUDE.md',
             'public/assets/manifest.json',
         ];
 


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

- `CopyApplicationStep`'s rsync exclude list drops `.idea` but predates the tooling most repos now carry, so `.claude`, `.vscode`, `CLAUDE.md` and `.mcp.json` are staged into `.yolo/build` on every build.
- On a repo using git worktrees under `.claude/`, that tree gets large — 354 MB on the app that prompted this, including two worktrees with their own `vendor/` directories — so every build pays to copy it.
- It also reaches the image: the generated `Dockerfile` copies the app with a blanket `COPY . /app`, so anything staged into `.yolo/build` ships unless the consuming app remembers its own `.dockerignore` entry — `.claude/settings.local.json` included.
- None of it is read by the container, so excluding it centrally means every app gets the smaller context and image without maintaining its own list.

**Is there anything the reviewer needs to know to deploy this?**

- No deploy impact and no behaviour change for anything the image needs: `.env.{environment}` stays on the include list, and `vendor`, `public/build`, `docker/` and `.yolo-entrypoint.sh` are untouched. The next build of each consuming app simply stages and ships less.
- `.vscode` is included for consistency with the existing `.idea` entry.
- No test changes — the exclude array is a local inside `__invoke` and isn't currently covered. I didn't want to restructure the step just to assert a list, but happy to expose it if you'd rather have the coverage.
- `vendor/bin/pint` clean; `vendor/bin/pest tests/Unit/Steps` 462/462 passed.

🤖 Generated with [Claude Code](https://claude.ai/code)
