### PR TITLE
feat(queues): manifest-configurable SQS visibility timeout

### DIFF
--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -2,132 +2,128 @@
 
 `yolo.yml` is the single source of truth for your application's infrastructure. Both `yolo sync` (infrastructure) and `yolo deploy` (code) read from it. This page documents every key.
 
-## A complete example
+## A minimal manifest
 
-Every key YOLO understands, in one annotated `yolo.yml`. **Required keys are uncommented; everything else is commented out showing its default**, so you can copy this and uncomment only what you need to change. `yolo init` scaffolds a minimal subset of this — a plain web app whose one container runs all three roles (web, queue worker, scheduler).
+The smallest useful web app — one container running all three roles (web, queue worker, scheduler), which is what `yolo init` scaffolds:
 
 ```yaml
-name: codinglabs                 # required — app name, prefixes every app-scoped resource
-# timezone: Australia/Brisbane   # default UTC — sets the year.week build-version prefix
+name: my-app
 
 environments:
   production:
-    # --- Required ---
-    account-id: '123456789012'   # required — verified against your AWS profile via STS
-    region: ap-southeast-2       # required
+    account-id: '123456789012'
+    region: ap-southeast-2
+    domain: example.com
 
-    # --- Routing (see /guide/domains) ---
-    domain: example.com    # public domain — required for a web app; omit for a worker app
-    #                      # the apex is derived automatically from the matching Route 53 zone
-    #
-    # Multi-tenant: everything tenant-related nests under one key, and the app's
-    # own host moves to the landlord (a root `domain` is refused alongside it).
-    # multitenancy:
-    #   landlord:
-    #     domain: app.example.com
-    #     wildcard-subdomains: true    # tenants served at {tenant}.app.example.com
-    #   queue-isolation: dedicated     # default shared — a queue set per tenant
-    #   tenants:
-    #     acme:                        # bare — served under the landlord's wildcard
-    #     globex: { domain: globex.io }  # its own zone, certificate and rules
-
-    # --- CI deployer OIDC trust (see /guide/ci-cd) ---
-    # branch: main               # default: main — branch this env deploys from
-    # tag: 'v*'                  # deploy on a tag pattern instead of a branch
-    # repository: org/repo       # default: inferred from your git origin
-
-    # --- App storage & shared infra names ---
-    # bucket: true                                   # app S3 bucket (AWS_BUCKET) — YOLO names and creates it
-    #                                                # (a bucket name instead adopts one that already exists)
-
-    # --- Cache & session (any app with tasks defaults to the cache, web apps to sessions too; uncomment only to override) ---
-    # cache:
-    #   store: redis             # default; file/database/array to opt out of the shared Valkey
-    # session:
-    #   driver: redis            # default (sessions live on the Valkey cluster); database/cookie/file to change the session backend
-
-    # --- YOLO-provisioned services this app consumes ---
-    # services:            # bare capability names only — service shape is hardcoded or lives in the environment manifest
-    #   - ivs
-    #   - mediaconvert
-    #   - rekognition
-
-    # --- Extra IAM for this app's task role (per-app; never reaches another app) ---
-    # task-role-policies:
-    #   - arn:aws:iam::123456789012:policy/my-app-extra-access
-    #   - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
-
-    # --- SQS queues ---
-    # queues:                      # priority tiers, drained strict-priority; omit for one queue
-    #   - high
-    #   - default                  # Laravel's default queue — keeps the naked queue name
-    # queue-visibility-timeout: 90 # seconds SQS hides a delivered message; keep above your longest job
-
-    # Every app runs three roles — web, the queue worker, and the scheduler. With
-    # just `web` below they share the one web container; uncommenting `queue` and/or
-    # `scheduler` further down extracts them into their own service (see the cascade
-    # table under tasks.web.*).
     tasks:
       web:
-        cpu: '512'               # default: '512' — Fargate CPU units
-        memory: '1024'           # default: '1024' — Fargate memory (MB)
-        # enable-execute-command: false  # default: true — ECS Exec shell access (gated by MFA on the admin tier)
-        # ssr: true                       # default: false — bundle Inertia SSR (needs Node in the Dockerfile)
-        # platform: linux/amd64           # default: linux/amd64
-        # shutdown-grace-period: 15       # default: 15 — web SIGTERM→SIGKILL window (also the ALB drain)
-        # log-retention: 30               # default: 30 — CloudWatch Logs retention (days)
-        #
-        # health-check:
-        #   path: /up                     # default: /up (Laravel's built-in health route)
-        #   interval: 10                  # default: 10 (seconds between checks)
-        #   timeout: 5                    # default: 5 — tolerant of a slow /up under load
-        #   healthy-threshold: 2          # default: 2
-        #   unhealthy-threshold: 5        # default: 5 — cushion for a slow-but-alive task
-        #   grace-period: 60              # default: 60 (ECS health-check grace period)
-        #
-        autoscaling: true              # REQUIRED for web — true (min 1, max 5) | false (fixed single task) | a block
-        # autoscaling:                    # …or tune it (web min must be ≥ 1)
-        #   min: 1                        # default: 1
-        #   max: 5                        # default: 5
-        #   cpu-utilization: 65           # default: 65 — the CPU safety-net policy
-        #   scale-out-cooldown: 60        # default: 60
-        #   scale-in-cooldown: 300        # default: 300
-        #   # request concurrency is the default signal (derived from task memory); burst
-        #   # (~10s spike detection) is unconditional for octane — neither has a knob
-
-      # Extract the queue into its own ECS service (scale independently of web). Like
-      # web, a standalone queue must be a config map that declares `autoscaling` — there's
-      # no bare `queue: true` shorthand. `false` switches the worker off entirely (jobs run
-      # inline, QUEUE_CONNECTION=sync) and tears the SQS queue down. Set
-      # autoscaling.min: 0 to scale to zero when idle — except when it also hosts the
-      # scheduler (no `scheduler` block below), where min 0 is rejected so cron isn't
-      # killed when it idles.
-      # queue:
-      #   autoscaling:                    # required — true | false | a { min, max } block
-      #     min: 0                        # 0 = scale to zero when idle (floor defaults to 1)
-      #     max: 5                        # default: 5
-      #     backlog-per-task: 100         # default: 100 — target messages per running task
-      #   cpu: '256'                      # default: '256'
-      #   memory: '512'                   # default: '512'
-      #   spot: false                     # default: false — true = Fargate Spot (~70% cheaper)
-      #   shutdown-grace-period: 60       # default: 60 — let an in-flight job finish on SIGTERM
-      #   enable-execute-command: false   # default: true
-
-      # Extract the scheduler into its own pinned-singleton service (always one
-      # task; deploys stop-then-start so a rollout never runs two crons), which
-      # drops the onOneServer() requirement. Without this block the scheduler rides
-      # the standalone queue if there is one, else the web container.
-      # scheduler:
-      #   cpu: '256'                      # default: '256'
-      #   memory: '512'                   # default: '512'
-      #   shutdown-grace-period: 115      # default: 115 — the in-flight schedule:run gets the whole stop window
-      #   enable-execute-command: false   # default: true
+        autoscaling: true
 
     build:
       - composer install --no-cache --no-interaction --optimize-autoloader --no-progress --classmap-authoritative --no-dev
       - npm ci
       - npm run build
-      - rm -rf package-lock.json node_modules database/seeders database/factories
+
+    deploy:
+      - php artisan migrate --force
+```
+
+## The full shape
+
+Every key YOLO understands, each value showing its default where one exists. This is a reference skeleton, not a valid manifest — some keys are mutually exclusive (a root `domain` is refused alongside `multitenancy`; `branch` and `tag` are alternatives) — so jump to a key's section below for its semantics before copying it.
+
+```yaml
+name: my-app
+timezone: UTC
+
+environments:
+  production:
+    account-id: '123456789012'
+    region: ap-southeast-2
+
+    domain: example.com
+    wildcard-subdomains: false
+
+    multitenancy:
+      landlord:
+        domain: app.example.com
+        wildcard-subdomains: true
+      queue-isolation: shared
+      tenants:
+        acme:
+        globex: { domain: globex.io }
+
+    branch: main
+    tag: 'v*'
+    repository: org/repo
+
+    bucket: true
+    database: my-database
+    services:
+      - ivs
+      - mediaconvert
+      - rekognition
+
+    cache:
+      store: redis
+    session:
+      driver: redis
+
+    queues:
+      - high
+      - default
+    queue-visibility-timeout: 90
+
+    task-role-policies:
+      - arn:aws:iam::123456789012:policy/my-app-extra-access
+
+    budget:
+      amount: 100
+      strategy: balanced
+
+    tasks:
+      web:
+        octane: true
+        cpu: '512'
+        memory: '1024'
+        platform: linux/amd64
+        enable-execute-command: true
+        shutdown-grace-period: 15
+        log-retention: 30
+        ssr: false
+        health-check:
+          path: /up
+          interval: 10
+          timeout: 5
+          healthy-threshold: 2
+          unhealthy-threshold: 5
+          grace-period: 60
+        autoscaling:
+          min: 1
+          max: 5
+          cpu-utilization: 65
+          scale-out-cooldown: 60
+          scale-in-cooldown: 300
+      queue:
+        autoscaling:
+          min: 1
+          max: 5
+          backlog-per-task: 100
+        cpu: '256'
+        memory: '512'
+        spot: false
+        shutdown-grace-period: 60
+        enable-execute-command: true
+      scheduler:
+        cpu: '256'
+        memory: '512'
+        shutdown-grace-period: 115
+        enable-execute-command: true
+
+    build:
+      - composer install --no-cache --no-interaction --optimize-autoloader --no-progress --classmap-authoritative --no-dev
+      - npm ci
+      - npm run build
 
     deploy:
       - php artisan migrate --force
@@ -136,7 +132,13 @@ environments:
       - php artisan optimize
 ```
 
-> Every commented key above has its own section below with the full semantics — this block is the map; the sections are the detail.
+| Area | Keys |
+|---|---|
+| App | [`name`](#name), [`timezone`](#timezone), [`environments`](#environments) |
+| Routing | [`domain`](#domain), [`wildcard-subdomains`](#wildcard-subdomains), [`multitenancy`](#multitenancy), [`branch` / `tag` / `repository`](#branch-tag-repository) |
+| Infrastructure | [`account-id`](#account-id), [`region`](#region), [`bucket`](#bucket), [`database`](#database), [`services`](#services), [`cache.store`](#cache), [`session.driver`](#session), [`queues`](#queues), [`queue-visibility-timeout`](#queue-visibility-timeout), [`task-role-policies`](#task-role-policies), [`budget`](#budget) |
+| Tasks | [`tasks.web`](#tasks-web), [`tasks.web.health-check`](#tasks-web-health-check), [`tasks.web.autoscaling`](#tasks-web-autoscaling), [`tasks.queue`](#tasks-queue), [`tasks.scheduler`](#tasks-scheduler) |
+| Hooks | [`build`](#build), [`deploy`](#deploy), [`deploy-all`](#deploy-all) |
 
 ::: warning Required keys
 Every command except `init` fails fast unless these three are present:
@@ -292,10 +294,6 @@ The value says **who owns the bucket**, and that is the whole difference:
 - **It exists in another AWS account.** S3's bucket namespace is global, so a name someone else has taken answers a probe with a 403 that is indistinguishable from "yours, but this tier may not read it". Adopting one of those would sync perfectly cleanly, grant the task role an ARN in a foreign account, and then fail every runtime write — so ownership is resolved from this account's own bucket listing, and a name that isn't in it is refused by name.
 
 A bucket name S3 would reject (wrong case, too short, doubled dots, IP-shaped) also fails validation here rather than surfacing as an `InvalidBucketName` part-way through an apply.
-
-### `alb`
-
-Name of the Application Load Balancer to use. Defaults to the per-environment shared `yolo-{env}` ALB.
 
 ### `services`
 

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -57,6 +57,12 @@ environments:
     #   - arn:aws:iam::123456789012:policy/my-app-extra-access
     #   - arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess
 
+    # --- SQS queues ---
+    # queues:                      # priority tiers, drained strict-priority; omit for one queue
+    #   - high
+    #   - default                  # Laravel's default queue — keeps the naked queue name
+    # queue-visibility-timeout: 90 # seconds SQS hides a delivered message; keep above your longest job
+
     # Every app runs three roles — web, the queue worker, and the scheduler. With
     # just `web` below they share the one web container; uncommenting `queue` and/or
     # `scheduler` further down extracts them into their own service (see the cascade
@@ -328,6 +334,24 @@ task-role-policies:
 ```
 
 The list is reconciled on every `yolo sync`: an ARN you add gets attached, and one you remove gets detached — the role's attachment set is YOLO's to own, so there's no left-behind grant. Each entry must be a customer- or AWS-managed IAM policy ARN; a malformed value fails the sync plan rather than silently dropping the grant. The YOLO baseline policy (ECS Exec channels, this app's SQS queues, SES send, and read+write on the [`bucket`](#bucket) when declared) is always attached and isn't listed here.
+
+### `queues`
+
+A list of queue **tier names in strict-priority order** — the worker drains the first tier to empty before glancing at the next (the comma-list semantics of Laravel's `--queue`). Declaring tiers provisions one SQS queue per tier per scope: `high` becomes `yolo-{env}-{app}-high` while the `default` tier keeps the naked scope name (it's Laravel's default queue, so un-routed jobs keep landing on it and adding tiers never renames it). On a multi-tenant app with [`queue-isolation: dedicated`](#multitenancy-queue-isolation), every tenant (and the landlord) gets the full tier set.
+
+```yaml
+queues:
+  - high
+  - default
+```
+
+Tiers are names only — the map form (`queues: {high: ...}`) is rejected. Omit the block entirely for a single queue at the app's name.
+
+### `queue-visibility-timeout`
+
+How long SQS hides a delivered message before re-delivering it, in seconds — the visibility timeout on every queue the app provisions (all tiers, every tenant scope). Default `90`; SQS caps it at `43200` (12 hours).
+
+Visibility must outlast your longest job: a message re-delivered while its job is still running executes the job twice, so keep this above the worker's job timeout (60s unless a job declares its own `$timeout`). Raise it in step with long-running jobs — and consider [`tasks.queue.shutdown-grace-period`](#tasks-queue) alongside it, so an in-flight long job also survives a deploy's drain window. The value is reconciled on every `yolo sync`, so a change reaches already-provisioned queues.
 
 ---
 

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -16,9 +16,6 @@ class Manifest
     /** Keys allowed at the manifest root, outside `environments`. */
     protected const ALLOWED_ROOT_KEYS = ['name', 'timezone', 'environments'];
 
-    /** {@see queueVisibilityTimeout} for why 90 and why app-wide. */
-    public const int DEFAULT_QUEUE_VISIBILITY_TIMEOUT = 90;
-
     /**
      * An in-memory manifest that stands in for yolo.yml when set. Default null —
      * every command reads the file from disk, unchanged. `destroy:environment`
@@ -1395,15 +1392,17 @@ class Manifest
      */
     public static function queueVisibilityTimeout(): int
     {
-        $value = static::get('queue-visibility-timeout', self::DEFAULT_QUEUE_VISIBILITY_TIMEOUT);
+        $seconds = Helpers::validatePositiveInt(
+            static::get('queue-visibility-timeout', 90),
+            'queue-visibility-timeout',
+        );
 
-        if (! is_int($value) || $value < 1 || $value > 43200) {
-            throw new IntegrityCheckException(sprintf(
-                'Invalid queue-visibility-timeout "%s" — expected a whole number of seconds between 1 and 43200 (12 hours, the SQS maximum).',
-                is_scalar($value) ? $value : gettype($value),
-            ));
+        if ($seconds > 43200) {
+            throw new IntegrityCheckException(
+                'queue-visibility-timeout must be at most 43200 (12 hours, the SQS maximum)',
+            );
         }
 
-        return $value;
+        return $seconds;
     }
 }

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -16,6 +16,9 @@ class Manifest
     /** Keys allowed at the manifest root, outside `environments`. */
     protected const ALLOWED_ROOT_KEYS = ['name', 'timezone', 'environments'];
 
+    /** {@see queueVisibilityTimeout} for why 90 and why app-wide. */
+    public const int DEFAULT_QUEUE_VISIBILITY_TIMEOUT = 90;
+
     /**
      * An in-memory manifest that stands in for yolo.yml when set. Default null —
      * every command reads the file from disk, unchanged. `destroy:environment`
@@ -72,6 +75,7 @@ class Manifest
         'multitenancy.tenants.*.domain',
         'multitenancy.tenants.*.wildcard-subdomains',
         'queues.*',
+        'queue-visibility-timeout',
         'bucket',
         'services',
         'database',
@@ -1347,11 +1351,13 @@ class Manifest
      * block returns `[]`: the app runs a single queue at its own name
      * (Helpers::queueNames).
      *
-     * Tiers are names only. Per-queue configuration (visibility timeout, retention,
-     * alarms) isn't a knob any consumer needs yet — sensible defaults are hardcoded on
-     * the Queue resource — so a map form (`queues: {high: …}`) is rejected rather than
-     * half-supported. When real per-tier config lands it introduces the map form
-     * alongside this list, not in place of it, so the list stays valid.
+     * Tiers are names only. Visibility timeout is deliberately app-wide
+     * ({@see queueVisibilityTimeout} — every tier drains through the one worker
+     * command with a single job timeout, so a per-tier value would have nothing to
+     * pair with), and no other per-tier knob has a consumer yet, so a map form
+     * (`queues: {high: …}`) is rejected rather than half-supported. When real
+     * per-tier config lands it introduces the map form alongside this list, not in
+     * place of it, so the list stays valid.
      *
      * @return array<int, string>
      */
@@ -1372,5 +1378,32 @@ class Manifest
         }
 
         return array_map(static fn ($tier): string => (string) $tier, $queues);
+    }
+
+    /**
+     * How long SQS hides a delivered message before re-delivering it, in seconds —
+     * the queue's VisibilityTimeout, applied to every queue the app provisions
+     * (all tiers, every tenant scope). One app-wide value rather than per-tier:
+     * visibility exists to outlast job runtime, and every tier drains through the
+     * same worker command with a single job timeout, so per-tier values would have
+     * nothing to pair with.
+     *
+     * The default clears the worker's default 60s job timeout with margin — a
+     * visibility below the job timeout re-delivers a message whose job is still
+     * running, so the job executes twice. Raise it in step with the app's
+     * longest-running job.
+     */
+    public static function queueVisibilityTimeout(): int
+    {
+        $value = static::get('queue-visibility-timeout', self::DEFAULT_QUEUE_VISIBILITY_TIMEOUT);
+
+        if (! is_int($value) || $value < 1 || $value > 43200) {
+            throw new IntegrityCheckException(sprintf(
+                'Invalid queue-visibility-timeout "%s" — expected a whole number of seconds between 1 and 43200 (12 hours, the SQS maximum).',
+                is_scalar($value) ? $value : gettype($value),
+            ));
+        }
+
+        return $value;
     }
 }

--- a/src/Resources/Sqs/Queue.php
+++ b/src/Resources/Sqs/Queue.php
@@ -3,20 +3,25 @@
 namespace Codinglabs\Yolo\Resources\Sqs;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Aws\Sqs;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Aws\Sqs\Exception\SqsException;
 use Codinglabs\Yolo\Resources\Resource;
 use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * An SQS queue, addressed by its full name so the solo, tenant and landlord
- * steps share one resource. Messages are retained for 14 days. App-scoped, so it
- * carries the yolo:app owner tag for `yolo audit`.
+ * steps share one resource. Messages are retained for 14 days; visibility
+ * timeout comes from the manifest (`queue-visibility-timeout`) and is
+ * reconciled onto existing queues, so raising it reaches every queue on the
+ * next sync. App-scoped, so it carries the yolo:app owner tag for `yolo audit`.
  */
-class Queue implements Deletable, Resource
+class Queue implements Deletable, Resource, SynchronisesConfiguration
 {
     use ResolvesTags;
 
@@ -57,9 +62,7 @@ class Queue implements Deletable, Resource
     {
         Aws::sqs()->createQueue([
             'QueueName' => $this->queueName,
-            'Attributes' => [
-                'MessageRetentionPeriod' => '1209600', // 14 days
-            ],
+            'Attributes' => $this->desiredAttributes(),
             ...Aws::tags($this->tags(), wrap: 'tags', associative: true),
         ]);
     }
@@ -67,6 +70,53 @@ class Queue implements Deletable, Resource
     public function synchroniseTags(bool $apply): array
     {
         return Aws::synchroniseSqsTags($this->url(), $this->tags(), $apply);
+    }
+
+    /**
+     * Reconcile the managed attributes on an existing queue. SQS reports every
+     * attribute as a string, so the desired map is string-valued and compared
+     * strictly. Reads only this queue's own live state, so the plan pass is safe
+     * before any sibling exists (the two-pass contract).
+     *
+     * @return array<int, Change>
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $queue = Sqs::queue($this->queueName);
+        $live = $queue['Attributes'] ?? [];
+
+        $changes = [];
+
+        foreach ($this->desiredAttributes() as $attribute => $desired) {
+            if (($live[$attribute] ?? null) !== $desired) {
+                $changes[] = Change::make($attribute, $live[$attribute] ?? null, $desired);
+            }
+        }
+
+        if ($changes !== [] && $apply) {
+            Aws::sqs()->setQueueAttributes([
+                'QueueUrl' => $queue['QueueUrl'],
+                'Attributes' => $this->desiredAttributes(),
+            ]);
+        }
+
+        return $changes;
+    }
+
+    /**
+     * The queue attributes YOLO owns, on create and on reconcile alike.
+     * Retention stays hardcoded (no consumer needs a knob); visibility is the
+     * manifest's, because it has to track the app's job runtime — a message
+     * re-delivered while its job is still running executes twice.
+     *
+     * @return array<string, string>
+     */
+    protected function desiredAttributes(): array
+    {
+        return [
+            'MessageRetentionPeriod' => '1209600', // 14 days
+            'VisibilityTimeout' => (string) Manifest::queueVisibilityTimeout(),
+        ];
     }
 
     /**

--- a/tests/Unit/ManifestTest.php
+++ b/tests/Unit/ManifestTest.php
@@ -130,6 +130,38 @@ describe('queue tiers', function (): void {
     });
 });
 
+describe('queue visibility timeout', function (): void {
+    it('defaults the visibility timeout past the worker\'s default job timeout', function (): void {
+        writeManifest([]);
+
+        expect(Manifest::queueVisibilityTimeout())->toBe(90);
+    });
+
+    it('reads a declared visibility timeout', function (): void {
+        writeManifest(['queue-visibility-timeout' => 900]);
+
+        expect(Manifest::queueVisibilityTimeout())->toBe(900);
+    });
+
+    it('accepts queue-visibility-timeout through the manifest validator', function (): void {
+        writeManifest(['queue-visibility-timeout' => 900]);
+
+        expect(Manifest::unknownKeys())->toBe([]);
+    });
+
+    it('hard-fails on a non-integer visibility timeout', function (): void {
+        writeManifest(['queue-visibility-timeout' => '5 minutes']);
+
+        expect(fn (): int => Manifest::queueVisibilityTimeout())->toThrow(IntegrityCheckException::class);
+    });
+
+    it('hard-fails on a visibility timeout outside the SQS bounds', function (int $seconds): void {
+        writeManifest(['queue-visibility-timeout' => $seconds]);
+
+        expect(fn (): int => Manifest::queueVisibilityTimeout())->toThrow(IntegrityCheckException::class);
+    })->with([0, 43201]);
+});
+
 describe('queue isolation', function (): void {
     it('defaults a multi-tenant app to shared queues', function (): void {
         writeManifest(['multitenancy' => ['tenants' => ['acme' => [], 'globex' => []]]]);

--- a/tests/Unit/Resources/Sqs/QueueTest.php
+++ b/tests/Unit/Resources/Sqs/QueueTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Resources\Sqs\Queue;
+
+it('creates a queue with the retention and visibility attributes', function (): void {
+    writeManifest(['queue-visibility-timeout' => 900]);
+
+    $captured = [];
+    bindMockSqsClient([], $captured);
+
+    (new Queue('yolo-testing-my-app'))->create();
+
+    expect($captured[0]['name'])->toBe('CreateQueue')
+        ->and($captured[0]['args']['Attributes'])->toBe([
+            'MessageRetentionPeriod' => '1209600',
+            'VisibilityTimeout' => '900',
+        ]);
+});
+
+it('reports an in-sync queue clean without writing', function (): void {
+    $queueUrl = 'https://sqs.ap-southeast-2.amazonaws.com/1234/yolo-testing-my-app';
+    writeManifest([]);
+
+    $captured = [];
+    bindMockSqsClient([
+        'ListQueues' => new Result(['QueueUrls' => [$queueUrl]]),
+        'GetQueueAttributes' => new Result(['Attributes' => [
+            'MessageRetentionPeriod' => '1209600',
+            'VisibilityTimeout' => '90',
+        ]]),
+    ], $captured);
+
+    $changes = (new Queue('yolo-testing-my-app'))->synchroniseConfiguration();
+
+    expect($changes)->toBe([])
+        ->and(array_column($captured, 'name'))->not->toContain('SetQueueAttributes');
+});
+
+it('reconciles a drifted visibility timeout onto an existing queue', function (): void {
+    $queueUrl = 'https://sqs.ap-southeast-2.amazonaws.com/1234/yolo-testing-my-app';
+    writeManifest(['queue-visibility-timeout' => 900]);
+
+    $captured = [];
+    bindMockSqsClient([
+        'ListQueues' => new Result(['QueueUrls' => [$queueUrl]]),
+        'GetQueueAttributes' => new Result(['Attributes' => [
+            'MessageRetentionPeriod' => '1209600',
+            'VisibilityTimeout' => '30',
+        ]]),
+    ], $captured);
+
+    $changes = (new Queue('yolo-testing-my-app'))->synchroniseConfiguration();
+
+    expect($changes)->toHaveCount(1)
+        ->and($changes[0]->attribute)->toBe('VisibilityTimeout')
+        ->and($changes[0]->from)->toBe('30')
+        ->and($changes[0]->to)->toBe('900');
+
+    $setAttributes = array_values(array_filter($captured, fn (array $call): bool => $call['name'] === 'SetQueueAttributes'));
+
+    expect($setAttributes)->toHaveCount(1)
+        ->and($setAttributes[0]['args']['QueueUrl'])->toBe($queueUrl)
+        ->and($setAttributes[0]['args']['Attributes'])->toBe([
+            'MessageRetentionPeriod' => '1209600',
+            'VisibilityTimeout' => '900',
+        ]);
+});
+
+it('computes visibility drift on the plan pass without writing', function (): void {
+    $queueUrl = 'https://sqs.ap-southeast-2.amazonaws.com/1234/yolo-testing-my-app';
+    writeManifest(['queue-visibility-timeout' => 900]);
+
+    $captured = [];
+    bindMockSqsClient([
+        'ListQueues' => new Result(['QueueUrls' => [$queueUrl]]),
+        'GetQueueAttributes' => new Result(['Attributes' => [
+            'MessageRetentionPeriod' => '1209600',
+            'VisibilityTimeout' => '30',
+        ]]),
+    ], $captured);
+
+    $changes = (new Queue('yolo-testing-my-app'))->synchroniseConfiguration(apply: false);
+
+    expect($changes)->toHaveCount(1)
+        ->and(array_column($captured, 'name'))->not->toContain('SetQueueAttributes');
+});
+
+it('treats a queue created before visibility was managed as drifted', function (): void {
+    $queueUrl = 'https://sqs.ap-southeast-2.amazonaws.com/1234/yolo-testing-my-app';
+    writeManifest([]);
+
+    $captured = [];
+    bindMockSqsClient([
+        'ListQueues' => new Result(['QueueUrls' => [$queueUrl]]),
+        'GetQueueAttributes' => new Result(['Attributes' => [
+            'MessageRetentionPeriod' => '1209600',
+            // SQS reports its own default when the attribute was never set explicitly
+            'VisibilityTimeout' => '30',
+        ]]),
+    ], $captured);
+
+    $changes = (new Queue('yolo-testing-my-app'))->synchroniseConfiguration(apply: false);
+
+    expect($changes)->toHaveCount(1)
+        ->and($changes[0]->describe())->toBe('VisibilityTimeout: 30 → 90');
+});


### PR DESCRIPTION
## Why

Every queue YOLO provisions ran on SQS's default 30s visibility timeout, while the worker runs with Laravel's default 60s job timeout — so a message whose job takes 30–60s can be re-delivered mid-run and executed twice. There was no knob to raise it for long-running jobs.

## What

- **New manifest key `queue-visibility-timeout`** (seconds, default `90`). App-wide by design: every tier drains through the one worker command with a single job timeout, so a per-tier value would have nothing to pair with — `Manifest::queueTiers()`'s "map form comes later" contract is untouched.
- **Default raised from SQS's 30 to 90**, clearing the worker's default 60s job timeout with margin. Existing queues will show one drift line on their next sync plan and self-heal on apply.
- **Validation hard-fails** on a non-integer or a value outside SQS's 1–43200 bounds, rather than letting AWS reject it mid-apply.
- **`Queue` now implements `SynchronisesConfiguration`** — visibility timeout and retention reconcile onto already-provisioned queues instead of only landing at create. The reconcile reads only the queue's own live state, so the plan pass survives with nothing created yet (two-pass contract).
- **Docs**: manifest reference gains `queues` (previously undocumented) and `queue-visibility-timeout` sections plus complete-example entries; VitePress build green.

## Untested server-contract assumptions

MockHandler proves request shape only: assumes `GetQueueAttributes` reports `VisibilityTimeout` as a string for queues created without it (SQS documents the 30s default as always reported), and that `SetQueueAttributes` accepts the full managed-attribute map. Worth watching the first real sync's plan → apply → clean-second-plan cycle.

## Validation

- 1,977 tests green (5 new resource tests + 6 new manifest tests)
- Rector, Pint, PHPStan clean; docs build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)