### PR TITLE
Accept a list for multitenancy.landlord.domain

### DIFF
--- a/docs/guide/multi-tenancy.md
+++ b/docs/guide/multi-tenancy.md
@@ -25,6 +25,16 @@ wildcard-subdomains: true  # …and every subdomain of it, one label deep
 
 `apex` is never declared — YOLO derives it from `domain` by walking the domain's labels against the hosted zones in the account, so a certificate lands on the right zone with nothing to configure.
 
+The landlord's `domain` also accepts a list, for a landlord serving several brand domains off the one app:
+
+```yaml
+    multitenancy:
+      landlord:
+        domain: [app.example.com, app.example.io]
+```
+
+The first entry stays canonical — `wildcard-subdomains`, the apex/`www` redirect and the certificate's own name all key off it. Every entry rides the same certificate as an additional SAN and gets its own forward-rule host-header value and Route 53 record in its own apex zone, with nothing inferred between them (no wildcard, no redirect, no shared zone assumed for the extra ones).
+
 ## Tenant in the route
 
 The app serves one host and reads the tenant off the URL — `app.example.com/acme`, or a header, or the session. Nothing about that is visible to AWS, so the manifest is a landlord and nothing else:

--- a/docs/reference/manifest.md
+++ b/docs/reference/manifest.md
@@ -215,6 +215,18 @@ The landlord's own hosting, using the same shape a tenant does: a `domain`, opti
 
 Optional — omit it for a multi-tenant app with no landlord host, where every tenant brings its own domain. The `:443` listener then takes its default certificate from the first tenant by sorted id.
 
+`domain` also accepts a list, for a landlord serving several brand domains off one app:
+
+```yaml
+multitenancy:
+  landlord:
+    domain:
+      - app.example.com
+      - app.example.io
+```
+
+The first entry is canonical — it's what `wildcard-subdomains`, the apex/`www` redirect and the app's certificate name key off. Every entry (including the first) rides the same certificate as an additional SAN, gets its own host-header value on the app's forward rule, and its own Route 53 alias record in its own apex zone. Nothing is inferred between the extra entries — no wildcard, no apex/`www` redirect, no shared zone assumed — each is served exactly as declared. Limited to what ALB's host-header condition holds (5 values, including the wildcard when `wildcard-subdomains` is on).
+
 #### `multitenancy.tenants`
 
 A map of tenant id → that tenant's config. The id identifies that tenant's resources throughout YOLO.

--- a/src/Commands/Command.php
+++ b/src/Commands/Command.php
@@ -169,7 +169,8 @@ abstract class Command extends SymfonyCommand
             && $this->ensureAutoscalingDeclared()
             && $this->ensureSchedulerHostNotScaleToZero()
             && $this->ensureQueueIsolationValid()
-            && $this->ensureWildcardSubdomainsValid();
+            && $this->ensureWildcardSubdomainsValid()
+            && $this->ensureLandlordDomainsValid();
     }
 
     /**
@@ -254,6 +255,65 @@ abstract class Command extends SymfonyCommand
                 'yolo.yml declares `wildcard-subdomains` with a www-canonical `domain` (%s) — the wildcard would land at *.%s and the certificate would no longer cover the apex it redirects from. Serve the app from the apex or a bare subdomain instead.',
                 $domain,
                 $domain,
+            ));
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * `multitenancy.landlord.domain` accepts a bare string or a list — every
+     * declared host, once normalised by {@see Manifest::domains()}, must be a
+     * non-empty string with no duplicates, so a malformed value (an empty list, a
+     * blank entry, a repeated host) is refused here with a pointed message rather
+     * than surfacing later as a cryptic ACM/ALB/Route 53 failure or a silently
+     * dropped duplicate host-header value.
+     */
+    protected function ensureLandlordDomainsValid(): bool
+    {
+        if (! Manifest::isMultitenanted() || ! Manifest::has('multitenancy.landlord.domain')) {
+            return true;
+        }
+
+        $raw = Manifest::get('multitenancy.landlord.domain');
+        $hosts = is_array($raw) ? $raw : [$raw];
+
+        if ($hosts === []) {
+            error('yolo.yml declares `multitenancy.landlord.domain` as an empty list — declare at least one host, or drop the key.');
+
+            return false;
+        }
+
+        foreach ($hosts as $host) {
+            if (! is_string($host) || trim($host) === '') {
+                error(sprintf(
+                    'yolo.yml declares `multitenancy.landlord.domain` with a blank or non-string entry (%s) — every host must be a non-empty string.',
+                    json_encode($host),
+                ));
+
+                return false;
+            }
+        }
+
+        if (count($hosts) !== count(array_unique($hosts))) {
+            error('yolo.yml declares `multitenancy.landlord.domain` with a duplicate host — each entry must be unique.');
+
+            return false;
+        }
+
+        // Every declared host rides the same ALB forward rule as a host-header
+        // condition value, plus the wildcard when wildcard-subdomains is on — ALB
+        // caps a rule at 5 host-header values, so fail here with a pointed message
+        // rather than a bare AWS InvalidConfigurationRequest at sync time.
+        $hostHeaderValues = count($hosts) + (Manifest::servesWildcardSubdomains() ? 1 : 0);
+
+        if ($hostHeaderValues > 5) {
+            error(sprintf(
+                'yolo.yml declares %d landlord domain(s)%s — ALB allows at most 5 host-header values per rule. Reduce the list, or split the extra hosts onto their own app.',
+                count($hosts),
+                Manifest::servesWildcardSubdomains() ? ' plus wildcard-subdomains' : '',
             ));
 
             return false;

--- a/src/Concerns/SyncsRecordSets.php
+++ b/src/Concerns/SyncsRecordSets.php
@@ -3,6 +3,7 @@
 namespace Codinglabs\Yolo\Concerns;
 
 use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Aws\ElbV2;
 use Codinglabs\Yolo\Aws\Route53;
 use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
@@ -13,25 +14,42 @@ trait SyncsRecordSets
 
     public function syncRecordSet(string $apex, string $domain, ?string $wildcardHost): void
     {
+        $this->writeAliasRecords($apex, $this->aliasedHosts($apex, $domain, $wildcardHost));
+    }
+
+    /**
+     * UPSERTs a single A-alias record for one additional landlord host — no
+     * apex/`www` sibling and no wildcard inferred, since an additional host is
+     * served exactly as declared. Its own apex may differ from the app's primary
+     * domain (a landlord serving several brands), so the caller resolves it via
+     * {@see Manifest::deriveApex()} rather than this trait
+     * assuming it shares the primary's zone.
+     */
+    public function syncAdditionalHostRecordSet(string $apex, string $host): void
+    {
+        $this->writeAliasRecords($apex, [$host]);
+    }
+
+    /**
+     * @param  array<int, string>  $hosts
+     */
+    protected function writeAliasRecords(string $apex, array $hosts): void
+    {
         Aws::route53()->changeResourceRecordSets([
             'ChangeBatch' => [
-                'Changes' => $this->generateChanges($apex, $domain, $wildcardHost),
+                'Changes' => $this->generateChanges($hosts),
                 'Comment' => 'Created by yolo CLI',
             ],
             'HostedZoneId' => Route53::hostedZone($apex)['Id'],
         ]);
     }
 
-    protected function generateChanges(string $apex, string $domain, ?string $wildcardHost): array
+    /**
+     * @param  array<int, string>  $hosts
+     */
+    protected function generateChanges(array $hosts): array
     {
         $ALB = ElbV2::loadBalancer((new LoadBalancer())->name());
-
-        // The canonical host plus, when it's one half of the apex/www pair, its
-        // sibling — both resolve to the ALB so the redirect rule can 301 the
-        // sibling to the canonical host. A bare subdomain has no sibling. A
-        // wildcard-subdomain app adds `*.{domain}`, so every subdomain resolves
-        // without a record per tenant.
-        $hosts = $this->aliasedHosts($apex, $domain, $wildcardHost);
 
         return array_map(fn (string $host): array => [
             'Action' => 'UPSERT',

--- a/src/Manifest.php
+++ b/src/Manifest.php
@@ -7,9 +7,12 @@ use Codinglabs\Yolo\Aws\Rds;
 use Codinglabs\Yolo\Aws\Route53;
 use Symfony\Component\Yaml\Yaml;
 use Codinglabs\Yolo\Enums\Service;
+use Codinglabs\Yolo\Commands\Command;
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Enums\QueueIsolation;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+use Codinglabs\Yolo\Steps\Sync\App\Solo\SyncHostedZoneStep;
+use Codinglabs\Yolo\Steps\Destroy\App\WithdrawAppDnsRecordsStep;
 
 class Manifest
 {
@@ -1004,7 +1007,11 @@ class Manifest
     }
 
     /**
-     * The host this app is served on, or null when it has none.
+     * The host this app is served on, or null when it has none — the primary/
+     * canonical entry of {@see domains()}. Every single-host consumer (apex
+     * derivation, the certificate's primary name, the app's own DNS record, the
+     * apex/`www` redirect) keys off this one; {@see additionalDomains()} names
+     * whatever else `domains()` holds.
      *
      * The single source for "the app's domain", because it lives in two places by
      * design: a solo app declares `domain` at the root of the environment block,
@@ -1016,16 +1023,77 @@ class Manifest
      */
     public static function domain(): ?string
     {
-        $domain = static::isMultitenanted()
+        return static::domains()[0] ?? null;
+    }
+
+    /**
+     * Every host this app's landlord is served on — normally one, but a
+     * multi-tenant landlord may declare a list (`multitenancy.landlord.domain:
+     * [app.example.com, app.example.io]`) to serve several brands off one
+     * certificate and target group. A solo app's root `domain` stays single-host
+     * (validation refuses an array there — see {@see ensureLandlordDomainsValid}
+     * on {@see Command}). Normalised once here so every
+     * caller reads a plain list regardless of whether yolo.yml wrote a string or
+     * an array; {@see domain()} returns the first entry, {@see additionalDomains()}
+     * the rest.
+     *
+     * @return array<int, string>
+     */
+    public static function domains(): array
+    {
+        $raw = static::isMultitenanted()
             ? static::get('multitenancy.landlord.domain')
             : static::get('domain');
 
-        return $domain === null ? null : (string) $domain;
+        if ($raw === null) {
+            return [];
+        }
+
+        return array_values(array_unique(array_map(
+            static fn (mixed $host): string => (string) $host,
+            is_array($raw) ? $raw : [$raw],
+        )));
+    }
+
+    /**
+     * Every landlord host beyond the primary/canonical one — the hosts that ride
+     * the landlord certificate as extra SANs, get their own host-header forward
+     * rule entry and their own Route 53 alias record, but never the apex/`www`
+     * redirect or wildcard-subdomain treatment {@see domain()} gets: each is
+     * served as the literal host declared, nothing inferred.
+     *
+     * @return array<int, string>
+     */
+    public static function additionalDomains(): array
+    {
+        return array_slice(static::domains(), 1);
     }
 
     public static function hasDomain(): bool
     {
         return static::domain() !== null;
+    }
+
+    /**
+     * Every distinct apex this app's own hosts resolve to — the primary domain's
+     * apex, plus each additional landlord host's own (a landlord may serve
+     * several brand domains, each behind its own zone). Empty when the app has no
+     * domain at all. The single source both {@see SyncHostedZoneStep}
+     * (provisions one) and {@see WithdrawAppDnsRecordsStep}
+     * (withdraws this app's records from one) fan out over.
+     *
+     * @return array<int, string>
+     */
+    public static function appApexes(): array
+    {
+        if (! static::hasDomain()) {
+            return [];
+        }
+
+        return array_values(array_unique([
+            static::apex(),
+            ...array_map(static::deriveApex(...), static::additionalDomains()),
+        ]));
     }
 
     /**

--- a/src/Resources/Acm/SslCertificate.php
+++ b/src/Resources/Acm/SslCertificate.php
@@ -4,12 +4,15 @@ namespace Codinglabs\Yolo\Resources\Acm;
 
 use Codinglabs\Yolo\Aws;
 use Codinglabs\Yolo\Aws\Acm;
+use Codinglabs\Yolo\Manifest;
+use Illuminate\Support\Collection;
 use Codinglabs\Yolo\Resources\Route53\HostedZone;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 /**
  * A DNS-validated ACM certificate covering a domain and its wildcard
- * (`*.{domain}`), addressed by domain so the solo and tenant steps share it.
+ * (`*.{domain}`), plus any additional bare SANs, addressed by domain so the solo
+ * and tenant steps share it.
  *
  * Unlike the create-or-sync Resources, a certificate is a small state machine
  * (request → pending validation → issued), so it doesn't implement the Resource
@@ -29,8 +32,16 @@ class SslCertificate
      * @param  string  $zone  the hosted zone the DNS validation record is written into — the
      *                        domain's apex, which is NOT the domain itself when the certificate
      *                        is issued for a subdomain (a wildcard-subdomain app)
+     * @param  array<int, string>  $additionalSans  extra bare hosts to cover on this same
+     *                                              certificate (a landlord serving several
+     *                                              domains off one cert) — no wildcard is
+     *                                              requested for these, only the literal host.
+     *                                              Each one's own DNS validation record is
+     *                                              written into ITS OWN apex zone
+     *                                              ({@see Manifest::deriveApex()}), which may
+     *                                              differ from `$zone`.
      */
-    public function __construct(protected string $domain, protected string $zone) {}
+    public function __construct(protected string $domain, protected string $zone, protected array $additionalSans = []) {}
 
     /**
      * The certificate summary (DomainName, Status, CertificateArn), or null when
@@ -47,24 +58,40 @@ class SslCertificate
         }
     }
 
+    /**
+     * Whether the live certificate's SAN set doesn't yet cover every desired
+     * additional SAN — the trigger for requesting a fresh certificate, since ACM
+     * certificates can't be amended in place once issued.
+     *
+     * @param  array<string, mixed>  $summary  as returned by {@see find()} (ListCertificates'
+     *                                         CertificateSummaryList entry, which carries
+     *                                         `SubjectAlternativeNameSummaries`)
+     */
+    public function isMissingAdditionalSans(array $summary): bool
+    {
+        return array_diff($this->additionalSans, $summary['SubjectAlternativeNameSummaries'] ?? []) !== [];
+    }
+
     public function request(): string
     {
         return Aws::acm()->requestCertificate([
             'DomainName' => $this->domain,
-            'SubjectAlternativeNames' => ["*.{$this->domain}"],
+            'SubjectAlternativeNames' => ["*.{$this->domain}", ...$this->additionalSans],
             'ValidationMethod' => 'DNS',
         ])['CertificateArn'];
     }
 
     /**
-     * Publish the DNS validation record into the zone, then block until ACM
-     * reports the certificate ISSUED. The domain and its wildcard share one
-     * validation record, so the wildcard option is filtered out to avoid a
-     * redundant UPSERT.
+     * Publish the DNS validation record for every SAN into its own zone, then
+     * block until ACM reports the certificate ISSUED. The primary domain and its
+     * wildcard share one validation record, so the wildcard option is filtered
+     * out to avoid a redundant UPSERT; each additional SAN gets its own option
+     * and, unlike the primary, may resolve through a completely different apex
+     * zone — grouped by zone so each writes exactly once.
      *
-     * The record goes into the *apex* zone, not a zone named after the
-     * certificate's domain: a certificate issued for a subdomain resolves through
-     * its parent zone, and no zone of its own need exist.
+     * The primary domain's record goes into `$zone` rather than a zone named
+     * after the domain itself: a certificate issued for a subdomain resolves
+     * through its parent zone, and no zone of its own need exist.
      */
     public function validate(string $certificateArn): void
     {
@@ -85,26 +112,34 @@ class SslCertificate
             sleep(2);
         }
 
-        Aws::route53()->changeResourceRecordSets([
-            'ChangeBatch' => [
-                'Changes' => collect($certificate['DomainValidationOptions'])
-                    ->filter(fn (array $option): bool => $option['ValidationMethod'] === 'DNS'
-                        && ! str_starts_with((string) $option['ValidationDomain'], '*'))
-                    ->map(fn (array $option): array => [
-                        'Action' => 'UPSERT',
-                        'ResourceRecordSet' => [
-                            'Name' => $option['ResourceRecord']['Name'],
-                            'Type' => $option['ResourceRecord']['Type'],
-                            'ResourceRecords' => [['Value' => $option['ResourceRecord']['Value']]],
-                            'TTL' => 300,
-                        ],
-                    ])
-                    ->values()
-                    ->all(),
-                'Comment' => 'Created by yolo CLI',
-            ],
-            'HostedZoneId' => (new HostedZone($this->zone))->arn(),
-        ]);
+        $zonesBySan = [$this->domain => $this->zone] + collect($this->additionalSans)
+            ->mapWithKeys(fn (string $san): array => [$san => Manifest::deriveApex($san)])
+            ->all();
+
+        collect($certificate['DomainValidationOptions'])
+            ->filter(fn (array $option): bool => $option['ValidationMethod'] === 'DNS'
+                && ! str_starts_with((string) $option['ValidationDomain'], '*'))
+            ->groupBy(fn (array $option): string => $zonesBySan[$option['ValidationDomain']] ?? $this->zone)
+            ->each(function (Collection $options, string $zone): void {
+                Aws::route53()->changeResourceRecordSets([
+                    'ChangeBatch' => [
+                        'Changes' => $options
+                            ->map(fn (array $option): array => [
+                                'Action' => 'UPSERT',
+                                'ResourceRecordSet' => [
+                                    'Name' => $option['ResourceRecord']['Name'],
+                                    'Type' => $option['ResourceRecord']['Type'],
+                                    'ResourceRecords' => [['Value' => $option['ResourceRecord']['Value']]],
+                                    'TTL' => 300,
+                                ],
+                            ])
+                            ->values()
+                            ->all(),
+                        'Comment' => 'Created by yolo CLI',
+                    ],
+                    'HostedZoneId' => (new HostedZone($zone))->arn(),
+                ]);
+            });
 
         while (Acm::certificate($this->domain)['Status'] !== 'ISSUED') {
             sleep(2);

--- a/src/Resources/ElbV2/ForwardListenerRule.php
+++ b/src/Resources/ElbV2/ForwardListenerRule.php
@@ -7,11 +7,19 @@ use Codinglabs\Yolo\Manifest;
 
 /**
  * Forwards the app's canonical host (`domain`) to its target group, plus
- * `*.{domain}` when the app serves its own subdomains. The apex/`www` sibling,
- * when there is one, is 301-redirected here by a {@see RedirectListenerRule}
- * rather than served — and because `*.{apex}` would otherwise also match that
- * sibling, redirect rules take a priority band above every forward rule
- * ({@see ListenerRule::PRIORITY_BANDS}).
+ * `*.{domain}` when the app serves its own subdomains, plus every additional
+ * landlord host ({@see Manifest::additionalDomains()}) — each served as the
+ * literal host declared, with no wildcard or redirect inferred for it. The
+ * apex/`www` sibling of the canonical host, when there is one, is
+ * 301-redirected here by a {@see RedirectListenerRule} rather than served — and
+ * because `*.{apex}` would otherwise also match that sibling, redirect rules
+ * take a priority band above every forward rule ({@see ListenerRule::PRIORITY_BANDS}).
+ *
+ * Still one rule with a stable Name tag (`yolo-{env}-{app}`) whatever the host
+ * count — never a rule per additional host — so it can never collide with a
+ * sibling rule's Name, e.g. the environment's own `search.{domain}` rule
+ * ({@see SearchListenerRule}, Name `yolo-{env}-search`), which sits in a wholly
+ * separate (Env, not App) scope regardless of host overlap.
  */
 class ForwardListenerRule extends ListenerRule
 {
@@ -25,6 +33,7 @@ class ForwardListenerRule extends ListenerRule
         return array_values(array_filter([
             Manifest::domain() ?? Manifest::apex(),
             Manifest::wildcardHost(),
+            ...Manifest::additionalDomains(),
         ]));
     }
 

--- a/src/Resources/Route53/HostedZone.php
+++ b/src/Resources/Route53/HostedZone.php
@@ -176,7 +176,11 @@ class HostedZone implements Adoptable, Resource, Undeletable
     /**
      * The hostnames YOLO writes A-alias records for — the canonical host, its
      * apex/www sibling when it has one, and the wildcard when the app serves its
-     * own subdomains. Shares {@see ResolvesCanonicalHost::aliasedHosts()} with
+     * own subdomains — plus, for the app's own zone, any additional landlord host
+     * ({@see Manifest::additionalDomains()}) that resolves to THIS apex (a
+     * landlord may declare hosts across several zones; each zone only manages the
+     * ones that are actually its own). Shares
+     * {@see ResolvesCanonicalHost::aliasedHosts()} with
      * {@see SyncsRecordSets::generateChanges()} so teardown withdraws exactly what
      * sync created and nothing else.
      *
@@ -188,9 +192,23 @@ class HostedZone implements Adoptable, Resource, Undeletable
         // built by forTenant() manages that tenant's. Resolved here rather than
         // defaulted inside aliasedHosts(), so a tenant's zone can never inherit the
         // app's wildcard (which would write `*.{app domain}` into the tenant's zone).
-        return $this->domain === null
-            ? $this->aliasedHosts($this->apex, Manifest::domain() ?? $this->apex, Manifest::wildcardHost())
-            : $this->aliasedHosts($this->apex, $this->domain, $this->wildcardHost);
+        if ($this->domain !== null) {
+            return $this->aliasedHosts($this->apex, $this->domain, $this->wildcardHost);
+        }
+
+        // The primary domain's own apex/www/wildcard treatment belongs ONLY to the
+        // zone that IS its apex — a landlord spanning several zones must never
+        // attribute the primary host to a foreign zone just because this instance
+        // has no explicit $domain.
+        $primary = Manifest::hasDomain() && Manifest::apex() === $this->apex
+            ? $this->aliasedHosts($this->apex, (string) Manifest::domain(), Manifest::wildcardHost())
+            : [];
+
+        $additional = collect(Manifest::additionalDomains())
+            ->filter(fn (string $host): bool => Manifest::deriveApex($host) === $this->apex)
+            ->all();
+
+        return array_values(array_unique([...$primary, ...$additional]));
     }
 
     /**

--- a/src/Steps/Deploy/SyncSoloRecordSetStep.php
+++ b/src/Steps/Deploy/SyncSoloRecordSetStep.php
@@ -11,11 +11,16 @@ use Codinglabs\Yolo\Concerns\SyncsRecordSets;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 
 /**
- * UPSERTs the records for the app's *own* domain. Gated on having a domain rather
- * than on being solo: a tenanted app that declares a `domain` of its own (serving
- * its tenants as subdomains of it) needs these records exactly as a solo app does
- * — tenancy is an orthogonal axis. A tenant's own records are written by
+ * UPSERTs the records for the app's *own* domain(s). Gated on having a domain
+ * rather than on being solo: a tenanted app that declares a `domain` of its own
+ * (serving its tenants as subdomains of it) needs these records exactly as a solo
+ * app does — tenancy is an orthogonal axis. A tenant's own records are written by
  * {@see SyncMultitenancyRecordSetStep}.
+ *
+ * A landlord may declare more than one host ({@see Manifest::additionalDomains()});
+ * each gets its own plain alias record in its own apex zone — no apex/`www`
+ * sibling and no wildcard inferred for it, since only the primary/canonical host
+ * gets that treatment.
  */
 class SyncSoloRecordSetStep implements ExecutesWebStep
 {
@@ -33,6 +38,10 @@ class SyncSoloRecordSetStep implements ExecutesWebStep
                 domain: (string) Manifest::domain(),
                 wildcardHost: Manifest::wildcardHost(),
             );
+
+            foreach (Manifest::additionalDomains() as $host) {
+                $this->syncAdditionalHostRecordSet(Manifest::deriveApex($host), $host);
+            }
 
             return StepResult::SYNCED;
         }

--- a/src/Steps/Destroy/App/WithdrawAppDnsRecordsStep.php
+++ b/src/Steps/Destroy/App/WithdrawAppDnsRecordsStep.php
@@ -13,14 +13,16 @@ use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Codinglabs\Yolo\Resources\Route53\HostedZone;
 
 /**
- * Withdraws this app's DNS records — and ONLY its records. The hosted zone itself
- * is never deleted: it's domain-level infrastructure (the registrar's NS delegation
- * points at it, and the domain's email / verification DNS and any sibling
- * environment's records all live in it), so it outlives any single app. Tearing the
- * app down removes the A/AAAA records YOLO inserted for it and leaves the zone — and
- * everything else in it — standing. Mirrors how `destroy:app` treats every other
- * shared resource: withdraw this app's slice, never delete the shared thing. See
- * {@see HostedZone::removeAppRecords()}.
+ * Withdraws this app's DNS records — and ONLY its records — across every zone it
+ * has one in: the primary domain's apex, plus each additional landlord host's own
+ * apex when it differs (a landlord serving several brand domains). The hosted
+ * zones themselves are never deleted: they're domain-level infrastructure (the
+ * registrar's NS delegation points at them, and the domain's email / verification
+ * DNS and any sibling environment's records all live there), so they outlive any
+ * single app. Tearing the app down removes the A/AAAA records YOLO inserted and
+ * leaves every zone — and everything else in it — standing. Mirrors how
+ * `destroy:app` treats every other shared resource: withdraw this app's slice,
+ * never delete the shared thing. See {@see HostedZone::removeAppRecords()}.
  */
 class WithdrawAppDnsRecordsStep implements Step
 {
@@ -34,32 +36,40 @@ class WithdrawAppDnsRecordsStep implements Step
             return StepResult::SKIPPED;
         }
 
-        $zone = new HostedZone(Manifest::apex());
+        $withdrawn = false;
 
-        if (! $zone->exists()) {
+        foreach (Manifest::appApexes() as $apex) {
+            $zone = new HostedZone($apex);
+
+            if (! $zone->exists()) {
+                continue;
+            }
+
+            $records = $zone->appRecords();
+
+            if ($records === []) {
+                continue;
+            }
+
+            // Name each record withdrawn — type + host (e.g. `A www.example.com`).
+            // Only this app's own A/AAAA alias records go; the shared, domain-level
+            // hosted zone and everything else in it (MX, NS, sibling envs) stays.
+            // The step is a withdrawal, never a zone delete — see {@see HostedZone}.
+            foreach ($records as $record) {
+                $this->recordChange(Change::make(sprintf('%s %s', $record['Type'], $record['Name']), 'present', null));
+            }
+
+            $withdrawn = true;
+
+            if (! Arr::get($options, 'dry-run')) {
+                $zone->removeAppRecords();
+            }
+        }
+
+        if (! $withdrawn) {
             return StepResult::SKIPPED;
         }
 
-        $records = $zone->appRecords();
-
-        if ($records === []) {
-            return StepResult::SKIPPED;
-        }
-
-        // Name each record withdrawn — type + host (e.g. `A www.example.com`). Only
-        // this app's own A/AAAA alias records go; the shared, domain-level hosted
-        // zone and everything else in it (MX, NS, sibling envs) stays. The step is
-        // a withdrawal, never a zone delete — see {@see HostedZone}.
-        foreach ($records as $record) {
-            $this->recordChange(Change::make(sprintf('%s %s', $record['Type'], $record['Name']), 'present', null));
-        }
-
-        if (Arr::get($options, 'dry-run')) {
-            return StepResult::WOULD_DELETE;
-        }
-
-        $zone->removeAppRecords();
-
-        return StepResult::DELETED;
+        return Arr::get($options, 'dry-run') ? StepResult::WOULD_DELETE : StepResult::DELETED;
     }
 }

--- a/src/Steps/Sync/App/Solo/SyncHostedZoneStep.php
+++ b/src/Steps/Sync/App/Solo/SyncHostedZoneStep.php
@@ -4,18 +4,43 @@ declare(strict_types=1);
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Solo;
 
+use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 use Codinglabs\Yolo\Resources\Route53\HostedZone;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 
+/**
+ * Syncs the app's own zone, plus one per additional landlord host
+ * ({@see Manifest::additionalDomains()}) whose apex isn't already covered — a
+ * landlord serving several brand domains needs a zone per apex, not just the
+ * primary's. Most apps declare a single host, so this is the one-zone case in
+ * the common shape and a small fan-out only when `domain` is a list.
+ */
 class SyncHostedZoneStep implements ExecutesWebStep
 {
     use SynchronisesResource;
 
     public function __invoke(array $options): StepResult
     {
-        return $this->syncResource(new HostedZone(Manifest::apex()), $options);
+        $created = false;
+        $synced = false;
+
+        foreach (Manifest::appApexes() as $apex) {
+            match ($this->syncResource(new HostedZone($apex), $options)) {
+                StepResult::CREATED, StepResult::WOULD_CREATE => $created = true,
+                StepResult::SYNCED, StepResult::WOULD_SYNC => $synced = true,
+                default => null,
+            };
+        }
+
+        $dryRun = (bool) Arr::get($options, 'dry-run');
+
+        return match (true) {
+            $created => $dryRun ? StepResult::WOULD_CREATE : StepResult::CREATED,
+            $synced => $dryRun ? StepResult::WOULD_SYNC : StepResult::SYNCED,
+            default => StepResult::SYNCED,
+        };
     }
 }

--- a/src/Steps/Sync/App/Solo/SyncSslCertificateStep.php
+++ b/src/Steps/Sync/App/Solo/SyncSslCertificateStep.php
@@ -2,17 +2,21 @@
 
 namespace Codinglabs\Yolo\Steps\Sync\App\Solo;
 
+use Codinglabs\Yolo\Change;
 use Illuminate\Support\Arr;
 use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\RecordsChanges;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 use Codinglabs\Yolo\Resources\Acm\SslCertificate;
 
 class SyncSslCertificateStep implements ExecutesWebStep
 {
+    use RecordsChanges;
+
     public function __invoke(array $options): StepResult
     {
-        $certificate = new SslCertificate(Manifest::certificateDomain(), Manifest::apex());
+        $certificate = new SslCertificate(Manifest::certificateDomain(), Manifest::apex(), Manifest::additionalDomains());
         $summary = $certificate->find();
 
         if ($summary === null) {
@@ -31,6 +35,24 @@ class SyncSslCertificateStep implements ExecutesWebStep
             }
 
             $certificate->validate($summary['CertificateArn']);
+
+            return StepResult::SYNCED;
+        }
+
+        // ACM certificates are immutable — an already-ISSUED certificate whose
+        // additional-SAN list has grown (a landlord adding another domain to an
+        // already-provisioned certificate) can't be amended in place, only
+        // superseded by requesting a fresh certificate covering the full desired
+        // SAN set. The old certificate is left standing, same as every other
+        // domain-name change here: this class is deliberately NOT Deletable.
+        if ($certificate->isMissingAdditionalSans($summary)) {
+            $this->recordChange(Change::make('certificate SANs', implode(', ', $summary['SubjectAlternativeNameSummaries'] ?? []), implode(', ', Manifest::additionalDomains())));
+
+            if (Arr::get($options, 'dry-run')) {
+                return StepResult::WOULD_SYNC;
+            }
+
+            $certificate->validate($certificate->request());
         }
 
         return StepResult::SYNCED;

--- a/tests/Unit/Commands/CommandManifestIntegrityTest.php
+++ b/tests/Unit/Commands/CommandManifestIntegrityTest.php
@@ -633,3 +633,80 @@ it('refuses a bucket name S3 would reject, rather than failing mid-apply', funct
         expect(invokeManifestIntegrity())->toBeFalse();
     }
 });
+
+it('accepts a landlord domain declared as a list of hosts', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.io']]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});
+
+it('refuses an empty landlord domain list', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => []]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('empty list');
+});
+
+it('refuses a blank host in a landlord domain list', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['app.example.com', '']]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('blank or non-string');
+});
+
+it('refuses a duplicate host in a landlord domain list', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.com']]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('duplicate host');
+});
+
+it('refuses more landlord domains than an ALB host-header rule can hold', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => [
+            'a.example.com', 'b.example.com', 'c.example.com', 'd.example.com', 'e.example.com', 'f.example.com',
+        ]]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('ALB allows at most 5');
+});
+
+it('counts the wildcard against the ALB host-header limit when wildcard-subdomains is on', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => [
+            'a.example.com', 'b.example.com', 'c.example.com', 'd.example.com', 'e.example.com',
+        ], 'wildcard-subdomains' => true]],
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeFalse();
+
+    expect(test()->promptOutput->fetch())->toContain('ALB allows at most 5');
+});
+
+it('leaves a solo domain untouched by the landlord domain-list validation', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'domain' => 'example.com',
+    ]);
+
+    expect(invokeManifestIntegrity())->toBeTrue();
+});

--- a/tests/Unit/MultitenancyTest.php
+++ b/tests/Unit/MultitenancyTest.php
@@ -39,6 +39,60 @@ describe('the app host', function (): void {
     });
 });
 
+describe('a landlord domain list', function (): void {
+    it('normalises a bare string to a single-entry list', function (): void {
+        writeManifest(['multitenancy' => ['landlord' => ['domain' => 'app.example.com']]]);
+
+        expect(Manifest::domains())->toBe(['app.example.com'])
+            ->and(Manifest::domain())->toBe('app.example.com')
+            ->and(Manifest::additionalDomains())->toBe([]);
+    });
+
+    it('normalises an array, keeping declaration order', function (): void {
+        writeManifest(['multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.io']]]]);
+
+        expect(Manifest::domains())->toBe(['app.example.com', 'app.example.io'])
+            ->and(Manifest::domain())->toBe('app.example.com')
+            ->and(Manifest::additionalDomains())->toBe(['app.example.io']);
+    });
+
+    it('dedupes a repeated host', function (): void {
+        writeManifest(['multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.com']]]]);
+
+        expect(Manifest::domains())->toBe(['app.example.com']);
+    });
+
+    it('is empty when the app has no domain at all', function (): void {
+        writeManifest(['multitenancy' => ['tenants' => ['acme' => ['domain' => 'acme.test']]]]);
+
+        expect(Manifest::domains())->toBe([])
+            ->and(Manifest::additionalDomains())->toBe([]);
+    });
+
+    it('stays single-host for a solo app\'s root `domain`', function (): void {
+        writeManifest(['domain' => 'example.com']);
+
+        expect(Manifest::domains())->toBe(['example.com'])
+            ->and(Manifest::additionalDomains())->toBe([]);
+    });
+
+    it('lists every distinct apex across the primary and additional hosts', function (): void {
+        bindHostedZones(['example.com', 'example.io']);
+
+        writeManifest(['multitenancy' => ['landlord' => ['domain' => [
+            'app.example.com', 'app.example.io', 'brand.example.com',
+        ]]]]);
+
+        expect(Manifest::appApexes())->toEqualCanonicalizing(['example.com', 'example.io']);
+    });
+
+    it('has no apexes when the app has no domain', function (): void {
+        writeManifest(['multitenancy' => ['tenants' => ['acme' => ['domain' => 'acme.test']]]]);
+
+        expect(Manifest::appApexes())->toBe([]);
+    });
+});
+
 // Mode (a `multitenancy` block exists) and fan-out (tenants are declared) are two
 // questions. Conflating them left a landlord-only manifest with no reader for its
 // domain, so it validated clean and deployed as a headless worker — no zone, no

--- a/tests/Unit/Resources/Acm/SslCertificateTest.php
+++ b/tests/Unit/Resources/Acm/SslCertificateTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Resources\Acm\SslCertificate;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+});
+
+describe('additional SANs', function (): void {
+    it('requests the domain, its wildcard, and every additional SAN — no wildcard for the additional ones', function (): void {
+        $captured = [];
+        bindRoutedAcmClient(['RequestCertificate' => new Result(['CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/abcd-1234'])], $captured);
+
+        (new SslCertificate('app.example.com', 'example.com', ['app.example.io', 'brand.other.com']))->request();
+
+        $args = collect($captured)->firstWhere('name', 'RequestCertificate')['args'];
+
+        expect($args['DomainName'])->toBe('app.example.com')
+            ->and($args['SubjectAlternativeNames'])->toBe(['*.app.example.com', 'app.example.io', 'brand.other.com']);
+    });
+
+    it('writes each additional SAN\'s DNS validation record into its OWN apex zone', function (): void {
+        $captured = [];
+        bindMockRoute53Client([
+            ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+            ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+        ], $captured);
+
+        bindRoutedAcmClient([
+            'DescribeCertificate' => new Result(['Certificate' => [
+                'DomainValidationOptions' => [
+                    [
+                        'ValidationMethod' => 'DNS',
+                        'ValidationDomain' => 'app.example.com',
+                        'ResourceRecord' => ['Name' => '_x.app.example.com', 'Type' => 'CNAME', 'Value' => '_y.acm-validations.aws'],
+                    ],
+                    // The primary's wildcard shares the primary's validation record
+                    // — filtered out to avoid a redundant UPSERT.
+                    [
+                        'ValidationMethod' => 'DNS',
+                        'ValidationDomain' => '*.app.example.com',
+                        'ResourceRecord' => ['Name' => '_x.app.example.com', 'Type' => 'CNAME', 'Value' => '_y.acm-validations.aws'],
+                    ],
+                    [
+                        'ValidationMethod' => 'DNS',
+                        'ValidationDomain' => 'app.example.io',
+                        'ResourceRecord' => ['Name' => '_a.app.example.io', 'Type' => 'CNAME', 'Value' => '_b.acm-validations.aws'],
+                    ],
+                ],
+            ]]),
+            'ListCertificates' => new Result(['CertificateSummaryList' => [[
+                'DomainName' => 'app.example.com',
+                'CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/abcd-1234',
+                'Status' => 'ISSUED',
+            ]]]),
+        ], $captured);
+
+        (new SslCertificate('app.example.com', 'example.com', ['app.example.io']))->validate('arn:aws:acm:ap-southeast-2:111111111111:certificate/abcd-1234');
+
+        $changeCalls = collect($captured)->where('name', 'ChangeResourceRecordSets')->values();
+
+        expect($changeCalls)->toHaveCount(2);
+
+        $byZone = $changeCalls->keyBy(fn (array $call): string => $call['args']['HostedZoneId']);
+
+        expect($byZone->has('ZONE-COM'))->toBeTrue()
+            ->and($byZone->has('ZONE-IO'))->toBeTrue();
+
+        $comChanges = $byZone['ZONE-COM']['args']['ChangeBatch']['Changes'];
+        $ioChanges = $byZone['ZONE-IO']['args']['ChangeBatch']['Changes'];
+
+        expect($comChanges)->toHaveCount(1)
+            ->and($comChanges[0]['ResourceRecordSet']['Name'])->toBe('_x.app.example.com')
+            ->and($ioChanges)->toHaveCount(1)
+            ->and($ioChanges[0]['ResourceRecordSet']['Name'])->toBe('_a.app.example.io');
+    });
+
+    it('reports no missing SANs when the live certificate already covers every desired one', function (): void {
+        $certificate = new SslCertificate('app.example.com', 'example.com', ['app.example.io']);
+
+        expect($certificate->isMissingAdditionalSans([
+            'SubjectAlternativeNameSummaries' => ['app.example.com', '*.app.example.com', 'app.example.io'],
+        ]))->toBeFalse();
+    });
+
+    it('reports a missing SAN when the live certificate does not yet cover a desired additional host', function (): void {
+        $certificate = new SslCertificate('app.example.com', 'example.com', ['app.example.io', 'brand.other.com']);
+
+        expect($certificate->isMissingAdditionalSans([
+            'SubjectAlternativeNameSummaries' => ['app.example.com', '*.app.example.com', 'app.example.io'],
+        ]))->toBeTrue();
+    });
+
+    it('reports no missing SANs when there are no additional SANs to begin with', function (): void {
+        $certificate = new SslCertificate('app.example.com', 'example.com');
+
+        expect($certificate->isMissingAdditionalSans(['SubjectAlternativeNameSummaries' => ['app.example.com', '*.app.example.com']]))->toBeFalse();
+    });
+});

--- a/tests/Unit/Resources/ElbV2/ForwardListenerRuleTest.php
+++ b/tests/Unit/Resources/ElbV2/ForwardListenerRuleTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 use Aws\Result;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+use Codinglabs\Yolo\Resources\ElbV2\SearchListenerRule;
 use Codinglabs\Yolo\Resources\ElbV2\ForwardListenerRule;
 
 function forwardRule(): ForwardListenerRule
@@ -54,6 +55,41 @@ describe('hosts', function (): void {
         // Scoped to the app's own domain, never the apex — a wildcard at the apex
         // would match a sibling app's host on the same shared listener.
         expect(forwardRule()->hosts())->toBe(['app.example.com', '*.app.example.com']);
+    });
+
+    it('adds every additional landlord host as its own literal host-header value', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.io', 'brand.other.com']]],
+        ]);
+
+        expect(forwardRule()->hosts())->toBe(['app.example.com', 'app.example.io', 'brand.other.com']);
+    });
+
+    it('composes additional landlord hosts with the wildcard, still one rule', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'multitenancy' => ['landlord' => [
+                'domain' => ['app.example.com', 'brand.example.io'],
+                'wildcard-subdomains' => true,
+            ]],
+        ]);
+
+        expect(forwardRule()->hosts())->toBe(['app.example.com', '*.app.example.com', 'brand.example.io']);
+    });
+
+    it('keeps a stable Name distinct from the environment search rule, whatever the host list', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'search.example.com']]],
+        ]);
+
+        // The additional host rides the SAME rule (identity is the Name tag, not
+        // the hosts it matches) — it can never collide with a sibling rule's Name,
+        // e.g. the environment's own search.{domain} rule, which lives in a wholly
+        // separate (Env) scope and is keyed `yolo-{env}-search`.
+        expect(forwardRule()->name())->toBe('yolo-testing-my-app')
+            ->and(forwardRule()->name())->not->toBe((new SearchListenerRule('arn:listener'))->name());
     });
 });
 

--- a/tests/Unit/Resources/Route53/HostedZoneTest.php
+++ b/tests/Unit/Resources/Route53/HostedZoneTest.php
@@ -128,3 +128,33 @@ it('gives no ownership warning for headless or multi-tenant apps (no single apex
     'headless' => [['tasks' => ['web' => true]]],
     'multi-tenant' => [['multitenancy' => ['tenants' => ['alpha' => []]]]],
 ]);
+
+describe('a multi-domain landlord', function (): void {
+    it('attributes the primary host only to the zone that is its own apex, never a foreign one', function (): void {
+        writeManifest([
+            'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+            'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+        ]);
+
+        $captured = [];
+        bindMockRoute53Client(
+            [
+                ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+                ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+            ],
+            $captured,
+            [
+                ['Type' => 'A', 'Name' => 'example.com.'],
+                ['Type' => 'A', 'Name' => 'app.example.io.'],
+            ],
+        );
+
+        // Both zone instances see the SAME live record list (the mock isn't
+        // zone-aware) — each must still only claim its own host, not the other
+        // zone's, or teardown from one zone would delete a record it never wrote.
+        expect(collect((new HostedZone('example.com'))->appRecords())->pluck('Name')->all())
+            ->toBe(['example.com'])
+            ->and(collect((new HostedZone('example.io'))->appRecords())->pluck('Name')->all())
+            ->toBe(['app.example.io']);
+    });
+});

--- a/tests/Unit/Steps/Deploy/SyncSoloRecordSetStepTest.php
+++ b/tests/Unit/Steps/Deploy/SyncSoloRecordSetStepTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Deploy\SyncSoloRecordSetStep;
+
+it('writes the primary record plus one plain alias per additional landlord host, each in its own zone', function (): void {
+    $elb = [];
+    bindAlbLookup($elb);
+
+    $r53 = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+        ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+    ], $r53);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncSoloRecordSetStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    $changeCalls = collect($r53)->where('name', 'ChangeResourceRecordSets')->values();
+
+    expect($changeCalls)->toHaveCount(2);
+
+    $byZone = $changeCalls->keyBy(fn (array $call): string => $call['args']['HostedZoneId']);
+
+    // The primary (the apex itself) gets its own apex/www-pair treatment — two
+    // records, both www and the bare apex.
+    $primaryChanges = $byZone['ZONE-COM']['args']['ChangeBatch']['Changes'];
+    expect(collect($primaryChanges)->pluck('ResourceRecordSet.Name')->all())
+        ->toEqualCanonicalizing(['example.com', 'www.example.com']);
+
+    // The additional host gets exactly one plain alias — no sibling, no wildcard.
+    $additionalChanges = $byZone['ZONE-IO']['args']['ChangeBatch']['Changes'];
+    expect($additionalChanges)->toHaveCount(1)
+        ->and($additionalChanges[0]['ResourceRecordSet']['Name'])->toBe('app.example.io');
+});
+
+it('reports WOULD_SYNC on the plan pass without writing anything', function (): void {
+    $elb = [];
+    bindAlbLookup($elb);
+
+    $r53 = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+        ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+    ], $r53);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncSoloRecordSetStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+
+    expect(collect($r53)->where('name', 'ChangeResourceRecordSets'))->toBeEmpty();
+});

--- a/tests/Unit/Steps/Destroy/App/WithdrawAppDnsRecordsStepTest.php
+++ b/tests/Unit/Steps/Destroy/App/WithdrawAppDnsRecordsStepTest.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Destroy\App\WithdrawAppDnsRecordsStep;
+
+it('withdraws records from every zone the app\'s own hosts span — not just the primary apex', function (): void {
+    $captured = [];
+    bindMockRoute53Client(
+        [
+            ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+            ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+        ],
+        $captured,
+        [
+            ['Type' => 'A', 'Name' => 'example.com.'],
+            ['Type' => 'A', 'Name' => 'www.example.com.'],
+            ['Type' => 'A', 'Name' => 'app.example.io.'],
+            // not ours — a sibling app's record in the same zone
+            ['Type' => 'A', 'Name' => 'other.example.io.'],
+        ],
+    );
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new WithdrawAppDnsRecordsStep())(['dry-run' => false]))->toBe(StepResult::DELETED);
+
+    $deleteCalls = collect($captured)
+        ->where('name', 'ChangeResourceRecordSets')
+        ->filter(fn (array $call): bool => collect($call['args']['ChangeBatch']['Changes'])->contains(fn (array $change): bool => $change['Action'] === 'DELETE'));
+
+    $deletedNames = $deleteCalls
+        ->flatMap(fn (array $call): array => $call['args']['ChangeBatch']['Changes'])
+        ->pluck('ResourceRecordSet.Name')
+        ->map(fn (string $name): string => rtrim($name, '.'))
+        ->all();
+
+    expect($deletedNames)->toEqualCanonicalizing(['example.com', 'www.example.com', 'app.example.io'])
+        ->and($deletedNames)->not->toContain('other.example.io');
+});
+
+it('reports SKIPPED when no zone holds any of the app\'s records', function (): void {
+    $captured = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+        ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+    ], $captured, []);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new WithdrawAppDnsRecordsStep())(['dry-run' => false]))->toBe(StepResult::SKIPPED);
+});

--- a/tests/Unit/Steps/Sync/App/Solo/SyncHostedZoneStepTest.php
+++ b/tests/Unit/Steps/Sync/App/Solo/SyncHostedZoneStepTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\Solo\SyncHostedZoneStep;
+
+it('syncs only the primary apex zone for a single-host landlord', function (): void {
+    $captured = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => 'app.example.com']],
+    ]);
+
+    expect((new SyncHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    // Only ONE zone touched — no ListTagsForResource/ChangeTagsForResource pair
+    // for a second, non-existent apex.
+    expect(collect($captured)->where('name', 'ChangeTagsForResource')->count())->toBe(1);
+});
+
+it('syncs a zone per distinct apex when the landlord spans several domains', function (): void {
+    $captured = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+        ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    $tagCalls = collect($captured)->where('name', 'ChangeTagsForResource')->values();
+
+    expect($tagCalls)->toHaveCount(2)
+        ->and($tagCalls->pluck('args.ResourceId')->all())->toEqualCanonicalizing(['ZONE-COM', 'ZONE-IO']);
+});
+
+it('dedupes when two additional hosts share the same apex', function (): void {
+    $captured = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['app.example.com', 'brand.example.com']]],
+    ]);
+
+    expect((new SyncHostedZoneStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    expect(collect($captured)->where('name', 'ChangeTagsForResource')->count())->toBe(1);
+});

--- a/tests/Unit/Steps/Sync/App/Solo/SyncSslCertificateStepTest.php
+++ b/tests/Unit/Steps/Sync/App/Solo/SyncSslCertificateStepTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+use Aws\Result;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Steps\Sync\App\Solo\SyncSslCertificateStep;
+
+// The primary landlord host IS the apex here (its own zone, no wildcard-subdomains),
+// so the certificate is issued for `example.com` + `*.example.com` — the step
+// derives the app's apex before it ever inspects the certificate, so every case
+// needs a Route 53 zone list even when it never touches Route 53 otherwise (the
+// ISSUED-and-covered / plan-pass cases below).
+beforeEach(fn () => bindHostedZones(['example.com', 'example.io']));
+
+it('requests a fresh certificate when an already-issued one is missing a newly declared additional domain', function (): void {
+    $captured = [];
+    bindMockRoute53Client([
+        ['Name' => 'example.com.', 'Id' => '/hostedzone/ZONE-COM'],
+        ['Name' => 'example.io.', 'Id' => '/hostedzone/ZONE-IO'],
+    ], $captured);
+    bindRoutedAcmClient([
+        'ListCertificates' => new Result(['CertificateSummaryList' => [[
+            'DomainName' => 'example.com',
+            'CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/old-1234',
+            'Status' => 'ISSUED',
+            // The live cert only covers the primary — app.example.io was added to
+            // yolo.yml after this certificate was already issued.
+            'SubjectAlternativeNameSummaries' => ['example.com', '*.example.com'],
+        ]]]),
+        'RequestCertificate' => new Result(['CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/new-5678']),
+        'DescribeCertificate' => new Result(['Certificate' => ['DomainValidationOptions' => [
+            [
+                'ValidationMethod' => 'DNS',
+                'ValidationDomain' => 'example.com',
+                'ResourceRecord' => ['Name' => '_x.example.com', 'Type' => 'CNAME', 'Value' => '_y.acm-validations.aws'],
+            ],
+        ]]]),
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncSslCertificateStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    $requestArgs = collect($captured)->firstWhere('name', 'RequestCertificate')['args'];
+
+    expect($requestArgs['SubjectAlternativeNames'])->toBe(['*.example.com', 'app.example.io']);
+});
+
+it('reports WOULD_SYNC on the plan pass without requesting a new certificate', function (): void {
+    $captured = [];
+    bindRoutedAcmClient([
+        'ListCertificates' => new Result(['CertificateSummaryList' => [[
+            'DomainName' => 'example.com',
+            'CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/old-1234',
+            'Status' => 'ISSUED',
+            'SubjectAlternativeNameSummaries' => ['example.com', '*.example.com'],
+        ]]]),
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncSslCertificateStep())(['dry-run' => true]))->toBe(StepResult::WOULD_SYNC);
+
+    expect(collect($captured)->where('name', 'RequestCertificate'))->toBeEmpty();
+});
+
+it('stays SYNCED with no re-request when the issued certificate already covers every additional domain', function (): void {
+    $captured = [];
+    bindRoutedAcmClient([
+        'ListCertificates' => new Result(['CertificateSummaryList' => [[
+            'DomainName' => 'example.com',
+            'CertificateArn' => 'arn:aws:acm:ap-southeast-2:111111111111:certificate/current-1234',
+            'Status' => 'ISSUED',
+            'SubjectAlternativeNameSummaries' => ['example.com', '*.example.com', 'app.example.io'],
+        ]]]),
+    ], $captured);
+
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'multitenancy' => ['landlord' => ['domain' => ['example.com', 'app.example.io']]],
+    ]);
+
+    expect((new SyncSslCertificateStep())(['dry-run' => false]))->toBe(StepResult::SYNCED);
+
+    expect(collect($captured)->where('name', 'RequestCertificate'))->toBeEmpty();
+});


### PR DESCRIPTION
## Summary

- `multitenancy.landlord.domain` now accepts a string or a list, normalised to a list of hosts at parse time (`Manifest::domains()`/`additionalDomains()`) — a landlord serving several brand domains off one app previously had nowhere to declare the extra hosts.
- Every additional host rides the primary domain's certificate as an extra SAN (each validated through its own apex zone — ACM certs are immutable, so an already-issued cert missing a newly-declared SAN triggers a fresh request/validate rather than silently drifting), gets its own host-header value on the app's existing forward rule (still one rule, one stable Name tag — never a collision with a sibling rule like the environment's `search.{domain}` rule), and its own Route 53 alias record in its own zone.
- Nothing is inferred between the extra hosts: no wildcard, no apex/`www` redirect, no shared zone assumed. Hosted-zone provisioning and DNS teardown now fan out across every zone the app's hosts span, not just the primary's.
- Manifest validation refuses an empty list, a blank/duplicate host, or more hosts than ALB's host-header condition can hold (5 values, wildcard included).
- Docs updated (`docs/reference/manifest.md`, `docs/guide/multi-tenancy.md`); VitePress build verified clean.

## Test plan

- [x] `./vendor/bin/pint` — clean
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `./vendor/bin/rector process --dry-run` — clean
- [x] `./vendor/bin/pest` — 1999 passed (33 new), including the arch-level two-pass reconciler contract test
- [x] `docs` — `npm run build` (VitePress) clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)