### PR TITLE
feat(alarms): alert alarm family with thresholds drawn on the dashboard

### DIFF
--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -99,11 +99,13 @@ Every environment gets a family of **"a human should look"** alarms — named `�
 | Alert | Scope | Fires when |
 |---|---|---|
 | `alb-5xx` | Environment | The load balancer itself is generating 5xx — no healthy targets, a dead target group, a broken rule |
-| `valkey-memory` / `valkey-evictions` | Environment | The shared cache/session node is above 85% memory, or evicting keys — sessions being thrown away |
-| `database-cpu` / `-memory` / `-connections` / `-buffer-cache` | Environment (when the env manifest declares a [`database`](/reference/commands#yolo-sync-environment)) | The cluster writer is saturating: CPU ≥ 80% sustained, freeable memory under 10% of the instance, connections past 75% of the class ceiling, or the working set no longer fitting in memory. The absolute thresholds derive from the writer's instance class at sync time |
+| `valkey-memory` / `valkey-evictions` | Environment | The shared cache/session node is above 85% memory, or evicting heavily and sustained (background LRU churn on a full node is by design and doesn't fire) |
+| `database-cpu` / `-memory` / `-connections` / `-buffer-cache` | Environment (when the manifest declares an Aurora cluster [`database`](/reference/manifest#database) — a plain RDS instance gets no database alerts) | The cluster writer is saturating: CPU ≥ 80% sustained, freeable memory under 5% of the instance, connections past 75% of the class ceiling, or the working set no longer fitting in memory. The absolute thresholds derive from the writer's instance class at sync time; a Serverless v2 writer keeps the percentage-based pair only |
 | `web-5xx` | App | The app is serving 5xx to ≥ 5% of its own requests (rate, not count, with a traffic floor so one error on a trickle can't page) |
 
 Topic **subscriptions are yours** — YOLO creates the topic but never subscribes endpoints. Subscribe an email or chat webhook to start; promote to a pager integration once the signal has earned trust. Thresholds are hardcoded — these are "bad things are happening" bars, not tuning knobs.
+
+Every alert's threshold is also **drawn as a red line on the matching CloudWatch dashboard chart** (the app dashboard gains `# Cache` and buffer-cache panels so every alarmed metric has one). The lines and the alarms read the same values from one source, and the dashboard is rebuilt on every sync — so what the chart shows as the alarm bar is always exactly what pages.
 
 ## Plan, confirm, apply
 

--- a/docs/guide/provisioning.md
+++ b/docs/guide/provisioning.md
@@ -92,6 +92,19 @@ Tune the rest in the AWS console; YOLO won't undo it.
 
 **Blocked and counted requests are logged to CloudWatch Logs** — the `aws-waf-logs-yolo-{env}` log group (the `aws-waf-logs-` prefix is mandated by WAFv2, so this is the one YOLO log group not named `yolo-{env}-…`), retained for 30 days. Each entry names the rule that matched, so you can answer *why* an IP was rejected and see what a Count-mode rule *would* have blocked — and the app's task role has read access to the stream, so an application can look up whether a given IP is tripping a rule. Allowed traffic is deliberately not logged here: the ALB's own access logs (in the env logs bucket) already record every request including WAF rejections, and duplicating the allow stream would multiply the logging cost for no extra signal. Logging is reconciled on every sync like the rest of the policy.
 
+## Alert alarms
+
+Every environment gets a family of **"a human should look"** alarms — named `…-alert-…` to keep them distinct from the autoscaling alarms, whose ALARM state is part of their control loop and means nothing by itself. Every alert fires to the env's `yolo-{env}-alarms` SNS topic (state changes in both directions), and none of them should be in ALARM under normal operation — if an alert is red, something is genuinely wrong:
+
+| Alert | Scope | Fires when |
+|---|---|---|
+| `alb-5xx` | Environment | The load balancer itself is generating 5xx — no healthy targets, a dead target group, a broken rule |
+| `valkey-memory` / `valkey-evictions` | Environment | The shared cache/session node is above 85% memory, or evicting keys — sessions being thrown away |
+| `database-cpu` / `-memory` / `-connections` / `-buffer-cache` | Environment (when the env manifest declares a [`database`](/reference/commands#yolo-sync-environment)) | The cluster writer is saturating: CPU ≥ 80% sustained, freeable memory under 10% of the instance, connections past 75% of the class ceiling, or the working set no longer fitting in memory. The absolute thresholds derive from the writer's instance class at sync time |
+| `web-5xx` | App | The app is serving 5xx to ≥ 5% of its own requests (rate, not count, with a traffic floor so one error on a trickle can't page) |
+
+Topic **subscriptions are yours** — YOLO creates the topic but never subscribes endpoints. Subscribe an email or chat webhook to start; promote to a pager integration once the signal has earned trust. Thresholds are hardcoded — these are "bad things are happening" bars, not tuning knobs.
+
 ## Plan, confirm, apply
 
 `sync` never surprises you. It runs as a three-step flow:

--- a/src/Aws/CloudWatch.php
+++ b/src/Aws/CloudWatch.php
@@ -8,9 +8,15 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
 
 class CloudWatch
 {
+    /**
+     * Targeted by name — DescribeAlarms unfiltered returns one 50-record page,
+     * so a full-region scan false-negatives once an account holds more alarms
+     * than a page (exists() would report WOULD_CREATE forever and fail the
+     * deploy drift gate). AlarmNames makes it a single exact lookup.
+     */
     public static function alarm(string $name): array
     {
-        foreach (Aws::cloudWatch()->describeAlarms()['MetricAlarms'] ?? [] as $alarm) {
+        foreach (Aws::cloudWatch()->describeAlarms(['AlarmNames' => [$name]])['MetricAlarms'] ?? [] as $alarm) {
             if ($alarm['AlarmName'] === $name) {
                 return $alarm;
             }
@@ -23,13 +29,27 @@ class CloudWatch
      * Every alarm whose name starts with the given prefix, reduced to
      * {name, state, reason} — the app's alarms for `yolo status:alarms`. Empty
      * when the read fails or none match, so the caller degrades gracefully.
+     * Server-side prefix filter + pagination, for the same page-limit reason
+     * as alarm().
      *
      * @return array<int, array{name: string, state: ?string, reason: ?string}>
      */
     public static function alarmsWithPrefix(string $prefix): array
     {
+        $alarms = [];
+        $token = null;
+
         try {
-            $alarms = Aws::cloudWatch()->describeAlarms()['MetricAlarms'] ?? [];
+            do {
+                $page = Aws::cloudWatch()->describeAlarms(array_filter([
+                    'AlarmNamePrefix' => $prefix,
+                    'NextToken' => $token,
+                ]));
+
+                $alarms = [...$alarms, ...($page['MetricAlarms'] ?? [])];
+
+                $token = $page['NextToken'] ?? null;
+            } while ($token !== null);
         } catch (AwsException) {
             return [];
         }

--- a/src/Commands/DestroyAppCommand.php
+++ b/src/Commands/DestroyAppCommand.php
@@ -138,6 +138,7 @@ class DestroyAppCommand extends SyncSteppedCommand implements PlansSequentially
         return [
             'app' => array_values(array_filter([
                 Steps\Destroy\App\TeardownCloudWatchDashboardStep::class,
+                Steps\Destroy\App\TeardownWebAlertAlarmStep::class,
                 Steps\Destroy\App\TeardownCloudFrontAssetDistributionStep::class,
                 // Autoscaling before the service it scales: burst (policy + its
                 // standalone alarm), then the scalable target (cascades the rest).

--- a/src/Commands/DestroyEnvironmentCommand.php
+++ b/src/Commands/DestroyEnvironmentCommand.php
@@ -194,6 +194,8 @@ class DestroyEnvironmentCommand extends SyncSteppedCommand implements PlansSeque
             Steps\Destroy\Environment\TeardownCacheSecurityGroupStep::class,
             Steps\Destroy\Environment\TeardownCacheSubnetGroupStep::class,
             Steps\Destroy\Environment\TeardownCacheParameterGroupStep::class,
+            // The alert alarms before the topic they fire to.
+            Steps\Destroy\Environment\TeardownAlertAlarmsStep::class,
             Steps\Destroy\Environment\TeardownSnsAlarmTopicStep::class,
             // Storage last: the env logs bucket, then the env config bucket, whose
             // deletion is the final act of the env (Tier A) teardown. The IAM tier

--- a/src/Commands/SyncAppCommand.php
+++ b/src/Commands/SyncAppCommand.php
@@ -337,6 +337,7 @@ class SyncAppCommand extends SyncSteppedCommand
                     ]
                     : [],
                 // observability — runs last so every resource it charts already exists
+                Steps\Sync\App\SyncWebAlertAlarmStep::class,
                 Steps\Sync\App\SyncCloudWatchDashboardStep::class,
             ],
         ];

--- a/src/Commands/SyncEnvironmentCommand.php
+++ b/src/Commands/SyncEnvironmentCommand.php
@@ -174,6 +174,9 @@ class SyncEnvironmentCommand extends SyncSteppedCommand
                 Steps\Sync\Environment\SyncWafLogGroupStep::class,
                 Steps\Sync\Environment\SyncWafWebAclStep::class,
                 Steps\Sync\Environment\SyncWafAssociationStep::class,
+                // The env alert alarms — after the SNS topic they fire to and
+                // the load balancer whose ARN suffix they dimension on.
+                Steps\Sync\Environment\SyncAlertAlarmsStep::class,
             ],
         ];
     }

--- a/src/Concerns/SynchronisesResource.php
+++ b/src/Concerns/SynchronisesResource.php
@@ -137,4 +137,27 @@ trait SynchronisesResource
 
         return StepResult::DELETED;
     }
+
+    /**
+     * Fold many per-resource results into one step result: the first pending
+     * or applied write wins, a clean SYNCED beats nothing-to-do, SKIPPED only
+     * when every resource skipped. For steps that sync a family of resources
+     * in one pass.
+     *
+     * @param  array<int, StepResult>  $results
+     */
+    protected function aggregateResults(array $results): StepResult
+    {
+        foreach ([
+            StepResult::WOULD_CREATE, StepResult::CREATED,
+            StepResult::WOULD_DELETE, StepResult::DELETED,
+            StepResult::WOULD_SYNC,
+        ] as $significant) {
+            if (in_array($significant, $results, true)) {
+                return $significant;
+            }
+        }
+
+        return in_array(StepResult::SYNCED, $results, true) ? StepResult::SYNCED : StepResult::SKIPPED;
+    }
 }

--- a/src/Resources/CloudWatch/AlertAlarm.php
+++ b/src/Resources/CloudWatch/AlertAlarm.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace Codinglabs\Yolo\Resources\CloudWatch;
+
+use Codinglabs\Yolo\Aws;
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Aws\CloudWatch;
+use Codinglabs\Yolo\Resources\Resource;
+use Codinglabs\Yolo\Resources\Deletable;
+use Codinglabs\Yolo\Resources\ResolvesTags;
+use Codinglabs\Yolo\Resources\Sns\SnsAlarmTopic;
+use Codinglabs\Yolo\Resources\SynchronisesConfiguration;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * One "bad things are happening" alarm, firing to the env SNS topic —
+ * parameterised so the alert steps compose the whole family (ALB 5xx, cache
+ * pressure, database saturation, per-app error rate) from one resource. The
+ * `alert-` name segment marks the family: these are the alarms that mean a
+ * human should look, distinct from the autoscaling alarms that live in ALARM
+ * as part of their control loop. Missing data is not breaching by default —
+ * an absent metric stream (idle env, torn-down source) must not page.
+ *
+ * Takes either a plain metric (namespace/metric/statistic) or a `metrics`
+ * math array (e.g. an error *rate* over two metrics); putMetricAlarm is a
+ * pure upsert either way, so drift re-puts the whole payload.
+ */
+class AlertAlarm implements Deletable, Resource, SynchronisesConfiguration
+{
+    use ResolvesTags;
+
+    /**
+     * @param  array<int, array{Name: string, Value: string}>  $dimensions
+     * @param  array<int, array<string, mixed>>  $metrics
+     */
+    public function __construct(
+        protected string $suffix,
+        protected string $description,
+        protected Scope $alarmScope,
+        protected string $comparisonOperator,
+        protected float $threshold,
+        protected int $evaluationPeriods,
+        protected ?string $namespace = null,
+        protected ?string $metricName = null,
+        protected array $dimensions = [],
+        protected string $statistic = 'Average',
+        protected int $period = 300,
+        protected ?int $datapointsToAlarm = null,
+        protected array $metrics = [],
+    ) {}
+
+    public function name(): string
+    {
+        return $this->keyedName('alert-' . $this->suffix);
+    }
+
+    public function scope(): Scope
+    {
+        return $this->alarmScope;
+    }
+
+    public function exists(): bool
+    {
+        try {
+            CloudWatch::alarm($this->name());
+
+            return true;
+        } catch (ResourceDoesNotExistException) {
+            return false;
+        }
+    }
+
+    public function arn(): string
+    {
+        return CloudWatch::alarm($this->name())['AlarmArn'];
+    }
+
+    public function create(): void
+    {
+        Aws::cloudWatch()->putMetricAlarm($this->payload());
+    }
+
+    public function delete(): void
+    {
+        Aws::cloudWatch()->deleteAlarms(['AlarmNames' => [$this->name()]]);
+    }
+
+    public function synchroniseTags(bool $apply): array
+    {
+        return Aws::synchroniseCloudWatchTags($this->arn(), $this->tags(), $apply);
+    }
+
+    /**
+     * Reconcile the alarm's managed fields — putMetricAlarm is a pure upsert,
+     * so drift re-puts the whole payload.
+     *
+     * @return array<int, Change>
+     */
+    public function synchroniseConfiguration(bool $apply = true): array
+    {
+        $live = CloudWatch::alarm($this->name());
+
+        $changes = [];
+
+        foreach (array_filter([
+            'Threshold' => $this->threshold,
+            'EvaluationPeriods' => $this->evaluationPeriods,
+            'ComparisonOperator' => $this->comparisonOperator,
+            'MetricName' => $this->metricName,
+            'DatapointsToAlarm' => $this->datapointsToAlarm,
+        ], fn (mixed $desired): bool => $desired !== null) as $field => $desired) {
+            if (($live[$field] ?? null) != $desired) {
+                $changes[] = Change::make($field, $live[$field] ?? null, $desired);
+            }
+        }
+
+        // Re-point the alarm after a topic rename: an alarm keeps firing to
+        // whatever ARN it was created with, so AlarmActions is drift like any
+        // other field. Resolving the desired ARN needs the topic to exist —
+        // on the plan pass of the very sync that creates it (greenfield, or a
+        // rename), absence itself proves the re-point is pending, so record
+        // the change without resolving; the apply pass runs after the topic
+        // step and resolves it (the two-pass contract).
+        try {
+            $desiredActions = [(new SnsAlarmTopic())->arn()];
+
+            if (($live['AlarmActions'] ?? []) != $desiredActions) {
+                $changes[] = Change::make('AlarmActions', $live['AlarmActions'][0] ?? null, $desiredActions[0]);
+            }
+        } catch (ResourceDoesNotExistException) {
+            $changes[] = Change::make('AlarmActions', $live['AlarmActions'][0] ?? null, (new SnsAlarmTopic())->name());
+        }
+
+        if ($changes !== [] && $apply) {
+            Aws::cloudWatch()->putMetricAlarm($this->payload());
+        }
+
+        return $changes;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function payload(): array
+    {
+        return [
+            'AlarmName' => $this->name(),
+            'AlarmDescription' => $this->description,
+            ...$this->metrics !== [] ? [
+                'Metrics' => $this->metrics,
+            ] : [
+                'Namespace' => $this->namespace,
+                'MetricName' => $this->metricName,
+                'Dimensions' => $this->dimensions,
+                'Statistic' => $this->statistic,
+                'Period' => $this->period,
+            ],
+            'EvaluationPeriods' => $this->evaluationPeriods,
+            ...$this->datapointsToAlarm !== null ? ['DatapointsToAlarm' => $this->datapointsToAlarm] : [],
+            'Threshold' => $this->threshold,
+            'ComparisonOperator' => $this->comparisonOperator,
+            'TreatMissingData' => 'notBreaching',
+            'AlarmActions' => [(new SnsAlarmTopic())->arn()],
+            'OKActions' => [(new SnsAlarmTopic())->arn()],
+            ...Aws::tags($this->tags()),
+        ];
+    }
+}

--- a/src/Resources/CloudWatch/AlertAlarm.php
+++ b/src/Resources/CloudWatch/AlertAlarm.php
@@ -50,6 +50,22 @@ class AlertAlarm implements Deletable, Resource, SynchronisesConfiguration
         protected array $metrics = [],
     ) {}
 
+    /**
+     * Name-only construction for the delete path — teardown addresses alarms
+     * purely by name, so the metric fields are irrelevant there.
+     */
+    public static function bare(string $suffix, Scope $alarmScope): self
+    {
+        return new self(
+            suffix: $suffix,
+            description: 'retired',
+            alarmScope: $alarmScope,
+            comparisonOperator: 'GreaterThanThreshold',
+            threshold: 0,
+            evaluationPeriods: 1,
+        );
+    }
+
     public function name(): string
     {
         return $this->keyedName('alert-' . $this->suffix);
@@ -115,6 +131,25 @@ class AlertAlarm implements Deletable, Resource, SynchronisesConfiguration
             }
         }
 
+        // The measurement itself is drift too: the dimensions carry ALB/target
+        // group ARN suffixes that change when those are recreated while the
+        // alarm's name survives — left unreconciled, the alarm points at a dead
+        // metric and notBreaching keeps it green forever. For metric-math
+        // alarms the whole semantics (expression, traffic floor) live here.
+        if ($this->metrics === []) {
+            foreach ([
+                'Dimensions' => $this->dimensions,
+                'Period' => $this->period,
+                'Statistic' => $this->statistic,
+            ] as $field => $desired) {
+                if (($live[$field] ?? null) != $desired) {
+                    $changes[] = Change::make($field, 'drift', 'reconciled');
+                }
+            }
+        } elseif ($this->metricsSignature($live['Metrics'] ?? []) != $this->metricsSignature($this->metrics)) {
+            $changes[] = Change::make('Metrics', 'drift', 'reconciled (metric math)');
+        }
+
         // Re-point the alarm after a topic rename: an alarm keeps firing to
         // whatever ARN it was created with, so AlarmActions is drift like any
         // other field. Resolving the desired ARN needs the topic to exist —
@@ -137,6 +172,31 @@ class AlertAlarm implements Deletable, Resource, SynchronisesConfiguration
         }
 
         return $changes;
+    }
+
+    /**
+     * A stable, echo-back-proof projection of a Metrics array, keyed by Id —
+     * only the authored fields are compared, so keys AWS adds on read can't
+     * fake drift and keep the sync --check gate deterministic.
+     *
+     * @param  array<int, array<string, mixed>>  $metrics
+     * @return array<string, array<string, mixed>>
+     */
+    protected function metricsSignature(array $metrics): array
+    {
+        $signatures = [];
+
+        foreach ($metrics as $entry) {
+            $signatures[$entry['Id'] ?? ''] = [
+                'expression' => $entry['Expression'] ?? null,
+                'returnData' => $entry['ReturnData'] ?? null,
+                'metric' => $entry['MetricStat']['Metric'] ?? null,
+                'period' => $entry['MetricStat']['Period'] ?? null,
+                'stat' => $entry['MetricStat']['Stat'] ?? null,
+            ];
+        }
+
+        return $signatures;
     }
 
     /**

--- a/src/Resources/CloudWatch/Dashboard.php
+++ b/src/Resources/CloudWatch/Dashboard.php
@@ -13,6 +13,7 @@ use Codinglabs\Yolo\Aws\WafV2;
 use Codinglabs\Yolo\Enums\Service;
 use Codinglabs\Yolo\Aws\CloudFront;
 use Codinglabs\Yolo\Aws\CloudWatch;
+use Codinglabs\Yolo\Services\Alerts;
 use Codinglabs\Yolo\Enums\ServerGroup;
 use Codinglabs\Yolo\Resources\Deletable;
 use Codinglabs\Yolo\Resources\WafV2\WebAcl;
@@ -21,6 +22,7 @@ use Codinglabs\Yolo\Resources\Ecs\EcsService;
 use Codinglabs\Yolo\Resources\S3\AssetBucket;
 use Codinglabs\Yolo\Resources\ElbV2\TargetGroup;
 use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
+use Codinglabs\Yolo\Resources\ElastiCache\CacheCluster;
 use Codinglabs\Yolo\Resources\CloudWatchLogs\TaskLogGroup;
 use Codinglabs\Yolo\Resources\CloudFront\AssetDistribution;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -69,7 +71,8 @@ class Dashboard implements Deletable
     // this floor means the service is degraded or fully out of rotation.
     protected const EXPECTED_HEALTHY_HOSTS = 1;
 
-    // 5xx SLO line (% of requests). A sustained breach is a user-facing outage.
+    // 5xx SLO line (% of requests) — the aspiration, drawn alongside the alert
+    // alarm's threshold (Alerts::WEB_5XX_RATE_PERCENT), which is what pages.
     protected const ERROR_RATE_SLO = 1;
 
     // Public: service definitions reference the palette when composing their
@@ -216,6 +219,15 @@ class Dashboard implements Deletable
             // identifier — or a manifest declared ahead of the database — read as
             // a clean sync. Declare the key only once the database exists.
             'rds' => Rds::target(),
+            // The writer's instance class feeds the capacity-derived alarm
+            // lines (connection ceiling, memory floor) — null while the writer
+            // isn't resolvable, which just omits the lines.
+            'databaseWriterClass' => ($target = Rds::target()) !== null && $target['cluster']
+                ? Alerts::writerClass($target['identifier'])
+                : null,
+            // The env-shared Valkey node, like the WAF: shown for any app
+            // behind it, omitted until the cluster exists.
+            'cacheNodeId' => (new CacheCluster())->exists() ? (new CacheCluster())->name() . '-001' : null,
             'buckets' => static::bucketNames(),
             'taskLogGroup' => $web ? (new TaskLogGroup())->name() : null,
             // Each service definition contributes its own context entries —
@@ -364,6 +376,13 @@ class Dashboard implements Deletable
             $widgets = [...$widgets, ...$section];
         }
 
+        // The env-shared Valkey node — like the WAF, shown for any app behind
+        // it and omitted until the cluster exists.
+        if ($context['cacheNodeId'] !== null) {
+            [$section, $y] = static::cacheSection($context, $y);
+            $widgets = [...$widgets, ...$section];
+        }
+
         [$section, $y] = static::storageSection($context, $y);
         $widgets = [...$widgets, ...$section];
 
@@ -443,7 +462,8 @@ class Dashboard implements Deletable
                     ['AWS/ApplicationELB', 'RequestCount', ...static::appAlbDimensions($targetGroup, $alb), ['id' => 'm2', 'visible' => false]],
                 ],
                 'annotations' => ['horizontal' => [
-                    ['color' => static::RED, 'label' => 'SLO', 'value' => static::ERROR_RATE_SLO, 'fill' => 'above'],
+                    ['color' => static::ORANGE, 'label' => 'SLO', 'value' => static::ERROR_RATE_SLO],
+                    ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::WEB_5XX_RATE_PERCENT, 'fill' => 'above'],
                 ]],
             ]);
             $y += 6;
@@ -499,12 +519,15 @@ class Dashboard implements Deletable
                 ],
             ]);
 
+            // 5-minute period so the ELB 5xx alarm line is honest: the alarm
+            // evaluates a 5-minute Sum, and a per-minute chart would overstate
+            // the threshold fivefold.
             $widgets[] = static::metric(12, $y, 12, 6, [
                 'title' => 'HTTP errors',
                 'region' => $region,
                 'view' => 'timeSeries',
                 'stacked' => false,
-                'period' => 60,
+                'period' => 300,
                 'stat' => 'Sum',
                 'metrics' => [
                     ['AWS/ApplicationELB', 'HTTPCode_Target_4XX_Count', ...static::appAlbDimensions($targetGroup, $alb), ['label' => '4xx', 'color' => static::ORANGE]],
@@ -513,6 +536,9 @@ class Dashboard implements Deletable
                     // to a target group, so this one line stays env-wide (labelled as such).
                     ['AWS/ApplicationELB', 'HTTPCode_ELB_5XX_Count', 'LoadBalancer', $alb, ['label' => 'ELB 5xx (LB-wide)', 'color' => static::PURPLE]],
                 ],
+                'annotations' => ['horizontal' => [
+                    ['color' => static::RED, 'label' => 'ELB 5xx alarm', 'value' => Alerts::ALB_5XX_PER_FIVE_MINUTES, 'fill' => 'above'],
+                ]],
             ]);
             $y += 6;
         }
@@ -855,6 +881,15 @@ class Dashboard implements Deletable
         $widgets = [static::header($y, '# Database')];
         $y++;
 
+        // The alert alarms only exist for a cluster (they dimension on the
+        // WRITER role), so the alarm lines draw only there — and the capacity
+        // pair only when the writer's class is tabulated (not Serverless v2).
+        $capacityClass = $context['databaseWriterClass'] !== null
+            && $context['databaseWriterClass'] !== 'db.serverless'
+            && array_key_exists($context['databaseWriterClass'], Alerts::AURORA_CLASSES)
+                ? $context['databaseWriterClass']
+                : null;
+
         $widgets[] = static::metric(0, $y, 12, 6, [
             'title' => 'RDS CPU',
             'region' => $region,
@@ -866,6 +901,9 @@ class Dashboard implements Deletable
             'metrics' => $rds['cluster']
                 ? [$metric('CPUUtilization', ['label' => 'Writer', 'color' => static::BLUE]), $reader('CPUUtilization', ['label' => 'Readers', 'color' => static::PURPLE])]
                 : [$metric('CPUUtilization')],
+            ...$rds['cluster'] ? ['annotations' => ['horizontal' => [
+                ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::DATABASE_CPU_PERCENT, 'fill' => 'above'],
+            ]]] : [],
         ]);
 
         $widgets[] = static::metric(12, $y, 12, 6, [
@@ -878,6 +916,9 @@ class Dashboard implements Deletable
             'metrics' => $rds['cluster']
                 ? [$metric('DatabaseConnections', ['label' => 'Writer', 'color' => static::BLUE]), $reader('DatabaseConnections', ['label' => 'Readers', 'color' => static::PURPLE])]
                 : [$metric('DatabaseConnections')],
+            ...$capacityClass !== null ? ['annotations' => ['horizontal' => [
+                ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::databaseConnectionsCeiling($capacityClass), 'fill' => 'above'],
+            ]]] : [],
         ]);
         $y += 6;
 
@@ -889,6 +930,9 @@ class Dashboard implements Deletable
             'period' => 60,
             'stat' => 'Average',
             'metrics' => [$metric('FreeableMemory')],
+            ...$capacityClass !== null ? ['annotations' => ['horizontal' => [
+                ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::databaseMemoryFloorBytes($capacityClass), 'fill' => 'below'],
+            ]]] : [],
         ]);
 
         // SelectThroughput/Insert/Update/Delete are Aurora-only metrics — a plain
@@ -964,6 +1008,77 @@ class Dashboard implements Deletable
                 ],
             ]);
         }
+        $y += 6;
+
+        // The buffer-cache hit ratio backs the database-buffer-cache alert —
+        // Aurora-only, like the alarm.
+        if ($rds['cluster']) {
+            $widgets[] = static::metric(0, $y, 12, 6, [
+                'title' => 'Aurora buffer cache hit ratio',
+                'region' => $region,
+                'view' => 'timeSeries',
+                'stacked' => false,
+                'period' => 60,
+                'stat' => 'Average',
+                'yAxis' => ['left' => ['min' => 0, 'max' => 100, 'showUnits' => false]],
+                'metrics' => [$metric('BufferCacheHitRatio', ['label' => 'Writer', 'color' => static::BLUE])],
+                'annotations' => ['horizontal' => [
+                    ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::DATABASE_BUFFER_CACHE_PERCENT, 'fill' => 'below'],
+                ]],
+            ]);
+            $y += 6;
+        }
+
+        return [$widgets, $y];
+    }
+
+    /**
+     * The env-shared Valkey node: memory pressure and evictions, each with its
+     * alert alarm's threshold drawn on — evictions at the alarm's 5-minute
+     * period so the line means what the alarm means.
+     *
+     * @param  array<string, mixed>  $context
+     * @return array{0: array<int, array<string, mixed>>, 1: int}
+     */
+    protected static function cacheSection(array $context, int $y): array
+    {
+        $region = $context['region'];
+        $node = $context['cacheNodeId'];
+
+        $widgets = [static::header($y, '# Cache')];
+        $y++;
+
+        $widgets[] = static::metric(0, $y, 12, 6, [
+            'title' => 'Valkey memory',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 60,
+            'stat' => 'Average',
+            'yAxis' => ['left' => ['min' => 0, 'max' => 100, 'showUnits' => false]],
+            'metrics' => [
+                ['AWS/ElastiCache', 'DatabaseMemoryUsagePercentage', 'CacheClusterId', $node, ['label' => 'Memory %', 'color' => static::BLUE]],
+            ],
+            'annotations' => ['horizontal' => [
+                ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::VALKEY_MEMORY_PERCENT, 'fill' => 'above'],
+            ]],
+        ]);
+
+        $widgets[] = static::metric(12, $y, 12, 6, [
+            'title' => 'Valkey evictions',
+            'region' => $region,
+            'view' => 'timeSeries',
+            'stacked' => false,
+            'period' => 300,
+            'stat' => 'Sum',
+            'yAxis' => ['left' => ['min' => 0]],
+            'metrics' => [
+                ['AWS/ElastiCache', 'Evictions', 'CacheClusterId', $node, ['label' => 'Evictions / 5 min', 'color' => static::ORANGE]],
+            ],
+            'annotations' => ['horizontal' => [
+                ['color' => static::RED, 'label' => 'Alarm', 'value' => Alerts::VALKEY_EVICTIONS_PER_FIVE_MINUTES, 'fill' => 'above'],
+            ]],
+        ]);
         $y += 6;
 
         return [$widgets, $y];

--- a/src/Services/Alerts.php
+++ b/src/Services/Alerts.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Codinglabs\Yolo\Services;
+
+use Codinglabs\Yolo\Aws\Rds;
+
+/**
+ * The single source of truth for the alert-alarm thresholds — the sync steps
+ * provision alarms from these values and the CloudWatch dashboard draws its
+ * red alarm lines from the same ones, so the lines on the charts can never
+ * disagree with the alarms that page.
+ */
+final class Alerts
+{
+    /** Web target 5xx as a percentage of the app's own requests. */
+    public const int WEB_5XX_RATE_PERCENT = 5;
+
+    /** ALB-generated 5xx per 5-minute period. */
+    public const int ALB_5XX_PER_FIVE_MINUTES = 25;
+
+    public const int VALKEY_MEMORY_PERCENT = 85;
+
+    /** Evictions per 5-minute period — sustained rate, not any-eviction. */
+    public const int VALKEY_EVICTIONS_PER_FIVE_MINUTES = 100;
+
+    public const int DATABASE_CPU_PERCENT = 80;
+
+    /** Freeable-memory floor as a fraction of the writer class's memory. */
+    public const float DATABASE_MEMORY_FLOOR_FRACTION = 0.05;
+
+    /** Connection ceiling as a fraction of the class default max_connections. */
+    public const float DATABASE_CONNECTIONS_FRACTION = 0.75;
+
+    public const int DATABASE_BUFFER_CACHE_PERCENT = 85;
+
+    /**
+     * Aurora MySQL capacity by instance class: [memory GiB, default
+     * max_connections]. The memory floor and connection ceiling need absolute
+     * values, and CloudWatch has no notion of an instance's totals — so they
+     * derive from the writer's class at sync time. max_connections rows follow
+     * Aurora MySQL's default GREATEST(log2(mem/805306368)*45,
+     * log2(mem/8187281408)*1000) — derive new rows from the formula, don't
+     * guess (the ~1000 tier only starts at 16 GiB).
+     *
+     * @var array<string, array{0: float, 1: int}>
+     */
+    public const array AURORA_CLASSES = [
+        'db.t3.small' => [2, 45],
+        'db.t3.medium' => [4, 90],
+        'db.t4g.medium' => [4, 90],
+        'db.t4g.large' => [8, 150],
+        'db.r5.large' => [16, 1000],
+        'db.r5.xlarge' => [32, 2000],
+        'db.r5.2xlarge' => [64, 3000],
+        'db.r5.4xlarge' => [128, 4000],
+        'db.r6g.large' => [16, 1000],
+        'db.r6g.xlarge' => [32, 2000],
+        'db.r6g.2xlarge' => [64, 3000],
+        'db.r6g.4xlarge' => [128, 4000],
+        'db.r6i.large' => [16, 1000],
+        'db.r6i.xlarge' => [32, 2000],
+        'db.r6i.2xlarge' => [64, 3000],
+        'db.r6i.4xlarge' => [128, 4000],
+        'db.r7g.large' => [16, 1000],
+        'db.r7g.xlarge' => [32, 2000],
+        'db.r7g.2xlarge' => [64, 3000],
+        'db.r7g.4xlarge' => [128, 4000],
+    ];
+
+    /**
+     * The writer instance's class, from the live cluster membership — null
+     * while the writer isn't resolvable (a cluster mid-creation or mid-
+     * failover), which on an adopted database means "not yet", not an error.
+     */
+    public static function writerClass(string $cluster): ?string
+    {
+        $members = Rds::cluster($cluster)['DBClusterMembers'] ?? [];
+        $writer = collect($members)->firstWhere('IsClusterWriter', true)['DBInstanceIdentifier'] ?? null;
+
+        if ($writer === null) {
+            return null;
+        }
+
+        return collect(Rds::clusterInstances($cluster))
+            ->firstWhere('DBInstanceIdentifier', $writer)['DBInstanceClass'] ?? null;
+    }
+
+    /** The memory-floor alarm threshold in bytes for a tabulated class. */
+    public static function databaseMemoryFloorBytes(string $writerClass): float
+    {
+        return round(self::AURORA_CLASSES[$writerClass][0] * self::DATABASE_MEMORY_FLOOR_FRACTION * 1024 ** 3);
+    }
+
+    /** The connection-ceiling alarm threshold for a tabulated class. */
+    public static function databaseConnectionsCeiling(string $writerClass): float
+    {
+        return round(self::AURORA_CLASSES[$writerClass][1] * self::DATABASE_CONNECTIONS_FRACTION);
+    }
+}

--- a/src/Steps/Destroy/App/TeardownWebAlertAlarmStep.php
+++ b/src/Steps/Destroy/App/TeardownWebAlertAlarmStep.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\App;
+
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Contracts\ExecutesWebStep;
+use Codinglabs\Yolo\Steps\Destroy\TeardownStep;
+use Codinglabs\Yolo\Resources\CloudWatch\AlertAlarm;
+
+/**
+ * Tears down the app's web 5xx alert alarm. Deletion is by name only, so the
+ * alarm is constructed bare — the target group it watched may already be gone.
+ */
+class TeardownWebAlertAlarmStep extends TeardownStep implements ExecutesWebStep
+{
+    protected function resource(): AlertAlarm
+    {
+        return new AlertAlarm(
+            suffix: 'web-5xx',
+            description: 'retired',
+            alarmScope: Scope::App,
+            comparisonOperator: 'GreaterThanThreshold',
+            threshold: 0,
+            evaluationPeriods: 1,
+        );
+    }
+}

--- a/src/Steps/Destroy/App/TeardownWebAlertAlarmStep.php
+++ b/src/Steps/Destroy/App/TeardownWebAlertAlarmStep.php
@@ -17,13 +17,6 @@ class TeardownWebAlertAlarmStep extends TeardownStep implements ExecutesWebStep
 {
     protected function resource(): AlertAlarm
     {
-        return new AlertAlarm(
-            suffix: 'web-5xx',
-            description: 'retired',
-            alarmScope: Scope::App,
-            comparisonOperator: 'GreaterThanThreshold',
-            threshold: 0,
-            evaluationPeriods: 1,
-        );
+        return AlertAlarm::bare('web-5xx', Scope::App);
     }
 }

--- a/src/Steps/Destroy/Environment/TeardownAlertAlarmsStep.php
+++ b/src/Steps/Destroy/Environment/TeardownAlertAlarmsStep.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Codinglabs\Yolo\Steps\Destroy\Environment;
+
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Resources\CloudWatch\AlertAlarm;
+
+/**
+ * Tears down the env alert alarms. Deletion is by name only, so the alarms
+ * are constructed bare — no live lookups of the load balancer, cache or
+ * database they watched, which may already be gone by this point in the
+ * destroy. Absent alarms (e.g. the database set on an env that never
+ * declared one) skip for free.
+ */
+class TeardownAlertAlarmsStep implements Step
+{
+    use SynchronisesResource;
+
+    private const array SUFFIXES = [
+        'alb-5xx',
+        'valkey-memory',
+        'valkey-evictions',
+        'database-cpu',
+        'database-memory',
+        'database-connections',
+        'database-buffer-cache',
+    ];
+
+    public function __invoke(array $options): StepResult
+    {
+        $results = [];
+
+        foreach (self::SUFFIXES as $suffix) {
+            $results[] = $this->teardownResource(new AlertAlarm(
+                suffix: $suffix,
+                description: 'retired',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanThreshold',
+                threshold: 0,
+                evaluationPeriods: 1,
+            ), $options);
+        }
+
+        foreach ([
+            StepResult::WOULD_DELETE, StepResult::DELETED,
+        ] as $significant) {
+            if (in_array($significant, $results, true)) {
+                return $significant;
+            }
+        }
+
+        return StepResult::SKIPPED;
+    }
+}

--- a/src/Steps/Destroy/Environment/TeardownAlertAlarmsStep.php
+++ b/src/Steps/Destroy/Environment/TeardownAlertAlarmsStep.php
@@ -9,6 +9,7 @@ use Codinglabs\Yolo\Contracts\Step;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
 use Codinglabs\Yolo\Resources\CloudWatch\AlertAlarm;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncAlertAlarmsStep;
 
 /**
  * Tears down the env alert alarms. Deletion is by name only, so the alarms
@@ -21,39 +22,14 @@ class TeardownAlertAlarmsStep implements Step
 {
     use SynchronisesResource;
 
-    private const array SUFFIXES = [
-        'alb-5xx',
-        'valkey-memory',
-        'valkey-evictions',
-        'database-cpu',
-        'database-memory',
-        'database-connections',
-        'database-buffer-cache',
-    ];
-
     public function __invoke(array $options): StepResult
     {
         $results = [];
 
-        foreach (self::SUFFIXES as $suffix) {
-            $results[] = $this->teardownResource(new AlertAlarm(
-                suffix: $suffix,
-                description: 'retired',
-                alarmScope: Scope::Env,
-                comparisonOperator: 'GreaterThanThreshold',
-                threshold: 0,
-                evaluationPeriods: 1,
-            ), $options);
+        foreach (SyncAlertAlarmsStep::SUFFIXES as $suffix) {
+            $results[] = $this->teardownResource(AlertAlarm::bare($suffix, Scope::Env), $options);
         }
 
-        foreach ([
-            StepResult::WOULD_DELETE, StepResult::DELETED,
-        ] as $significant) {
-            if (in_array($significant, $results, true)) {
-                return $significant;
-            }
-        }
-
-        return StepResult::SKIPPED;
+        return $this->aggregateResults($results);
     }
 }

--- a/src/Steps/Sync/App/SyncWebAlertAlarmStep.php
+++ b/src/Steps/Sync/App/SyncWebAlertAlarmStep.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Sync\App;
+
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Contracts\ExecutesWebStep;
+use Codinglabs\Yolo\Resources\ElbV2\TargetGroup;
+use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
+use Codinglabs\Yolo\Resources\CloudWatch\AlertAlarm;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * The app's error-rate alarm on the env SNS topic: sustained target 5xx as a
+ * percentage of the app's own requests. A rate, not a count, so a busy app
+ * and a quiet one share one threshold — with a traffic floor (a minute under
+ * one request per second scores 0) so a single error on a trickle of
+ * requests can't page. The dimensions are ARN suffixes, so on a greenfield
+ * plan the alarm reports pending and lands on the next sync.
+ */
+class SyncWebAlertAlarmStep implements ExecutesWebStep
+{
+    use SynchronisesResource;
+
+    public function __invoke(array $options): StepResult
+    {
+        try {
+            $dimensions = [
+                ['Name' => 'TargetGroup', 'Value' => Dashboard::targetGroupDimension((new TargetGroup())->arn())],
+                ['Name' => 'LoadBalancer', 'Value' => Dashboard::loadBalancerDimension((new LoadBalancer())->arn())],
+            ];
+        } catch (ResourceDoesNotExistException) {
+            $this->recordChange(Change::make('web 5xx alert', null, 'created (target group pending)'));
+
+            return StepResult::WOULD_CREATE;
+        }
+
+        return $this->syncResource($this->alarm($dimensions), $options);
+    }
+
+    /**
+     * @param  array<int, array{Name: string, Value: string}>  $dimensions
+     */
+    public function alarm(array $dimensions = []): AlertAlarm
+    {
+        return new AlertAlarm(
+            suffix: 'web-5xx',
+            description: 'This app is serving 5xx to at least 5% of its requests - users are seeing errors',
+            alarmScope: Scope::App,
+            comparisonOperator: 'GreaterThanOrEqualToThreshold',
+            threshold: 5,
+            evaluationPeriods: 5,
+            datapointsToAlarm: 3,
+            metrics: [
+                [
+                    'Id' => 'requests',
+                    'MetricStat' => [
+                        'Metric' => [
+                            'Namespace' => 'AWS/ApplicationELB',
+                            'MetricName' => 'RequestCount',
+                            'Dimensions' => $dimensions,
+                        ],
+                        'Period' => 60,
+                        'Stat' => 'Sum',
+                    ],
+                    'ReturnData' => false,
+                ],
+                [
+                    'Id' => 'errors',
+                    'MetricStat' => [
+                        'Metric' => [
+                            'Namespace' => 'AWS/ApplicationELB',
+                            'MetricName' => 'HTTPCode_Target_5XX_Count',
+                            'Dimensions' => $dimensions,
+                        ],
+                        'Period' => 60,
+                        'Stat' => 'Sum',
+                    ],
+                    'ReturnData' => false,
+                ],
+                [
+                    'Id' => 'rate',
+                    // The traffic floor: under 60 requests/min the rate is
+                    // pinned to 0, so one error on three requests can't page.
+                    // FILL backstops the 5xx series, which has no datapoints
+                    // at all in an error-free minute.
+                    'Expression' => 'IF(requests >= 60, 100 * FILL(errors, 0) / requests, 0)',
+                    'Label' => 'target 5xx rate %',
+                    'ReturnData' => true,
+                ],
+            ],
+        );
+    }
+}

--- a/src/Steps/Sync/App/SyncWebAlertAlarmStep.php
+++ b/src/Steps/Sync/App/SyncWebAlertAlarmStep.php
@@ -4,6 +4,7 @@ namespace Codinglabs\Yolo\Steps\Sync\App;
 
 use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Services\Alerts;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 use Codinglabs\Yolo\Resources\ElbV2\TargetGroup;
@@ -44,14 +45,14 @@ class SyncWebAlertAlarmStep implements ExecutesWebStep
     /**
      * @param  array<int, array{Name: string, Value: string}>  $dimensions
      */
-    public function alarm(array $dimensions = []): AlertAlarm
+    protected function alarm(array $dimensions): AlertAlarm
     {
         return new AlertAlarm(
             suffix: 'web-5xx',
             description: 'This app is serving 5xx to at least 5% of its requests - users are seeing errors',
             alarmScope: Scope::App,
             comparisonOperator: 'GreaterThanOrEqualToThreshold',
-            threshold: 5,
+            threshold: Alerts::WEB_5XX_RATE_PERCENT,
             evaluationPeriods: 5,
             datapointsToAlarm: 3,
             metrics: [

--- a/src/Steps/Sync/Environment/SyncAlertAlarmsStep.php
+++ b/src/Steps/Sync/Environment/SyncAlertAlarmsStep.php
@@ -4,9 +4,9 @@ namespace Codinglabs\Yolo\Steps\Sync\Environment;
 
 use Codinglabs\Yolo\Change;
 use Codinglabs\Yolo\Aws\Rds;
-use Codinglabs\Yolo\Manifest;
 use Codinglabs\Yolo\Enums\Scope;
 use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Services\Alerts;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
@@ -29,38 +29,29 @@ use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
  * - Aurora CPU / memory / connections / buffer-cache (only when the manifest
  *   declares a `database`): saturation tells on the adopted cluster, watching
  *   the writer so the alarm follows a failover.
+ *
+ * Thresholds live in {@see Alerts} — the CloudWatch dashboard draws its alarm
+ * lines from the same values, so charts and alarms can't drift apart.
  */
 class SyncAlertAlarmsStep implements Step
 {
     use SynchronisesResource;
 
     /**
-     * Aurora MySQL capacity by instance class: [memory GiB, default
-     * max_connections]. The memory floor and connection ceiling alarms need
-     * absolute thresholds, and CloudWatch has no notion of an instance's
-     * totals — so they derive from the writer's class at sync time. An
-     * unknown class hard-fails with a pointer here rather than silently
-     * shipping no coverage.
+     * The full alert family this step can provision — the teardown step
+     * consumes the same list, so the two can never diverge and orphan an
+     * alarm past its topic.
      *
-     * @var array<string, array{0: float, 1: int}>
+     * @var array<int, string>
      */
-    private const array AURORA_CLASSES = [
-        'db.t3.small' => [2, 45],
-        'db.t3.medium' => [4, 90],
-        'db.t4g.medium' => [4, 90],
-        'db.t4g.large' => [8, 1000],
-        'db.r5.large' => [16, 1000],
-        'db.r5.xlarge' => [32, 2000],
-        'db.r5.2xlarge' => [64, 3000],
-        'db.r5.4xlarge' => [128, 4000],
-        'db.r6g.large' => [16, 1000],
-        'db.r6g.xlarge' => [32, 2000],
-        'db.r6g.2xlarge' => [64, 3000],
-        'db.r6g.4xlarge' => [128, 4000],
-        'db.r7g.large' => [16, 1000],
-        'db.r7g.xlarge' => [32, 2000],
-        'db.r7g.2xlarge' => [64, 3000],
-        'db.r7g.4xlarge' => [128, 4000],
+    public const array SUFFIXES = [
+        'alb-5xx',
+        'valkey-memory',
+        'valkey-evictions',
+        'database-cpu',
+        'database-memory',
+        'database-connections',
+        'database-buffer-cache',
     ];
 
     public function __invoke(array $options): StepResult
@@ -71,7 +62,7 @@ class SyncAlertAlarmsStep implements Step
             $results[] = $this->syncResource($alarm, $options);
         }
 
-        return $this->aggregate($results);
+        return $this->aggregateResults($results);
     }
 
     /**
@@ -99,7 +90,7 @@ class SyncAlertAlarmsStep implements Step
                 description: 'The load balancer is generating 5xx responses itself - no healthy targets, a dead target group, or a broken rule; app-side errors have their own per-app alarm',
                 alarmScope: Scope::Env,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold: 25,
+                threshold: Alerts::ALB_5XX_PER_FIVE_MINUTES,
                 evaluationPeriods: 2,
                 namespace: 'AWS/ApplicationELB',
                 metricName: 'HTTPCode_ELB_5XX_Count',
@@ -126,18 +117,23 @@ class SyncAlertAlarmsStep implements Step
                 description: 'The shared Valkey node is above 85% memory - cache/session pressure; evictions follow if this holds',
                 alarmScope: Scope::Env,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold: 85,
+                threshold: Alerts::VALKEY_MEMORY_PERCENT,
                 evaluationPeriods: 2,
                 namespace: 'AWS/ElastiCache',
                 metricName: 'DatabaseMemoryUsagePercentage',
                 dimensions: $dimensions,
             ),
+            // A sustained rate, not any-eviction: the node runs allkeys-lru by
+            // design, so background LRU churn on a full-but-healthy cache is
+            // normal — a >0 trigger would latch red permanently the day an
+            // env's working set fills the node. Heavy sustained eviction is
+            // the session-loss signal.
             new AlertAlarm(
                 suffix: 'valkey-evictions',
-                description: 'Valkey is evicting keys - sessions and cache entries are being thrown away; the node needs headroom',
+                description: 'Valkey is evicting heavily and sustained - sessions and cache entries are being thrown away; the node needs headroom',
                 alarmScope: Scope::Env,
-                comparisonOperator: 'GreaterThanThreshold',
-                threshold: 0,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold: Alerts::VALKEY_EVICTIONS_PER_FIVE_MINUTES,
                 evaluationPeriods: 3,
                 namespace: 'AWS/ElastiCache',
                 metricName: 'Evictions',
@@ -150,54 +146,97 @@ class SyncAlertAlarmsStep implements Step
 
     /**
      * Saturation tells on the declared database cluster, dimensioned on the
-     * writer so the alarms follow a failover. The absolute thresholds (memory
-     * floor, connection ceiling) derive from the writer's instance class; a
-     * cluster that can't be resolved yet reports pending rather than failing
-     * the plan.
+     * writer so the alarms follow a failover. Aurora clusters only — a plain
+     * RDS instance database has neither the WRITER role dimension nor the
+     * BufferCacheHitRatio metric, so the set doesn't exist there (the docs
+     * say so). The absolute thresholds (memory floor, connection ceiling)
+     * derive from the writer's instance class; a cluster whose writer can't
+     * be resolved yet reports pending rather than failing the plan, and a
+     * declared-but-nonexistent database keeps Rds::target()'s manifest-error
+     * throw, same as every other consumer.
      *
      * @return array<int, AlertAlarm>
      */
     protected function auroraAlarms(): array
     {
-        $cluster = Manifest::database();
+        $target = Rds::target();
 
-        if ($cluster === null) {
+        if ($target === null || ! $target['cluster']) {
             return [];
         }
 
-        $capacity = $this->writerCapacity($cluster);
+        $cluster = $target['identifier'];
+        $writerClass = Alerts::writerClass($cluster);
 
-        if ($capacity === null) {
-            $this->recordChange(Change::make('database alerts', null, 'created (cluster pending)'));
+        if ($writerClass === null) {
+            $this->recordChange(Change::make('database alerts', null, 'created (cluster writer pending)'));
 
             return [];
         }
-
-        [$memoryGib, $maxConnections] = $capacity;
 
         $dimensions = [
             ['Name' => 'DBClusterIdentifier', 'Value' => $cluster],
             ['Name' => 'Role', 'Value' => 'WRITER'],
         ];
 
-        return [
+        $alarms = [
             new AlertAlarm(
                 suffix: 'database-cpu',
                 description: 'Database writer CPU sustained above 80% - queries are queuing; find the load before it becomes an outage',
                 alarmScope: Scope::Env,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold: 80,
+                threshold: Alerts::DATABASE_CPU_PERCENT,
                 evaluationPeriods: 3,
                 namespace: 'AWS/RDS',
                 metricName: 'CPUUtilization',
                 dimensions: $dimensions,
             ),
+            // 6-of-8 rather than a straight run: the ratio legitimately dips
+            // while the buffer pool re-warms after a restart or failover, and
+            // that window can exceed a straight half-hour on a large working
+            // set — the alarm is for sustained degradation, not warm-up.
+            new AlertAlarm(
+                suffix: 'database-buffer-cache',
+                description: 'Database buffer cache hit ratio below 85% sustained - the working set no longer fits in memory, reads are hitting storage',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'LessThanThreshold',
+                threshold: Alerts::DATABASE_BUFFER_CACHE_PERCENT,
+                evaluationPeriods: 8,
+                namespace: 'AWS/RDS',
+                metricName: 'BufferCacheHitRatio',
+                dimensions: $dimensions,
+                datapointsToAlarm: 6,
+            ),
+        ];
+
+        // Serverless v2 reports class "db.serverless" — capacity floats with
+        // the ACU range, so the static memory/connection thresholds have no
+        // basis there; the percentage-based pair above still holds.
+        if ($writerClass === 'db.serverless') {
+            return $alarms;
+        }
+
+        if (! array_key_exists($writerClass, Alerts::AURORA_CLASSES)) {
+            throw new IntegrityCheckException(sprintf(
+                'Unknown database instance class "%s" for cluster "%s" - add its memory and max_connections to %s::AURORA_CLASSES so the saturation alarms get real thresholds.',
+                $writerClass,
+                $cluster,
+                Alerts::class,
+            ));
+        }
+
+        return [
+            ...$alarms,
+            // 5%, not a rounder 10%: Aurora deliberately gives ~75% of class
+            // memory to the buffer pool, so a warm, healthy writer routinely
+            // idles with under 10% freeable — a higher floor latches in ALARM
+            // under normal operation.
             new AlertAlarm(
                 suffix: 'database-memory',
-                description: 'Database writer freeable memory below 10% of the instance - swap and restart territory',
+                description: 'Database writer freeable memory below 5% of the instance - swap and restart territory',
                 alarmScope: Scope::Env,
                 comparisonOperator: 'LessThanOrEqualToThreshold',
-                threshold: round($memoryGib * 0.10 * 1024 ** 3),
+                threshold: Alerts::databaseMemoryFloorBytes($writerClass),
                 evaluationPeriods: 3,
                 namespace: 'AWS/RDS',
                 metricName: 'FreeableMemory',
@@ -208,71 +247,12 @@ class SyncAlertAlarmsStep implements Step
                 description: 'Database connections above 75% of the class default ceiling - the next spike gets refused connections',
                 alarmScope: Scope::Env,
                 comparisonOperator: 'GreaterThanOrEqualToThreshold',
-                threshold: round($maxConnections * 0.75),
+                threshold: Alerts::databaseConnectionsCeiling($writerClass),
                 evaluationPeriods: 2,
                 namespace: 'AWS/RDS',
                 metricName: 'DatabaseConnections',
                 dimensions: $dimensions,
             ),
-            new AlertAlarm(
-                suffix: 'database-buffer-cache',
-                description: 'Database buffer cache hit ratio below 85% for half an hour - the working set no longer fits in memory, reads are hitting storage',
-                alarmScope: Scope::Env,
-                comparisonOperator: 'LessThanThreshold',
-                threshold: 85,
-                evaluationPeriods: 6,
-                namespace: 'AWS/RDS',
-                metricName: 'BufferCacheHitRatio',
-                dimensions: $dimensions,
-            ),
         ];
-    }
-
-    /**
-     * The writer instance's [memory GiB, default max_connections], from the
-     * live cluster membership — null while the cluster (or its writer) isn't
-     * resolvable, which on an adopted database means "not yet", not an error.
-     *
-     * @return array{0: float, 1: int}|null
-     */
-    protected function writerCapacity(string $cluster): ?array
-    {
-        $members = Rds::cluster($cluster)['DBClusterMembers'] ?? [];
-        $writer = collect($members)->firstWhere('IsClusterWriter', true)['DBInstanceIdentifier'] ?? null;
-
-        if ($writer === null) {
-            return null;
-        }
-
-        $class = collect(Rds::clusterInstances($cluster))
-            ->firstWhere('DBInstanceIdentifier', $writer)['DBInstanceClass'] ?? null;
-
-        if ($class === null) {
-            return null;
-        }
-
-        return self::AURORA_CLASSES[$class] ?? throw new IntegrityCheckException(sprintf(
-            'Unknown database instance class "%s" for cluster "%s" - add its memory and max_connections to %s::AURORA_CLASSES so the saturation alarms get real thresholds.',
-            $class,
-            $cluster,
-            self::class,
-        ));
-    }
-
-    /**
-     * @param  array<int, StepResult>  $results
-     */
-    protected function aggregate(array $results): StepResult
-    {
-        foreach ([
-            StepResult::WOULD_CREATE, StepResult::CREATED,
-            StepResult::WOULD_SYNC,
-        ] as $significant) {
-            if (in_array($significant, $results, true)) {
-                return $significant;
-            }
-        }
-
-        return in_array(StepResult::SYNCED, $results, true) ? StepResult::SYNCED : StepResult::SKIPPED;
     }
 }

--- a/src/Steps/Sync/Environment/SyncAlertAlarmsStep.php
+++ b/src/Steps/Sync/Environment/SyncAlertAlarmsStep.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace Codinglabs\Yolo\Steps\Sync\Environment;
+
+use Codinglabs\Yolo\Change;
+use Codinglabs\Yolo\Aws\Rds;
+use Codinglabs\Yolo\Manifest;
+use Codinglabs\Yolo\Enums\Scope;
+use Codinglabs\Yolo\Contracts\Step;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Resources\ElbV2\LoadBalancer;
+use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
+use Codinglabs\Yolo\Resources\CloudWatch\AlertAlarm;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+use Codinglabs\Yolo\Resources\ElastiCache\CacheCluster;
+use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
+
+/**
+ * The environment's "bad things are happening" alarms on the env SNS topic —
+ * the signals that mean a human should look, kept deliberately separate from
+ * the autoscaling alarms whose ALARM state is part of their control loop:
+ *
+ * - ALB-generated 5xx: the load balancer itself can't route (no healthy
+ *   targets, a dead target group) — app-side errors have their own per-app
+ *   rate alarm in sync:app.
+ * - Valkey memory/evictions: the shared cache/session store under pressure —
+ *   evictions mean sessions are being thrown away before anyone notices.
+ * - Aurora CPU / memory / connections / buffer-cache (only when the manifest
+ *   declares a `database`): saturation tells on the adopted cluster, watching
+ *   the writer so the alarm follows a failover.
+ */
+class SyncAlertAlarmsStep implements Step
+{
+    use SynchronisesResource;
+
+    /**
+     * Aurora MySQL capacity by instance class: [memory GiB, default
+     * max_connections]. The memory floor and connection ceiling alarms need
+     * absolute thresholds, and CloudWatch has no notion of an instance's
+     * totals — so they derive from the writer's class at sync time. An
+     * unknown class hard-fails with a pointer here rather than silently
+     * shipping no coverage.
+     *
+     * @var array<string, array{0: float, 1: int}>
+     */
+    private const array AURORA_CLASSES = [
+        'db.t3.small' => [2, 45],
+        'db.t3.medium' => [4, 90],
+        'db.t4g.medium' => [4, 90],
+        'db.t4g.large' => [8, 1000],
+        'db.r5.large' => [16, 1000],
+        'db.r5.xlarge' => [32, 2000],
+        'db.r5.2xlarge' => [64, 3000],
+        'db.r5.4xlarge' => [128, 4000],
+        'db.r6g.large' => [16, 1000],
+        'db.r6g.xlarge' => [32, 2000],
+        'db.r6g.2xlarge' => [64, 3000],
+        'db.r6g.4xlarge' => [128, 4000],
+        'db.r7g.large' => [16, 1000],
+        'db.r7g.xlarge' => [32, 2000],
+        'db.r7g.2xlarge' => [64, 3000],
+        'db.r7g.4xlarge' => [128, 4000],
+    ];
+
+    public function __invoke(array $options): StepResult
+    {
+        $results = [];
+
+        foreach ([...$this->albAlarms(), ...$this->valkeyAlarms(), ...$this->auroraAlarms()] as $alarm) {
+            $results[] = $this->syncResource($alarm, $options);
+        }
+
+        return $this->aggregate($results);
+    }
+
+    /**
+     * The ALB's own 5xx — needs the load balancer to exist (its CloudWatch
+     * dimension is an ARN suffix), so on a greenfield plan it reports pending
+     * and lands on the next sync.
+     *
+     * @return array<int, AlertAlarm>
+     */
+    protected function albAlarms(): array
+    {
+        try {
+            $dimensions = [
+                ['Name' => 'LoadBalancer', 'Value' => Dashboard::loadBalancerDimension((new LoadBalancer())->arn())],
+            ];
+        } catch (ResourceDoesNotExistException) {
+            $this->recordChange(Change::make('alb 5xx alert', null, 'created (load balancer pending)'));
+
+            return [];
+        }
+
+        return [
+            new AlertAlarm(
+                suffix: 'alb-5xx',
+                description: 'The load balancer is generating 5xx responses itself - no healthy targets, a dead target group, or a broken rule; app-side errors have their own per-app alarm',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold: 25,
+                evaluationPeriods: 2,
+                namespace: 'AWS/ApplicationELB',
+                metricName: 'HTTPCode_ELB_5XX_Count',
+                dimensions: $dimensions,
+                statistic: 'Sum',
+            ),
+        ];
+    }
+
+    /**
+     * @return array<int, AlertAlarm>
+     */
+    protected function valkeyAlarms(): array
+    {
+        // Single-node replication group: the node's CacheClusterId is the
+        // group id with the -001 member suffix.
+        $dimensions = [
+            ['Name' => 'CacheClusterId', 'Value' => (new CacheCluster())->name() . '-001'],
+        ];
+
+        return [
+            new AlertAlarm(
+                suffix: 'valkey-memory',
+                description: 'The shared Valkey node is above 85% memory - cache/session pressure; evictions follow if this holds',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold: 85,
+                evaluationPeriods: 2,
+                namespace: 'AWS/ElastiCache',
+                metricName: 'DatabaseMemoryUsagePercentage',
+                dimensions: $dimensions,
+            ),
+            new AlertAlarm(
+                suffix: 'valkey-evictions',
+                description: 'Valkey is evicting keys - sessions and cache entries are being thrown away; the node needs headroom',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanThreshold',
+                threshold: 0,
+                evaluationPeriods: 3,
+                namespace: 'AWS/ElastiCache',
+                metricName: 'Evictions',
+                dimensions: $dimensions,
+                statistic: 'Sum',
+                datapointsToAlarm: 2,
+            ),
+        ];
+    }
+
+    /**
+     * Saturation tells on the declared database cluster, dimensioned on the
+     * writer so the alarms follow a failover. The absolute thresholds (memory
+     * floor, connection ceiling) derive from the writer's instance class; a
+     * cluster that can't be resolved yet reports pending rather than failing
+     * the plan.
+     *
+     * @return array<int, AlertAlarm>
+     */
+    protected function auroraAlarms(): array
+    {
+        $cluster = Manifest::database();
+
+        if ($cluster === null) {
+            return [];
+        }
+
+        $capacity = $this->writerCapacity($cluster);
+
+        if ($capacity === null) {
+            $this->recordChange(Change::make('database alerts', null, 'created (cluster pending)'));
+
+            return [];
+        }
+
+        [$memoryGib, $maxConnections] = $capacity;
+
+        $dimensions = [
+            ['Name' => 'DBClusterIdentifier', 'Value' => $cluster],
+            ['Name' => 'Role', 'Value' => 'WRITER'],
+        ];
+
+        return [
+            new AlertAlarm(
+                suffix: 'database-cpu',
+                description: 'Database writer CPU sustained above 80% - queries are queuing; find the load before it becomes an outage',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold: 80,
+                evaluationPeriods: 3,
+                namespace: 'AWS/RDS',
+                metricName: 'CPUUtilization',
+                dimensions: $dimensions,
+            ),
+            new AlertAlarm(
+                suffix: 'database-memory',
+                description: 'Database writer freeable memory below 10% of the instance - swap and restart territory',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'LessThanOrEqualToThreshold',
+                threshold: round($memoryGib * 0.10 * 1024 ** 3),
+                evaluationPeriods: 3,
+                namespace: 'AWS/RDS',
+                metricName: 'FreeableMemory',
+                dimensions: $dimensions,
+            ),
+            new AlertAlarm(
+                suffix: 'database-connections',
+                description: 'Database connections above 75% of the class default ceiling - the next spike gets refused connections',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'GreaterThanOrEqualToThreshold',
+                threshold: round($maxConnections * 0.75),
+                evaluationPeriods: 2,
+                namespace: 'AWS/RDS',
+                metricName: 'DatabaseConnections',
+                dimensions: $dimensions,
+            ),
+            new AlertAlarm(
+                suffix: 'database-buffer-cache',
+                description: 'Database buffer cache hit ratio below 85% for half an hour - the working set no longer fits in memory, reads are hitting storage',
+                alarmScope: Scope::Env,
+                comparisonOperator: 'LessThanThreshold',
+                threshold: 85,
+                evaluationPeriods: 6,
+                namespace: 'AWS/RDS',
+                metricName: 'BufferCacheHitRatio',
+                dimensions: $dimensions,
+            ),
+        ];
+    }
+
+    /**
+     * The writer instance's [memory GiB, default max_connections], from the
+     * live cluster membership — null while the cluster (or its writer) isn't
+     * resolvable, which on an adopted database means "not yet", not an error.
+     *
+     * @return array{0: float, 1: int}|null
+     */
+    protected function writerCapacity(string $cluster): ?array
+    {
+        $members = Rds::cluster($cluster)['DBClusterMembers'] ?? [];
+        $writer = collect($members)->firstWhere('IsClusterWriter', true)['DBInstanceIdentifier'] ?? null;
+
+        if ($writer === null) {
+            return null;
+        }
+
+        $class = collect(Rds::clusterInstances($cluster))
+            ->firstWhere('DBInstanceIdentifier', $writer)['DBInstanceClass'] ?? null;
+
+        if ($class === null) {
+            return null;
+        }
+
+        return self::AURORA_CLASSES[$class] ?? throw new IntegrityCheckException(sprintf(
+            'Unknown database instance class "%s" for cluster "%s" - add its memory and max_connections to %s::AURORA_CLASSES so the saturation alarms get real thresholds.',
+            $class,
+            $cluster,
+            self::class,
+        ));
+    }
+
+    /**
+     * @param  array<int, StepResult>  $results
+     */
+    protected function aggregate(array $results): StepResult
+    {
+        foreach ([
+            StepResult::WOULD_CREATE, StepResult::CREATED,
+            StepResult::WOULD_SYNC,
+        ] as $significant) {
+            if (in_array($significant, $results, true)) {
+                return $significant;
+            }
+        }
+
+        return in_array(StepResult::SYNCED, $results, true) ? StepResult::SYNCED : StepResult::SKIPPED;
+    }
+}

--- a/tests/Unit/Commands/DestroyAppCommandTest.php
+++ b/tests/Unit/Commands/DestroyAppCommandTest.php
@@ -94,6 +94,10 @@ it('composes the MediaConvert role teardown when the app uses mediaconvert', fun
         ->toContain(Steps\Destroy\App\TeardownMediaConvertRoleStep::class);
 });
 
+it('composes the web alert alarm teardown for a web app', function () use ($soloWeb): void {
+    expect(destroyPlanClasses($soloWeb))->toContain(Steps\Destroy\App\TeardownWebAlertAlarmStep::class);
+});
+
 it('tears resources down in reverse dependency order', function () use ($soloWeb): void {
     $classes = destroyPlanClasses($soloWeb);
     $at = fn (string $class): int|false => array_search($class, $classes, true);

--- a/tests/Unit/Commands/DestroyEnvironmentCommandTest.php
+++ b/tests/Unit/Commands/DestroyEnvironmentCommandTest.php
@@ -221,6 +221,15 @@ it('tears the Valkey cache cluster down before the groups and SG it pins', funct
         ->toBeLessThan($at(Steps\Destroy\Environment\TeardownCacheSecurityGroupStep::class));
 });
 
+it('tears the alert alarms down before the SNS topic they fire to', function (): void {
+    $classes = destroyEnvPlanClasses();
+    $at = fn (string $class): int|false => array_search($class, $classes, true);
+
+    expect($at(Steps\Destroy\Environment\TeardownAlertAlarmsStep::class))
+        ->not->toBeFalse()
+        ->toBeLessThan($at(Steps\Destroy\Environment\TeardownSnsAlarmTopicStep::class));
+});
+
 it('reframes the runner wording as an irreversible destroy', function (): void {
     $command = new DestroyEnvironmentCommand();
 

--- a/tests/Unit/Resources/CloudWatch/DashboardTest.php
+++ b/tests/Unit/Resources/CloudWatch/DashboardTest.php
@@ -8,6 +8,7 @@ use Aws\CommandInterface;
 use Codinglabs\Yolo\Helpers;
 use GuzzleHttp\Promise\Create;
 use Aws\Exception\AwsException;
+use Codinglabs\Yolo\Services\Alerts;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Resources\CloudWatch\Dashboard;
 use Codinglabs\Yolo\Exceptions\ResourceDoesNotExistException;
@@ -40,6 +41,8 @@ function dashboardContext(array $overrides = []): array
         'queueService' => null,
         'schedulerService' => null,
         'rds' => ['identifier' => 'my-cluster', 'cluster' => true],
+        'databaseWriterClass' => 'db.r6g.large',
+        'cacheNodeId' => 'yolo-testing-cache-001',
         'buckets' => ['yolo-111111111111-testing-my-app-config', 'yolo-111111111111-testing-my-app-assets'],
         'taskLogGroup' => '/yolo/testing-my-app',
         'ivsLogGroup' => null,
@@ -90,6 +93,11 @@ function bindDashboardEnv(string $body): void
 
 beforeEach(function (): void {
     writeManifest(['region' => 'ap-southeast-2', 'account-id' => '111111111111']);
+
+    // resolveContext probes the env cache cluster for the # Cache section —
+    // an empty ElastiCache world reads as "no cluster yet" (section omitted).
+    $elastiCache = [];
+    bindMockElastiCacheClient([], $elastiCache);
 });
 
 it('names the dashboard per app + environment', function (): void {
@@ -205,6 +213,49 @@ it('omits the target-health panel when the target group is not resolved yet', fu
     expect(findWidget($body, 'Target health'))->toBeNull();
     // The 5xx rate only needs the ALB, so it still renders and takes the left slot.
     expect(findWidget($body, '5xx error rate')['x'])->toBe(0);
+});
+
+it('draws every alert alarm threshold as a red line from the same values the alarms sync', function (): void {
+    $body = Dashboard::body(dashboardContext());
+
+    $line = function (?array $widget): array {
+        expect($widget)->not->toBeNull();
+
+        return collect($widget['properties']['annotations']['horizontal'])
+            ->firstWhere('color', Dashboard::RED);
+    };
+
+    expect($line(findWidget($body, '5xx error rate'))['value'])->toBe(Alerts::WEB_5XX_RATE_PERCENT);
+    expect($line(findWidget($body, 'HTTP errors'))['value'])->toBe(Alerts::ALB_5XX_PER_FIVE_MINUTES);
+    expect($line(findWidget($body, 'RDS CPU'))['value'])->toBe(Alerts::DATABASE_CPU_PERCENT);
+    expect($line(findWidget($body, 'RDS connections'))['value'])->toBe(Alerts::databaseConnectionsCeiling('db.r6g.large'));
+    expect($line(findWidget($body, 'RDS freeable memory'))['value'])->toBe(Alerts::databaseMemoryFloorBytes('db.r6g.large'));
+    expect($line(findWidget($body, 'Aurora buffer cache hit ratio'))['value'])->toBe(Alerts::DATABASE_BUFFER_CACHE_PERCENT);
+
+    // The HTTP errors panel runs at the alarm's own 5-minute period so the
+    // line means what the alarm means.
+    expect(findWidget($body, 'HTTP errors')['properties']['period'])->toBe(300);
+});
+
+it('renders the # Cache section with the valkey alarm lines, and omits it without a cache node', function (): void {
+    $body = Dashboard::body(dashboardContext());
+
+    expect(widgetTitles($body))->toContain('# Cache');
+    expect(findWidget($body, 'Valkey memory')['properties']['annotations']['horizontal'][0]['value'])->toBe(Alerts::VALKEY_MEMORY_PERCENT);
+
+    $evictions = findWidget($body, 'Valkey evictions');
+    expect($evictions['properties']['annotations']['horizontal'][0]['value'])->toBe(Alerts::VALKEY_EVICTIONS_PER_FIVE_MINUTES)
+        ->and($evictions['properties']['period'])->toBe(300);
+
+    expect(widgetTitles(Dashboard::body(dashboardContext(['cacheNodeId' => null]))))->not->toContain('# Cache');
+});
+
+it('omits the capacity-derived lines for a Serverless v2 writer but keeps the percentage lines', function (): void {
+    $body = Dashboard::body(dashboardContext(['databaseWriterClass' => 'db.serverless']));
+
+    expect(findWidget($body, 'RDS connections')['properties'])->not->toHaveKey('annotations');
+    expect(findWidget($body, 'RDS freeable memory')['properties'])->not->toHaveKey('annotations');
+    expect(findWidget($body, 'RDS CPU')['properties']['annotations']['horizontal'][0]['value'])->toBe(Alerts::DATABASE_CPU_PERCENT);
 });
 
 it('expresses the 5xx error rate as this app target 5xx over its own requests with a 1% SLO line', function (): void {

--- a/tests/Unit/Steps/Alerts/AlertAlarmsTest.php
+++ b/tests/Unit/Steps/Alerts/AlertAlarmsTest.php
@@ -1,0 +1,238 @@
+<?php
+
+use Aws\Result;
+use Aws\MockHandler;
+use Aws\Sns\SnsClient;
+use Aws\CommandInterface;
+use Codinglabs\Yolo\Helpers;
+use GuzzleHttp\Promise\Create;
+use Codinglabs\Yolo\Enums\StepResult;
+use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
+use Codinglabs\Yolo\Steps\Sync\App\SyncWebAlertAlarmStep;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncAlertAlarmsStep;
+use Codinglabs\Yolo\Steps\Destroy\Environment\TeardownAlertAlarmsStep;
+
+beforeEach(function (): void {
+    writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+});
+
+function bindAlertsSnsClient(): void
+{
+    $mock = new class() extends MockHandler
+    {
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            return Create::promiseFor(new Result(['Topics' => [
+                ['TopicArn' => 'arn:aws:sns:ap-southeast-2:111111111111:yolo-testing-alarms'],
+            ]]));
+        }
+    };
+
+    Helpers::app()->instance('sns', new SnsClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+function alertsLoadBalancersResult(): Result
+{
+    return new Result(['LoadBalancers' => [[
+        'LoadBalancerName' => 'yolo-testing',
+        'LoadBalancerArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111:loadbalancer/app/yolo-testing/abc123',
+    ]]]);
+}
+
+function alertsAuroraResults(string $writerClass = 'db.r6g.large'): array
+{
+    return [
+        'DescribeDBClusters' => new Result(['DBClusters' => [[
+            'DBClusterIdentifier' => 'testing-cluster',
+            'DBClusterMembers' => [
+                ['DBInstanceIdentifier' => 'testing-writer', 'IsClusterWriter' => true],
+                ['DBInstanceIdentifier' => 'testing-reader', 'IsClusterWriter' => false],
+            ],
+        ]]]),
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'testing-writer', 'DBInstanceClass' => $writerClass, 'Endpoint' => ['Address' => 'w.example.com']],
+            ['DBInstanceIdentifier' => 'testing-reader', 'DBInstanceClass' => $writerClass, 'Endpoint' => ['Address' => 'r.example.com']],
+        ]]),
+    ];
+}
+
+it('provisions the full env alert family against the writer class capacity', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+    $rds = [];
+    bindMockRdsClient(alertsAuroraResults(), $rds);
+
+    expect((new SyncAlertAlarmsStep())([]))->toBe(StepResult::CREATED);
+
+    $puts = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args')->keyBy('AlarmName');
+
+    expect($puts->keys()->all())->toEqualCanonicalizing([
+        'yolo-testing-alert-alb-5xx',
+        'yolo-testing-alert-valkey-memory',
+        'yolo-testing-alert-valkey-evictions',
+        'yolo-testing-alert-database-cpu',
+        'yolo-testing-alert-database-memory',
+        'yolo-testing-alert-database-connections',
+        'yolo-testing-alert-database-buffer-cache',
+    ]);
+
+    expect($puts['yolo-testing-alert-alb-5xx']['Threshold'])->toBe(25.0)
+        ->and($puts['yolo-testing-alert-alb-5xx']['Statistic'])->toBe('Sum')
+        ->and($puts['yolo-testing-alert-alb-5xx']['Dimensions'])->toBe([
+            ['Name' => 'LoadBalancer', 'Value' => 'app/yolo-testing/abc123'],
+        ]);
+
+    expect($puts['yolo-testing-alert-valkey-memory']['Dimensions'])->toBe([
+        ['Name' => 'CacheClusterId', 'Value' => 'yolo-testing-cache-001'],
+    ]);
+
+    // r6g.large: 16 GiB → 10% floor in bytes; 1000 default connections → 75%.
+    expect($puts['yolo-testing-alert-database-cpu']['Threshold'])->toBe(80.0)
+        ->and($puts['yolo-testing-alert-database-memory']['Threshold'])->toBe(round(16 * 0.10 * 1024 ** 3))
+        ->and($puts['yolo-testing-alert-database-connections']['Threshold'])->toBe(750.0)
+        ->and($puts['yolo-testing-alert-database-buffer-cache']['ComparisonOperator'])->toBe('LessThanThreshold');
+
+    expect($puts['yolo-testing-alert-database-cpu']['Dimensions'])->toEqualCanonicalizing([
+        ['Name' => 'DBClusterIdentifier', 'Value' => 'testing-cluster'],
+        ['Name' => 'Role', 'Value' => 'WRITER'],
+    ]);
+
+    // Every alert fires to the env topic and never pages on missing data.
+    foreach ($puts as $payload) {
+        expect($payload['AlarmActions'])->toBe(['arn:aws:sns:ap-southeast-2:111111111111:yolo-testing-alarms'])
+            ->and($payload['TreatMissingData'])->toBe('notBreaching');
+    }
+});
+
+it('skips the database set when the manifest declares no database', function (): void {
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+
+    (new SyncAlertAlarmsStep())([]);
+
+    $names = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args.AlarmName');
+
+    expect($names->filter(fn (string $name): bool => str_contains($name, 'database')))->toBeEmpty()
+        ->and($names)->toHaveCount(3);
+});
+
+it('hard-fails on a database class missing from the capacity table', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+    $rds = [];
+    bindMockRdsClient(alertsAuroraResults(writerClass: 'db.x2g.16xlarge'), $rds);
+
+    (new SyncAlertAlarmsStep())([]);
+})->throws(IntegrityCheckException::class, 'db.x2g.16xlarge');
+
+it('reports the alb alarm pending while the load balancer is unresolvable', function (): void {
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => new Result(['LoadBalancers' => []])], $elb);
+
+    $step = new SyncAlertAlarmsStep();
+    $step([]);
+
+    $names = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args.AlarmName');
+
+    expect($names)->not->toContain('yolo-testing-alert-alb-5xx')
+        ->and(collect($step->changes())->pluck('attribute'))->toContain('alb 5xx alert');
+});
+
+it('provisions the app web 5xx rate alarm with a traffic floor', function (): void {
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client([
+        'DescribeLoadBalancers' => alertsLoadBalancersResult(),
+        'DescribeTargetGroups' => new Result(['TargetGroups' => [[
+            'TargetGroupName' => 'yolo-testing-my-app',
+            'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111:targetgroup/yolo-testing-my-app/xyz789',
+        ]]]),
+    ], $elb);
+
+    expect((new SyncWebAlertAlarmStep())([]))->toBe(StepResult::CREATED);
+
+    $put = collect($cloudWatch)->firstWhere('name', 'PutMetricAlarm')['args'];
+
+    expect($put['AlarmName'])->toBe('yolo-testing-my-app-alert-web-5xx')
+        ->and($put['Threshold'])->toBe(5.0)
+        ->and($put['EvaluationPeriods'])->toBe(5)
+        ->and($put['DatapointsToAlarm'])->toBe(3)
+        ->and($put)->not->toHaveKey('Namespace');
+
+    $metrics = collect($put['Metrics'])->keyBy('Id');
+
+    // Rate over the app's own dimensions, with the traffic floor pinned to 0
+    // below one request per second.
+    expect($metrics['rate']['Expression'])->toBe('IF(requests >= 60, 100 * FILL(errors, 0) / requests, 0)')
+        ->and($metrics['requests']['MetricStat']['Metric']['Dimensions'])->toEqualCanonicalizing([
+            ['Name' => 'TargetGroup', 'Value' => 'targetgroup/yolo-testing-my-app/xyz789'],
+            ['Name' => 'LoadBalancer', 'Value' => 'app/yolo-testing/abc123'],
+        ])
+        ->and($metrics['errors']['MetricStat']['Metric']['MetricName'])->toBe('HTTPCode_Target_5XX_Count');
+});
+
+it('reports the web alarm pending while the target group is unresolvable', function (): void {
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client([
+        'DescribeLoadBalancers' => alertsLoadBalancersResult(),
+        'DescribeTargetGroups' => new Result(['TargetGroups' => []]),
+    ], $elb);
+
+    $step = new SyncWebAlertAlarmStep();
+
+    expect($step([]))->toBe(StepResult::WOULD_CREATE);
+    expect(collect($cloudWatch)->where('name', 'PutMetricAlarm'))->toBeEmpty();
+    expect(collect($step->changes())->pluck('attribute'))->toContain('web 5xx alert');
+});
+
+it('tears down the env alert family by name without touching the sources they watched', function (): void {
+    $existing = collect([
+        'yolo-testing-alert-alb-5xx',
+        'yolo-testing-alert-database-cpu',
+    ])->map(fn (string $name): array => ['AlarmName' => $name, 'AlarmArn' => 'arn:' . $name])->all();
+
+    $cloudWatch = [];
+    bindMockCloudWatchClient([
+        'DescribeAlarms' => new Result(['MetricAlarms' => $existing]),
+    ], $cloudWatch);
+
+    expect((new TeardownAlertAlarmsStep())([]))->toBe(StepResult::DELETED);
+
+    $deleted = collect($cloudWatch)->where('name', 'DeleteAlarms')->pluck('args.AlarmNames')->flatten();
+
+    expect($deleted)->toContain('yolo-testing-alert-alb-5xx')
+        ->toContain('yolo-testing-alert-database-cpu')
+        ->not->toContain('yolo-testing-alert-valkey-memory');
+});

--- a/tests/Unit/Steps/Alerts/AlertAlarmsTest.php
+++ b/tests/Unit/Steps/Alerts/AlertAlarmsTest.php
@@ -4,16 +4,23 @@ use Aws\Result;
 use Aws\MockHandler;
 use Aws\Sns\SnsClient;
 use Aws\CommandInterface;
+use Codinglabs\Yolo\Aws\Rds;
 use Codinglabs\Yolo\Helpers;
 use GuzzleHttp\Promise\Create;
+use Aws\CloudWatch\CloudWatchClient;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Exceptions\IntegrityCheckException;
 use Codinglabs\Yolo\Steps\Sync\App\SyncWebAlertAlarmStep;
 use Codinglabs\Yolo\Steps\Sync\Environment\SyncAlertAlarmsStep;
+use Codinglabs\Yolo\Steps\Destroy\App\TeardownWebAlertAlarmStep;
 use Codinglabs\Yolo\Steps\Destroy\Environment\TeardownAlertAlarmsStep;
 
 beforeEach(function (): void {
     writeManifest(['account-id' => '111111111111', 'region' => 'ap-southeast-2']);
+
+    // Rds::target() memoises classification per identifier for the process —
+    // flush so each test's mocked RDS world classifies fresh.
+    Rds::flushTargets();
 });
 
 function bindAlertsSnsClient(): void
@@ -99,18 +106,19 @@ it('provisions the full env alert family against the writer class capacity', fun
         ['Name' => 'CacheClusterId', 'Value' => 'yolo-testing-cache-001'],
     ]);
 
-    // r6g.large: 16 GiB → 10% floor in bytes; 1000 default connections → 75%.
+    // r6g.large: 16 GiB → 5% floor in bytes; 1000 default connections → 75%.
     expect($puts['yolo-testing-alert-database-cpu']['Threshold'])->toBe(80.0)
-        ->and($puts['yolo-testing-alert-database-memory']['Threshold'])->toBe(round(16 * 0.10 * 1024 ** 3))
+        ->and($puts['yolo-testing-alert-database-memory']['Threshold'])->toBe(round(16 * 0.05 * 1024 ** 3))
         ->and($puts['yolo-testing-alert-database-connections']['Threshold'])->toBe(750.0)
-        ->and($puts['yolo-testing-alert-database-buffer-cache']['ComparisonOperator'])->toBe('LessThanThreshold');
+        ->and($puts['yolo-testing-alert-valkey-evictions']['Threshold'])->toBe(100.0)
+        ->and($puts['yolo-testing-alert-database-buffer-cache']['ComparisonOperator'])->toBe('LessThanThreshold')
+        ->and($puts['yolo-testing-alert-database-buffer-cache']['DatapointsToAlarm'])->toBe(6);
 
     expect($puts['yolo-testing-alert-database-cpu']['Dimensions'])->toEqualCanonicalizing([
         ['Name' => 'DBClusterIdentifier', 'Value' => 'testing-cluster'],
         ['Name' => 'Role', 'Value' => 'WRITER'],
     ]);
 
-    // Every alert fires to the env topic and never pages on missing data.
     foreach ($puts as $payload) {
         expect($payload['AlarmActions'])->toBe(['arn:aws:sns:ap-southeast-2:111111111111:yolo-testing-alarms'])
             ->and($payload['TreatMissingData'])->toBe('notBreaching');
@@ -190,8 +198,6 @@ it('provisions the app web 5xx rate alarm with a traffic floor', function (): vo
 
     $metrics = collect($put['Metrics'])->keyBy('Id');
 
-    // Rate over the app's own dimensions, with the traffic floor pinned to 0
-    // below one request per second.
     expect($metrics['rate']['Expression'])->toBe('IF(requests >= 60, 100 * FILL(errors, 0) / requests, 0)')
         ->and($metrics['requests']['MetricStat']['Metric']['Dimensions'])->toEqualCanonicalizing([
             ['Name' => 'TargetGroup', 'Value' => 'targetgroup/yolo-testing-my-app/xyz789'],
@@ -215,6 +221,259 @@ it('reports the web alarm pending while the target group is unresolvable', funct
     expect($step([]))->toBe(StepResult::WOULD_CREATE);
     expect(collect($cloudWatch)->where('name', 'PutMetricAlarm'))->toBeEmpty();
     expect(collect($step->changes())->pluck('attribute'))->toContain('web 5xx alert');
+});
+
+/**
+ * Bind a CloudWatch client over a map of live alarms (AlarmName => record):
+ * DescribeAlarms honours the AlarmNames filter, ListTagsForResource answers
+ * per-ARN with the tags the adoption guard expects, writes capture and no-op.
+ *
+ * @param  array<string, array<string, mixed>>  $liveAlarms
+ * @param  array<int, array{name: string, args: array<string, mixed>}>  $captured
+ */
+function bindAlertsCloudWatchWorld(array $liveAlarms, array &$captured): void
+{
+    $mock = new class($liveAlarms, $captured) extends MockHandler
+    {
+        public function __construct(protected array $liveAlarms, protected array &$captured) {}
+
+        public function __invoke(CommandInterface $cmd, $request)
+        {
+            $args = $cmd->toArray();
+            $this->captured[] = ['name' => $cmd->getName(), 'args' => $args];
+
+            return Create::promiseFor(match ($cmd->getName()) {
+                'DescribeAlarms' => new Result(['MetricAlarms' => array_values(array_intersect_key(
+                    $this->liveAlarms,
+                    isset($args['AlarmNames']) ? array_flip($args['AlarmNames']) : $this->liveAlarms,
+                ))]),
+                'ListTagsForResource' => new Result(['Tags' => alertsTagsForArn((string) $args['ResourceARN'])]),
+                default => new Result([]),
+            });
+        }
+    };
+
+    Helpers::app()->instance('cloudWatch', new CloudWatchClient([
+        'region' => 'ap-southeast-2',
+        'version' => 'latest',
+        'credentials' => false,
+        'handler' => $mock,
+    ]));
+}
+
+/**
+ * @return array<int, array{Key: string, Value: string}>
+ */
+function alertsTagsForArn(string $arn): array
+{
+    $name = substr($arn, strrpos($arn, ':') + 1);
+    $app = str_contains($name, '-my-app-');
+
+    return collect(array_filter([
+        'Name' => $name,
+        'yolo:scope' => $app ? 'app' : 'env',
+        'yolo:environment' => 'testing',
+        'yolo:app' => $app ? 'my-app' : null,
+    ]))->map(fn (string $value, string $key): array => ['Key' => $key, 'Value' => $value])->values()->all();
+}
+
+/**
+ * The live-alarm map an in-sync world holds, built by running the create path
+ * and echoing its own PutMetricAlarm payloads back — in sync by construction.
+ *
+ * @return array<string, array<string, mixed>>
+ */
+function alertsProvisionedAlarms(): array
+{
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client([
+        'DescribeLoadBalancers' => alertsLoadBalancersResult(),
+        'DescribeTargetGroups' => new Result(['TargetGroups' => [[
+            'TargetGroupName' => 'yolo-testing-my-app',
+            'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111:targetgroup/yolo-testing-my-app/xyz789',
+        ]]]),
+    ], $elb);
+    $rds = [];
+    bindMockRdsClient(alertsAuroraResults(), $rds);
+
+    (new SyncAlertAlarmsStep())([]);
+    (new SyncWebAlertAlarmStep())([]);
+
+    return collect($cloudWatch)
+        ->where('name', 'PutMetricAlarm')
+        ->pluck('args')
+        ->keyBy('AlarmName')
+        ->map(fn (array $payload): array => [
+            ...$payload,
+            'AlarmArn' => 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:' . $payload['AlarmName'],
+        ])
+        ->all();
+}
+
+it('skips the database set for a plain-instance database', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-instance',
+    ]);
+
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+    $rds = [];
+    bindMockRdsClient([
+        'DescribeDBClusters' => new Result(['DBClusters' => []]),
+        'DescribeDBInstances' => new Result(['DBInstances' => [
+            ['DBInstanceIdentifier' => 'testing-instance', 'DBInstanceClass' => 'db.t4g.medium', 'Endpoint' => ['Address' => 'i.example.com']],
+        ]]),
+    ], $rds);
+
+    $step = new SyncAlertAlarmsStep();
+    $step([]);
+
+    $names = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args.AlarmName');
+
+    expect($names->filter(fn (string $name): bool => str_contains($name, 'database')))->toBeEmpty()
+        ->and($names)->toHaveCount(3);
+});
+
+it('keeps the percentage pair only for a Serverless v2 writer', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+    $rds = [];
+    bindMockRdsClient(alertsAuroraResults(writerClass: 'db.serverless'), $rds);
+
+    (new SyncAlertAlarmsStep())([]);
+
+    $names = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args.AlarmName');
+
+    expect($names)->toContain('yolo-testing-alert-database-cpu')
+        ->toContain('yolo-testing-alert-database-buffer-cache')
+        ->not->toContain('yolo-testing-alert-database-memory')
+        ->not->toContain('yolo-testing-alert-database-connections');
+});
+
+it('reports the database alerts pending while the cluster has no resolvable writer', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    bindAlertsSnsClient();
+    $cloudWatch = [];
+    bindMockCloudWatchClient([], $cloudWatch);
+    $elb = [];
+    bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+    $rds = [];
+    bindMockRdsClient([
+        'DescribeDBClusters' => new Result(['DBClusters' => [[
+            'DBClusterIdentifier' => 'testing-cluster',
+            'DBClusterMembers' => [
+                ['DBInstanceIdentifier' => 'testing-reader', 'IsClusterWriter' => false],
+            ],
+        ]]]),
+        'DescribeDBInstances' => new Result(['DBInstances' => []]),
+    ], $rds);
+
+    $step = new SyncAlertAlarmsStep();
+    $step([]);
+
+    $names = collect($cloudWatch)->where('name', 'PutMetricAlarm')->pluck('args.AlarmName');
+
+    expect($names->filter(fn (string $name): bool => str_contains($name, 'database')))->toBeEmpty()
+        ->and(collect($step->changes())->pluck('attribute'))->toContain('database alerts');
+});
+
+it('honours the reconciler contract for the env alert family', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    $live = alertsProvisionedAlarms();
+
+    $bindWorld = function (array &$captured) use ($live): void {
+        Rds::flushTargets();
+        bindAlertsSnsClient();
+        bindAlertsCloudWatchWorld($live, $captured);
+        $elb = [];
+        bindRoutedElbV2Client(['DescribeLoadBalancers' => alertsLoadBalancersResult()], $elb);
+        $rds = [];
+        bindMockRdsClient(alertsAuroraResults(), $rds);
+    };
+
+    assertSyncStepReconciles(
+        makeStep: fn (): SyncAlertAlarmsStep => new SyncAlertAlarmsStep(),
+        bindInSync: $bindWorld,
+        bindDrifted: function (array &$captured) use ($live, $bindWorld): void {
+            $live['yolo-testing-alert-alb-5xx']['Threshold'] = 999;
+            $bindWorld($captured);
+            bindAlertsCloudWatchWorld($live, $captured);
+        },
+        writeCommand: 'PutMetricAlarm',
+    );
+});
+
+it('honours the reconciler contract for the app web 5xx alarm, including metric-math drift', function (): void {
+    writeManifest([
+        'account-id' => '111111111111', 'region' => 'ap-southeast-2',
+        'database' => 'testing-cluster',
+    ]);
+
+    $live = alertsProvisionedAlarms();
+
+    $bindWorld = function (array &$captured) use ($live): void {
+        bindAlertsSnsClient();
+        bindAlertsCloudWatchWorld($live, $captured);
+        $elb = [];
+        bindRoutedElbV2Client([
+            'DescribeLoadBalancers' => alertsLoadBalancersResult(),
+            'DescribeTargetGroups' => new Result(['TargetGroups' => [[
+                'TargetGroupName' => 'yolo-testing-my-app',
+                'TargetGroupArn' => 'arn:aws:elasticloadbalancing:ap-southeast-2:111:targetgroup/yolo-testing-my-app/xyz789',
+            ]]]),
+        ], $elb);
+    };
+
+    assertSyncStepReconciles(
+        makeStep: fn (): SyncWebAlertAlarmStep => new SyncWebAlertAlarmStep(),
+        bindInSync: $bindWorld,
+        bindDrifted: function (array &$captured) use ($live, $bindWorld): void {
+            // The semantics live in the metric math — a drifted expression
+            // (e.g. a hand-lowered traffic floor) must reconcile back.
+            $live['yolo-testing-my-app-alert-web-5xx']['Metrics'][2]['Expression'] = 'IF(requests >= 1, 100 * FILL(errors, 0) / requests, 0)';
+            $bindWorld($captured);
+            bindAlertsCloudWatchWorld($live, $captured);
+        },
+        writeCommand: 'PutMetricAlarm',
+    );
+});
+
+it('tears down the app web alarm by the exact name the sync step created', function (): void {
+    $cloudWatch = [];
+    bindAlertsCloudWatchWorld([
+        'yolo-testing-my-app-alert-web-5xx' => [
+            'AlarmName' => 'yolo-testing-my-app-alert-web-5xx',
+            'AlarmArn' => 'arn:aws:cloudwatch:ap-southeast-2:111111111111:alarm:yolo-testing-my-app-alert-web-5xx',
+        ],
+    ], $cloudWatch);
+
+    expect((new TeardownWebAlertAlarmStep())([]))->toBe(StepResult::DELETED);
+
+    expect(collect($cloudWatch)->firstWhere('name', 'DeleteAlarms')['args']['AlarmNames'])
+        ->toBe(['yolo-testing-my-app-alert-web-5xx']);
 });
 
 it('tears down the env alert family by name without touching the sources they watched', function (): void {


### PR DESCRIPTION
## Hey, I made a thing! 🥳

**What problems are you solving?**

- Outside Typesense's health alarms, an environment shipped with **zero alarms that mean a human should look** — the autoscaling alarms live in ALARM as part of their control loop, so the env SNS topic mostly sat silent and the console offered no way to separate genuine problems from business-as-usual alarm states.
- This provisions an `alert-` named family, every one firing to the existing `yolo-{env}-alarms` topic, and none of which should be red under normal operation:
  - **`alb-5xx`** (env) — the load balancer itself generating 5xx: no healthy targets, a dead target group, a broken rule.
  - **`valkey-memory` / `valkey-evictions`** (env) — the shared cache/session node above 85%, or evicting heavily and sustained (≥100/5min — the node runs `allkeys-lru`, so background churn at capacity is by design and doesn't fire).
  - **`database-cpu` / `-memory` / `-connections` / `-buffer-cache`** (env, Aurora clusters only) — saturation tells on the cluster writer: CPU ≥ 80% sustained, freeable memory under 5% of the instance (Aurora's buffer pool owns ~75% of RAM by design, so a higher floor latches red on a healthy writer), connections past 75% of the class ceiling, buffer-cache hit below 85% at 6-of-8 periods (post-failover warm-up can't page). Dimensioned WRITER so alarms follow a failover; a plain RDS instance database gets no database set (documented); Serverless v2 keeps the percentage pair only.
  - **`web-5xx`** (app) — the app serving 5xx to ≥ 5% of its own requests, as metric math with a traffic floor (under 60 req/min the rate pins to 0).
- **Every threshold is also drawn as a red alarm line on the matching dashboard chart**, read from one shared source (`Services\Alerts`) by both the alarm steps and the dashboard body — the dashboard rebuilds on every sync, so the lines track the alarms as they evolve and can never disagree with what pages. Alarmed metrics without a chart gained one: a `# Cache` section (Valkey memory + evictions at the alarm's 5-minute period) and an Aurora buffer-cache panel; the HTTP errors panel moves to a 5-minute period so the ELB 5xx line means what the alarm means; the 5xx-rate panel shows the 1% SLO aspiration in orange beside the 5% alarm bar in red.
- The database memory floor and connection ceiling derive from the writer's instance class via a capacity table (rows follow Aurora MySQL's documented max_connections formula — the ~1000 tier only starts at 16 GiB); an **unknown class hard-fails** with a pointer to the table rather than silently shipping no coverage.
- `CloudWatch::alarm()` becomes a targeted `AlarmNames` lookup and the prefix scan paginates — the previous single-page scan would false-negative past ~50 alarms in a region and wedge the deploy drift gate on phantom creates.
- The `alert-` name segment is the triage contract: filter on it and everything you see is meaningful. (Audit note: the autoscaling alarms' actions are scaling-policy ARNs, not SNS — they never notified anyone.)
- Docs: new "Alert alarms" section in the provisioning guide.

**Is there anything the reviewer needs to know to deploy this?**

- Next `yolo sync <env>` plans the env family (+1 per-app alarm and the dashboard update on each `sync:app`); on an env without a declared Aurora cluster `database` the four database alarms simply don't exist. Alarm cost ~US$1/env/month.
- The alert alarms' drift comparison covers dimensions and the metric-math expression, so a recreated ALB/target group re-points the alarm on the next sync instead of leaving it silently watching a dead metric.
- Topic **subscriptions remain operator-owned** — nothing pages anyone until an endpoint is subscribed. All alerts treat missing data as not-breaching.
- Greenfield plan passes report the ALB/TG-dimensioned alarms as pending and land on the next sync — same idiom as the Typesense healthy-host alarms.

🤖 Generated with [Claude Code](https://claude.ai/code)