### PR TITLE
fix(iam): grant the vended log delivery chain WAF logging provisions on the caller

### DIFF
--- a/src/Resources/Iam/AdminPolicy.php
+++ b/src/Resources/Iam/AdminPolicy.php
@@ -287,6 +287,17 @@ class AdminPolicy implements Deletable, Resource, SynchronisesConfiguration
                         'logs:CreateLogGroup', 'logs:DeleteLogGroup',
                         'logs:PutRetentionPolicy', 'logs:DeleteRetentionPolicy',
                         'logs:TagResource', 'logs:UntagResource',
+                        // Vended log delivery — wafv2:PutLoggingConfiguration provisions
+                        // the WAF->log-group delivery on the caller's behalf, so AWS
+                        // requires the caller (not the service) to hold the delivery
+                        // lifecycle plus the log-group resource-policy write. Delivery
+                        // APIs are unscopeable; the reads the flow also needs
+                        // (DescribeLogGroups, DescribeResourcePolicies, GetLogDelivery)
+                        // come from the observer half, but ListLogDeliveries fits none
+                        // of its read wildcards so it rides here with its family.
+                        'logs:CreateLogDelivery', 'logs:UpdateLogDelivery',
+                        'logs:DeleteLogDelivery', 'logs:ListLogDeliveries',
+                        'logs:PutResourcePolicy',
                         'events:PutRule', 'events:DeleteRule',
                         'events:PutTargets', 'events:RemoveTargets',
                         'events:TagResource', 'events:UntagResource',

--- a/tests/Unit/Resources/Iam/AdminPolicyTest.php
+++ b/tests/Unit/Resources/Iam/AdminPolicyTest.php
@@ -77,6 +77,24 @@ it('grants the ECR login + layer-upload chain sync needs to push the Typesense i
     );
 });
 
+it('grants the vended log delivery chain wafv2:PutLoggingConfiguration provisions on the caller', function (): void {
+    // Streaming WAF traffic to a CloudWatch Logs log group rides vended log
+    // delivery: the Put call creates the delivery and writes the log-group
+    // resource policy on the CALLER's permissions, not the service's — so
+    // wafv2:Put* alone AccessDenieds the sync. The logs verbs are enumerated
+    // (no write wildcard to absorb a new one), which is how this gap shipped.
+    // The flow's reads (DescribeLogGroups, DescribeResourcePolicies,
+    // GetLogDelivery) come from the observer half's Describe*/Get*;
+    // ListLogDeliveries fits none of its read wildcards so it lives here.
+    expect(adminActions())->toContain(
+        'logs:CreateLogDelivery',
+        'logs:UpdateLogDelivery',
+        'logs:DeleteLogDelivery',
+        'logs:ListLogDeliveries',
+        'logs:PutResourcePolicy',
+    );
+});
+
 it('never grants a blanket wildcard or blanket IAM', function (): void {
     $actions = adminActions();
 


### PR DESCRIPTION
## Problem

Syncing an environment with the new WAF logging stream (#209) under the capped admin tier aborts at the web ACL step:

```
Error executing "PutLoggingConfiguration" on "https://wafv2.<region>.amazonaws.com/";
AccessDeniedException (client): You don't have the permissions that are required to perform this operation.
```

Streaming WAF traffic to a CloudWatch Logs log group rides **vended log delivery**: `wafv2:PutLoggingConfiguration` creates the delivery and writes the log-group resource policy on the *caller's* permissions, not the service's. The admin tier holds `wafv2:Put*`, but the `logs:` verbs are deliberately enumerated (no write wildcard), so the new write class had nothing to absorb it — exactly the "verbs that don't fit a write wildcard" exception the policy doc-block describes, and a server-side permission contract MockHandler tests can't see (two-pass checklist item 5).

## Fix

Add the delivery family to `AdminPolicy`'s unscopeable service-set statement:

- `logs:CreateLogDelivery` / `logs:UpdateLogDelivery` / `logs:DeleteLogDelivery` — the delivery lifecycle (delete covers web ACL teardown)
- `logs:ListLogDeliveries` — a read the Put flow needs, but it fits none of the observer half's read wildcards (`Describe*`, `Get*`, `Filter*`)
- `logs:PutResourcePolicy` — the account-level log-group resource policy the delivery writes

The flow's other reads (`DescribeLogGroups`, `DescribeResourcePolicies`, `GetLogDelivery`) already ride the observer policy attached to the same role.

`SyncAdminPolicyStep` runs before `SyncWafWebAclStep` in `sync:environment`, so the widened document lands before the WAF step retries on the next sync — no manual policy surgery needed.

## Tests

New `AdminPolicyTest` case pins the delivery chain grant. Full suite 2022 passed, PHPStan level 5 clean, Rector clean, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)