### PR TITLE
fix(sync): retry the WAF logging put past a denial racing its own same-sync grant

### DIFF
--- a/src/Aws/WafV2.php
+++ b/src/Aws/WafV2.php
@@ -61,16 +61,37 @@ class WafV2
     }
 
     /**
-     * The shared bounded-retry loop: run $operation, retrying only while it throws
-     * the given eventually-consistent WAFv2 error code, then let anything else (or
-     * exhaustion) propagate.
+     * Run the logging-configuration put, retrying on WAFUnavailableEntityException
+     * (the web ACL not yet referenceable) and AccessDeniedException. Retrying a
+     * denial normally masks a real permission gap — the carve-out exists because
+     * sync grants its own logging permissions: the admin policy step widens the
+     * tier's document earlier in the same apply pass, and IAM propagation to
+     * WAF's authorisation layer can lag that write by seconds, so the very first
+     * sync to enable logging races its own grant. A real gap still fails, just
+     * after the bounded window.
      *
      * @template T
      *
      * @param  callable(): T  $operation
      * @return T
      */
-    private static function retryWhileCode(callable $operation, string $retryableCode, int $maxAttempts, int $sleepSeconds): mixed
+    public static function retryWhileLoggingPermissionsPropagate(callable $operation, int $maxAttempts = 5, int $sleepSeconds = 5): mixed
+    {
+        return self::retryWhileCode($operation, ['WAFUnavailableEntityException', 'AccessDeniedException'], $maxAttempts, $sleepSeconds);
+    }
+
+    /**
+     * The shared bounded-retry loop: run $operation, retrying only while it throws
+     * one of the given eventually-consistent WAFv2 error codes, then let anything
+     * else (or exhaustion) propagate.
+     *
+     * @template T
+     *
+     * @param  callable(): T  $operation
+     * @param  string|array<int, string>  $retryableCodes
+     * @return T
+     */
+    private static function retryWhileCode(callable $operation, string|array $retryableCodes, int $maxAttempts, int $sleepSeconds): mixed
     {
         $attempt = 0;
 
@@ -80,7 +101,7 @@ class WafV2
             } catch (AwsException $exception) {
                 $attempt++;
 
-                if ($attempt >= $maxAttempts || $exception->getAwsErrorCode() !== $retryableCode) {
+                if ($attempt >= $maxAttempts || ! in_array($exception->getAwsErrorCode(), (array) $retryableCodes, true)) {
                     throw $exception;
                 }
 

--- a/src/Resources/WafV2/WebAcl.php
+++ b/src/Resources/WafV2/WebAcl.php
@@ -248,7 +248,7 @@ class WebAcl implements Deletable, Resource, SynchronisesConfiguration
         }
 
         if ($apply) {
-            WafV2::retryWhileUnavailable(fn () => Aws::wafV2()->putLoggingConfiguration([
+            WafV2::retryWhileLoggingPermissionsPropagate(fn () => Aws::wafV2()->putLoggingConfiguration([
                 'LoggingConfiguration' => [
                     'ResourceArn' => $webAclArn,
                     'LogDestinationConfigs' => [$desiredDestination],

--- a/tests/Unit/Aws/WafV2Test.php
+++ b/tests/Unit/Aws/WafV2Test.php
@@ -57,6 +57,69 @@ it('rethrows a non-unavailable AWS error immediately without retrying', function
     expect($calls)->toBe(1);
 });
 
+it('retries the logging put past AccessDeniedException (the put racing its own same-sync IAM grant)', function (): void {
+    // Sync widens the admin tier's own policy earlier in the same apply pass,
+    // and IAM propagation to WAF's authorisation layer can lag the write by
+    // seconds — so the first sync to enable logging can be denied by a grant
+    // that is already in place.
+    $calls = 0;
+
+    $result = WafV2::retryWhileLoggingPermissionsPropagate(function () use (&$calls): string {
+        if (++$calls < 3) {
+            throw new AwsException('You don\'t have the permissions that are required to perform this operation.', new Command('PutLoggingConfiguration'), ['code' => 'AccessDeniedException']);
+        }
+
+        return 'logging';
+    }, maxAttempts: 5, sleepSeconds: 0);
+
+    expect($result)->toBe('logging')
+        ->and($calls)->toBe(3);
+});
+
+it('retries the logging put past WAFUnavailableEntityException too (fresh web ACL not yet referenceable)', function (): void {
+    $calls = 0;
+
+    $result = WafV2::retryWhileLoggingPermissionsPropagate(function () use (&$calls): string {
+        if (++$calls < 2) {
+            throw wafUnavailable();
+        }
+
+        return 'logging';
+    }, maxAttempts: 5, sleepSeconds: 0);
+
+    expect($result)->toBe('logging')
+        ->and($calls)->toBe(2);
+});
+
+it('rethrows a non-retryable error from the logging put without retrying, and gives up on a persistent denial', function (): void {
+    $calls = 0;
+
+    $invalid = function () use (&$calls): mixed {
+        return WafV2::retryWhileLoggingPermissionsPropagate(function () use (&$calls): string {
+            $calls++;
+
+            throw new AwsException('bad input', new Command('PutLoggingConfiguration'), ['code' => 'WAFInvalidParameterException']);
+        }, maxAttempts: 5, sleepSeconds: 0);
+    };
+
+    expect($invalid)->toThrow(AwsException::class);
+    expect($calls)->toBe(1);
+
+    // A REAL permission gap still surfaces — just after the bounded window.
+    $calls = 0;
+
+    $denied = function () use (&$calls): mixed {
+        return WafV2::retryWhileLoggingPermissionsPropagate(function () use (&$calls): string {
+            $calls++;
+
+            throw new AwsException('denied', new Command('PutLoggingConfiguration'), ['code' => 'AccessDeniedException']);
+        }, maxAttempts: 3, sleepSeconds: 0);
+    };
+
+    expect($denied)->toThrow(AwsException::class);
+    expect($calls)->toBe(3);
+});
+
 it('retries past WAFAssociatedItemException (the web ACL delete racing the disassociate)', function (): void {
     $calls = 0;
 


### PR DESCRIPTION
## Problem

The first sync to enable the WAF logging stream self-provisions its own permissions: `SyncAdminPolicyStep` widens the tier's policy document (#215) earlier in the same apply pass, then `SyncWafWebAclStep` calls `PutLoggingConfiguration` a second or two later. IAM propagation to WAF's authorisation layer can lag the policy write by seconds, so the put gets `AccessDeniedException` from a grant that is already in place — the sync aborts, and a plain re-run succeeds (observed exactly this way on a real first sync: denied at the WAF step immediately after the policy version landed, clean on re-run).

This is checklist item 4's territory — write-time validation racing eventual consistency on apply — with IAM as the laggy plane instead of WAF.

## Fix

`WafV2::retryWhileLoggingPermissionsPropagate()` — the logging put now retries on `AccessDeniedException` alongside the existing `WAFUnavailableEntityException`, bounded at 5 × 5s. Retrying a denial normally masks a real gap, which is why the carve-out is scoped to this one call and documented at the helper: a genuine permission gap still propagates, just after the window. `retryWhileCode` now takes one-or-many codes.

## Tests

New cases pin: a transient denial retries to success, the unavailable-entity code still retries, a non-retryable code propagates immediately, and a persistent denial still fails after exhaustion. Full suite 2025 passed, PHPStan level 5 clean, Rector clean, Pint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)