### PR TITLE
fix(sync): skip the WAF log group step under read-tier deploy checks

### DIFF
--- a/src/Steps/Sync/Environment/SyncWafLogGroupStep.php
+++ b/src/Steps/Sync/Environment/SyncWafLogGroupStep.php
@@ -5,9 +5,10 @@ namespace Codinglabs\Yolo\Steps\Sync\Environment;
 use Codinglabs\Yolo\Enums\StepResult;
 use Codinglabs\Yolo\Contracts\ExecutesWebStep;
 use Codinglabs\Yolo\Concerns\SynchronisesResource;
+use Codinglabs\Yolo\Contracts\SkippedByDeployCheck;
 use Codinglabs\Yolo\Resources\CloudWatchLogs\WafLogGroup;
 
-class SyncWafLogGroupStep implements ExecutesWebStep
+class SyncWafLogGroupStep implements ExecutesWebStep, SkippedByDeployCheck
 {
     use SynchronisesResource;
 

--- a/tests/Unit/DeployCheckTest.php
+++ b/tests/Unit/DeployCheckTest.php
@@ -7,6 +7,7 @@ use Codinglabs\Yolo\Contracts\SkippedByDeployCheck;
 use Codinglabs\Yolo\Steps\Sync\Environment\SyncVpcStep;
 use Codinglabs\Yolo\Steps\Sync\App\SyncTypesenseKeyStep;
 use Codinglabs\Yolo\Concerns\ChecksIfCommandsShouldBeRunning;
+use Codinglabs\Yolo\Steps\Sync\Environment\SyncWafLogGroupStep;
 use Codinglabs\Yolo\Steps\Sync\Environment\BuildTypesenseImageStep;
 use Codinglabs\Yolo\Steps\Sync\Environment\SyncTypesenseAdminKeyStep;
 use Codinglabs\Yolo\Steps\Sync\Environment\SyncTypesenseLogGroupStep;
@@ -29,6 +30,7 @@ it('marks the read-tier-fenced env-backed-service steps as skipped-by-deploy-che
     SyncTypesenseTaskDefinitionStep::class,
     SyncTypesenseLogGroupStep::class,
     SyncIvsCloudWatchLogGroupStep::class,
+    SyncWafLogGroupStep::class,
     // The app-scope key step reads the Observer-fenced per-app `.env`, so `audit`
     // (Observer tier) must skip it rather than 403 on the once-minted check.
     SyncTypesenseKeyStep::class,


### PR DESCRIPTION
## Summary

- The pre-deploy in-sync gate (`EnsureInSyncStep`) runs `sync --check` under the deployer tier, which is deliberately fenced from env-tier log-group tags. `SyncWafLogGroupStep` was never marked `SkippedByDeployCheck`, so once the WAF log group exists, every deploy's gate fails on `logs:ListTagsForResource` against it instead of planning past it.
- Marks the step `SkippedByDeployCheck`, exactly like its sibling env log-group steps (IVS, Typesense) — admin `yolo sync` remains its drift check.
- Adds it to the deploy-check dataset in `DeployCheckTest`.

## Anything the reviewer needs to know

- One-interface change + test entry; no permission changes. The alternative — granting the read tier `logs:ListTagsForResource` on the env log group — would widen the deployer's fence for a resource it can never reconcile anyway, which is the exact situation the marker exists for.
- Surfaced by the first deploy after an environment adopted WAF logging: the gate planned "will create" fine while the group was absent, then hard-failed on the tags read once admin sync created it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)