### PR TITLE
fix(run): one-off --command silently no-ops — the agent never runs a shell

### DIFF
--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -471,7 +471,7 @@ yolo run <environment> [--command="<cmd>"] [--group=<groups>]
 
 Each group is its own ECS service when extracted, and `run` execs into the container named after the group. A bundled queue/scheduler runs inside the web container, so a `--group=queue` lookup that finds no standalone queue service simply falls through to the next group.
 
-A `--command` string is base64-encoded before it reaches ECS Exec and decoded once, right before it runs — quote it for your own shell as normal and it arrives on the container byte-for-byte, so a namespaced one-liner (`--command="php artisan tinker --execute='\App\Foo::bar()'"`) survives intact instead of losing its backslashes somewhere between here and the container.
+ECS Exec doesn't run a `--command` string through a shell on the container — the agent splits it into argv and execs it directly, so raw shell syntax (pipes, quoting, backslashes) never behaves the way it would at a prompt. `run` therefore wraps the string as an explicit `sh -c` over a base64 payload, decoded once right before it runs — quote it for your own shell as normal and it arrives on the container byte-for-byte, so a namespaced one-liner (`--command="php artisan tinker --execute='\App\Foo::bar()'"`) survives intact, and pipelines and `&&` chains actually execute instead of being printed as literal text.
 
 **Requirements:** the AWS [Session Manager plugin](https://docs.aws.amazon.com/systems-manager/latest/userguide/session-manager-working-with-install-plugin.html) installed locally. ECS Exec is on by default (`enable-execute-command` defaults to `true`); it must not have been disabled (`enable-execute-command: false`) on the target group in the manifest.
 

--- a/src/Commands/RunCommand.php
+++ b/src/Commands/RunCommand.php
@@ -140,21 +140,28 @@ class RunCommand extends Command implements DeployerCommand
     }
 
     /**
-     * A one-off `--command` string crosses at least one more real shell parse
-     * after this process's own — ECS Exec runs it on the container side via its
-     * own `sh -c`, and POSIX shell rules apply there exactly as they would to
-     * anything else typed at a prompt: an unquoted backslash is itself consumed
-     * ("\App\Foo" -> "AppFoo"), which is how a namespaced PHP one-liner
-     * (`--execute=\App\Foo::bar()`) turns into a "Class not found" once it lands.
-     * Base64-encoding the command sidesteps that hop entirely — the payload is
-     * pure `[A-Za-z0-9+/=]`, which no shell reinterprets, and it's decoded back
-     * to the exact original bytes only once, right before it actually runs.
+     * The SSM agent does NOT run a one-off `--command` through a shell. It
+     * shellwords-splits the string (quotes grouped, unquoted backslashes
+     * consumed — which is what used to mangle a namespaced one-liner's
+     * `\App\Foo` into `AppFoo`) and then execs argv directly. Two consequences
+     * drive this format:
+     *
+     *  1. Shell syntax in the string is inert — a bare `echo <b64> | base64 -d
+     *     | sh` runs `echo` with six literal arguments, prints them, and exits
+     *     0: a silent no-op. The command must therefore be handed to the agent
+     *     as an explicit `sh -c <script>` argv so a real shell exists to run it.
+     *  2. The operator's command can't ride inside that `sh -c` script raw —
+     *     its own quotes and backslashes would collide with the agent's
+     *     tokeniser. Base64-encoding it keeps the payload pure
+     *     `[A-Za-z0-9+/=]`, inert to both the tokeniser and the inner shell,
+     *     decoded back to the exact original bytes only where it finally runs.
+     *
      * Never applied to the interactive `/bin/sh` shell — its stdin has to stay
      * wired to the operator's terminal, not a decode pipeline.
      */
     public static function encodeCommand(string $command): string
     {
-        return sprintf('echo %s | base64 -d | sh', base64_encode($command));
+        return sprintf("sh -c 'echo %s | base64 -d | sh'", base64_encode($command));
     }
 
     /**

--- a/tests/Unit/Commands/RunCommandTest.php
+++ b/tests/Unit/Commands/RunCommandTest.php
@@ -54,59 +54,94 @@ it('omits --profile when none is configured (e.g. running on AWS)', function ():
     expect($args)->toContain('--command', 'php artisan migrate --force');
 });
 
-it('encodes a one-off command as a base64 decode-and-run pipeline', function (): void {
+/**
+ * Simulate the SSM agent's handling of a one-off command: it does NOT run the
+ * string through a shell — it shellwords-splits it (quotes group, an unquoted
+ * backslash escapes the next byte) and execs the resulting argv directly.
+ *
+ * @return array<int, string>
+ */
+function agentArgv(string $command): array
+{
+    $argv = [];
+    $current = '';
+    $started = false;
+
+    for ($i = 0, $length = strlen($command); $i < $length; $i++) {
+        $char = $command[$i];
+
+        if ($char === "'") {
+            $started = true;
+            while (++$i < $length && $command[$i] !== "'") {
+                $current .= $command[$i];
+            }
+        } elseif ($char === '"') {
+            $started = true;
+            while (++$i < $length && $command[$i] !== '"') {
+                $current .= $command[$i] === '\\' ? $command[++$i] : $command[$i];
+            }
+        } elseif ($char === '\\') {
+            $started = true;
+            $current .= $command[++$i];
+        } elseif ($char === ' ' || $char === "\t") {
+            if ($started) {
+                $argv[] = $current;
+                $current = '';
+                $started = false;
+            }
+        } else {
+            $started = true;
+            $current .= $char;
+        }
+    }
+
+    if ($started) {
+        $argv[] = $current;
+    }
+
+    return $argv;
+}
+
+it('encodes a one-off command as an explicit sh -c over a base64 decode-and-run pipeline', function (): void {
     $command = "php artisan tinker --execute='\\App\\Models\\Foo::bar()'";
 
     $encoded = RunCommand::encodeCommand($command);
 
-    expect($encoded)->toBe('echo ' . base64_encode($command) . ' | base64 -d | sh');
-    expect($encoded)->toMatch('/^echo [A-Za-z0-9+\/=]+ \| base64 -d \| sh$/');
+    expect($encoded)->toBe(sprintf("sh -c 'echo %s | base64 -d | sh'", base64_encode($command)));
+    expect($encoded)->toMatch('/^sh -c \'echo [A-Za-z0-9+\/=]+ \| base64 -d \| sh\'$/');
 });
 
-it('survives a naive re-quoting hop that mangles a namespaced one-liner', function (): void {
+it('tokenises to a three-element sh -c argv under the agent parse', function (): void {
+    // The pipeline must arrive as ONE argument to `sh -c`. A bare pipeline
+    // (no sh -c wrapper) tokenises to `echo` plus literal arguments — under
+    // direct exec that prints the pipeline text and exits 0 without ever
+    // running the command: a silent no-op that reports success.
+    $argv = agentArgv(RunCommand::encodeCommand('php artisan migrate:fresh --seed --force'));
+
+    expect($argv)->toHaveCount(3);
+    expect(array_slice($argv, 0, 2))->toBe(['sh', '-c']);
+    expect($argv[2])->toMatch('/^echo [A-Za-z0-9+\/=]+ \| base64 -d \| sh$/');
+});
+
+it('survives the agent parse plus direct exec byte-for-byte', function (): void {
     // A namespaced PHP one-liner, properly single-quoted for the one shell
-    // that's meant to finally run it — the exact "Class not found" shape from
-    // the bug report reduces to this: printf stands in for `php artisan
-    // tinker --execute=...`, and `\App\Foo` stands in for the namespaced class.
+    // that's meant to finally run it — the "Class not found" shape reduces to
+    // this: printf stands in for `php artisan tinker --execute=...`, and
+    // `\App\Foo` stands in for the namespaced class. Raw, the agent's
+    // tokeniser strips its quoting and consumes the backslashes before any
+    // shell sees it; encoded, the payload is pure `[A-Za-z0-9+/=]`, so the
+    // parse has nothing to reinterpret and the original bytes reach the final
+    // decode intact.
     $command = "printf %s '\\App\\Foo'";
 
-    // Confirm that shape is correct for a single parse — this is what the
-    // documented workaround (attach interactively, paste the command
-    // directly) gets right: exactly one shell reads it, so the single quotes
-    // do their job.
-    $direct = new Process(['sh', '-c', $command]);
-    $direct->mustRun();
-    expect($direct->getOutput())->toBe('\App\Foo');
+    $process = new Process(agentArgv(RunCommand::encodeCommand($command)));
+    $process->mustRun();
 
-    // Simulate the extra hop between the terminal and the container: something
-    // in the chain (the AWS CLI, the SSM plugin, ECS's own exec wrapper — the
-    // exact culprit is opaque and undocumented) re-embeds the command inside
-    // another single-quoted shell string, the way a wrapper built by naive
-    // string concatenation would. `$command` already contains single quotes
-    // of its own, so they collide with the wrapper's — the shell closes the
-    // outer quote early, spilling `\App\Foo` into unquoted territory where a
-    // bare backslash is consumed rather than preserved.
-    $naivelyReEmbed = fn (string $text): string => "sh -c '{$text}'";
-
-    $mangled = new Process(['sh', '-c', $naivelyReEmbed($command)]);
-    $mangled->mustRun();
-    expect($mangled->getOutput())->toBe('AppFoo');
-
-    // The fix: wrap it first. The payload is pure `[A-Za-z0-9+/=]` — no single
-    // quotes, no backslashes — so the same naive re-embedding has nothing to
-    // collide with, and the original bytes reach the final decode intact.
-    $wrapped = RunCommand::encodeCommand($command);
-    expect($wrapped)->not->toContain("'");
-
-    $fixed = new Process(['sh', '-c', $naivelyReEmbed($wrapped)]);
-    $fixed->mustRun();
-    expect($fixed->getOutput())->toBe('\App\Foo');
+    expect($process->getOutput())->toBe('\App\Foo');
 });
 
 it('propagates the exit code of the decoded command through the pipeline', function (): void {
-    $wrapped = RunCommand::encodeCommand('exit 7');
-
-    $process = new Process(['sh', '-c', $wrapped]);
+    $process = new Process(agentArgv(RunCommand::encodeCommand('exit 7')));
     $process->run();
 
     expect($process->getExitCode())->toBe(7);


### PR DESCRIPTION
## Summary

- `yolo run <env> --command="..."` has been silently no-oping while reporting success. The SSM agent does **not** run the command string through a shell on the container — it shellwords-splits it and execs the argv directly. The base64 pipeline from #193 (`echo <b64> | base64 -d | sh`) therefore execs `echo` with six literal arguments: it prints the pipeline text into the session and exits 0, and the actual command never runs. The observable symptom is a session that opens, prints `<b64> | base64 -d | sh` (echo's literal args), and exits immediately.
- The direct-exec model also explains the original mangling #193 chased: the agent's quote-aware tokeniser is what consumes unquoted backslashes — there was never a container-side `sh -c` hop.
- Fix: `encodeCommand` now emits `sh -c 'echo <b64> | base64 -d | sh'`, so the agent parse yields a real shell as argv with the decode pipeline as its single script argument. The payload stays base64 — inert to both the tokeniser and the inner shell — so arbitrary quoting, backslashes, pipes and `&&` chains all arrive byte-for-byte.
- Docs updated to describe the real transport (direct exec, no shell) and why the wrapper exists.

## Test plan

- [x] Replaced #193's regression simulation (a naive re-quoting shell hop — which passed while the real path no-op'd) with a faithful one: a shellwords tokeniser + direct `Process(argv)` exec, matching the agent. Covers argv shape (`['sh', '-c', <pipeline>]`), byte-for-byte survival of a quoted/backslashed one-liner, and exit-code propagation.
- [x] `./vendor/bin/pest` — 2027 passed
- [x] `./vendor/bin/phpstan analyse --memory-limit=1G` — no errors
- [x] `./vendor/bin/rector process --dry-run` — clean
- [x] `./vendor/bin/pint` — clean

Untested server-contract assumption: the agent's tokeniser honouring single quotes is inferred from observed behaviour (backslash consumption, literal pipes) and the standard `sh -c` wrapping workaround for ECS Exec — verify with a real one-off (`--command="php artisan migrate:status"`) before relying on it for a destructive command.

🤖 Generated with [Claude Code](https://claude.com/claude-code)